### PR TITLE
adding carets to nav RHD-472

### DIFF
--- a/_partials/solution-left-menu.html.slim
+++ b/_partials/solution-left-menu.html.slim
@@ -9,4 +9,6 @@ ul.side-nav
   li.side-nav-toggle
     a(href="#") Menu
   - page.nav_items.each do |k,v|
-    li(class="#{k == page.solution_subsection ? "active" : ""}"): a(href="../#{k}") #{v}
+    li(class="#{k == page.solution_subsection ? "active" : ""}"): a(href="../#{k}")
+      | #{v}
+      i.fa.fa-caret-right.fa-lg


### PR DESCRIPTION
We don't have the active page like we do on the products page as `page.solution_subsection` is nil and there isn't any information that shows current page in the `page` object. 

So - good for now but we should get that working. 
