### PR TITLE
fixed buzz pagination on infinite scroll RHD-522

### DIFF
--- a/javascripts/buzz.js
+++ b/javascripts/buzz.js
@@ -228,7 +228,7 @@ app.buzz = {
           window.setTimeout(function(){ buzzFlag = true; },1000);
 
           app.buzz.infiniteScrollCalled = true;
-          var from = $('.buzz-item').length;
+          var from = $('.buzz-container > div').length;
         
           // load in more
           app.buzz.filter(app.templates.buzzTemplate, $buzz, 8, true, from, function() {


### PR DESCRIPTION
Someone changed the markup and the counting broke. Easy fix. 
