### PR TITLE
Fixed moving slider buttons RHD-437

### DIFF
--- a/stylesheets/_slider.scss
+++ b/stylesheets/_slider.scss
@@ -285,8 +285,6 @@
 
     &:hover, &.slider-pager-active {
       background:$red;
-      padding-left:10px;
-      padding-right:10px;
     }
 
     &.arrow {


### PR DESCRIPTION
Initially had a slight animation when you hovered the buttons but this doesn't work with the longer copy as it causes a re-flow to the text. 
