### PR TITLE
RHD-521 - ajax-loader.gif not found on DevOps Buzz page

### DIFF
--- a/stylesheets/_buzz.scss
+++ b/stylesheets/_buzz.scss
@@ -145,7 +145,7 @@ h4.buzz-message.divider {
 }
 
 span.loader {
-    background: url("../images/icons/ajax-loader.gif") center no-repeat;
+    background: cdn("../images/icons/ajax-loader.gif") center no-repeat;
     content: '';
     display: block;
     width:100%;


### PR DESCRIPTION
../ only works for non-nested files.  Changed it to relative to base_url.