### PR TITLE
added external icon RHD-415

### DIFF
--- a/_partials/developer-materials-results.html.slim
+++ b/_partials/developer-materials-results.html.slim
@@ -37,8 +37,9 @@
           / Title
           td.title
             p
-              a(ng-href="{{item.fields.sys_url_view | urlFix}}")
+              a(ng-href="{{item.fields.sys_url_view | urlFix}}" )
                 | {{item.fields.sys_title}}
+                i.fa.fa-external-link(ng-hide="item | checkInternal")
             span.contributor(data-sys-contributor="{{item.fields.sys_author}}")
               a.name
                 | {{item.fields.sys_author | name}}

--- a/javascripts/developer-materials.angular.js
+++ b/javascripts/developer-materials.angular.js
@@ -183,7 +183,10 @@ dcp.filter('timeAgo',function() {
 */
 dcp.filter('urlFix', function() {
   return function(str){
-    if (str.contains("access.redhat.com") || str.contains("hub-osdevelopers.rhcloud.com")) {
+    if(!str.length) {
+      return; // no string provided
+    }
+    else if (str.contains("access.redhat.com") || str.contains("hub-osdevelopers.rhcloud.com")) {
       return str;
     } else {
       return str.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+\/)?/, '#{site.base_url}/');
@@ -242,6 +245,21 @@ dcp.filter('safeNumber', function() {
   return function(input) {
     var n = parseInt(input, 10);
     return isNaN(n) ? 0 : n;
+  }
+});
+
+/**
+ * checkInternal checks is a link is internal
+ */
+dcp.filter('checkInternal',function() {
+  return function(item) {
+    if(!item.fields.sys_url_view) {
+      return true;
+    }
+    else if(!!item.fields.sys_url_view.match(window.location.host)) {
+      return true;
+    }
+    return false;
   }
 });
 

--- a/stylesheets/_developer-materials.scss
+++ b/stylesheets/_developer-materials.scss
@@ -115,6 +115,7 @@ ul.results {
   }
   i {
     color:$grey-4;
+    margin-left: 5px;
   }
   i.fa-star,i.fa-star-half-empty {
     color:$light-orange;


### PR DESCRIPTION
Adds an external link icon to external links

Might not work perfectly in staging since we do the "urlfix", which changes links from pr.developer.redhat.com to localhost, but that won't be an issue on production

This also includes a fix to the `urlFix` function which was flooding the console with errors when there was no link available. 