### PR TITLE
Migrate Upstream Projects page to Searchisko 2.

### DIFF
--- a/javascripts/connectors.js
+++ b/javascripts/connectors.js
@@ -114,7 +114,8 @@ app.connectors = {
         } else {
             var hits = data.hits.hits;
         }
-        
+
+        // Note: we might be able to get rid of sortJsonArrayByProperty function after migration to Searchisko 2.
         hits.sortJsonArrayByProperty("_source." + orderBy);
 
         var html = "";

--- a/javascripts/namespace.js
+++ b/javascripts/namespace.js
@@ -48,6 +48,7 @@ app.dcp.error_message = "<div class='dcp-error-message'>It appears we're unable 
 app.dcp2 = {};
 app.dcp2.url = {};
 app.dcp2.url.search = '#{site.dcp2_base_protocol_relative_url}v2/rest/search';
+app.dcp2.url.project= '#{site.dcp2_base_protocol_relative_url}v2/rest/search/suggest_project_name_ngram_more_fields';
 
 /*
   Products

--- a/javascripts/projects.js
+++ b/javascripts/projects.js
@@ -4,6 +4,9 @@ interpolate: true
 
 app.project = {
   getCorrectUrl : function (linkUrl) {
+    if ($.isArray(linkUrl) && linkUrl.length > 0) {
+      linkUrl = linkUrl[0];
+    }
     if (linkUrl.indexOf("/") > 0) {
       return linkUrl;
     } else {
@@ -18,10 +21,8 @@ app.project = {
     }
   },
   projectFilter : function(filters, keyword, container, thumbnailSize) {
-    //Currently the only way to specify no limit
-    var maxResults = 500;
 
-    var url = app.dcp.url.project;
+    var url = app.dcp2.url.project;
 
     // Pass search params to GTM for analytics
     window.dataLayer = window.dataLayer || [];
@@ -33,24 +34,19 @@ app.project = {
 
     var filters = $.extend(filters, {"keyword": keyword});
     var currentFilters = {};
-    var request_data = {
-        "field"  : ["_source"],
-        "query" : query,
-        "size" : maxResults
-    }
+    var request_data = {};
 
-    if ($('select[name="filter-products"]').length && $('select[name="filter-products"]').val() !== "") {
-      var product = $('select[name="filter-products"]').val();
+    var filter_products = $('select[name="filter-products"]');
+    if (filter_products.length && filter_products.val() !== "") {
+      var product = filter_products.val();
       filters['project'] = app.products[product]['upstream'];
       window.dataLayer.push({ 'product' : product });
     } else {
       window.dataLayer.push({ 'product' : null });
     }
 
-    if (filters['project']) {
-      url = app.dcp.url.search;
-      request_data["sys_type"] = "project_info";
-    }
+    // sort by sys_title
+    filters['sort'] = 'sys_title';
 
     $.each(filters, function(key, val) {
       // if its empty, remove it from the filters
@@ -59,8 +55,7 @@ app.project = {
       }
     });
 
-    // Prep each filter
-    var query = ['((_exists_:archived AND NOT archived:true) OR (_missing_:archived))'];
+    var query = [];
 
     if(currentFilters['keyword']) {
       window.dataLayer.push({ 'keyword' : query });
@@ -107,12 +102,12 @@ app.project = {
     } else {
       var hits = data.hits.hits;
     }
-    hits.sortJsonArrayByProperty("_source.sys_title");
-    var html = "";
-    // loop over every hit
 
+    var html = "";
+
+    // loop over every hit
     for (var i = 0; i < hits.length; i++) {
-      var props = hits[i]._source;
+      var props = hits[i].fields;
 
       var imgsrc = "http://static.jboss.org/" + (props.specialIcon || props.sys_project) + "/images/" + (props.specialIcon || props.sys_project) + "_" + thumbnailSize + ".png";
 


### PR DESCRIPTION
See <https://issues.jboss.org/browse/RHD-571>

Please comment on this PR. I am not sure if changes to `Gemfile.lock` file should be part of this PR.
Also note that at the Searchisko REST API we are moving from general Search API to registered query called [suggest_project_name](https://github.com/searchisko/configuration/blob/v2.0.2/data/query/suggest_project_name.md) (more specifically the `suggest_project_name_ngram_more_fields` variant).