### PR TITLE
Fixes RHD-465 (learn links in /products)

### DIFF
--- a/_layouts/product-index.html.slim
+++ b/_layouts/product-index.html.slim
@@ -51,8 +51,9 @@ layout: technology-base
                       a(href="#{site.base_url}/products/#{product.id}/docs-and-apis/")
                           i.fa.fa-file-text-o
                           |  Docs and APIs
-                    li
-                      a(href="#{site.base_url}/products/#{product.id}/learn")
-                        i.fa.fa-files-o
-                        |  Learn
+                    - if site.engine.page_by_source_path("products/#{product.id}/learn")
+                      li
+                        a(href="#{site.base_url}/products/#{product.id}/learn")
+                          i.fa.fa-files-o
+                          |  Learn
 


### PR DESCRIPTION
I think this is where Paul was talking, there are no learn links in any
of the download pages.
