### PR TITLE
Fixing BOM replacement URL

### DIFF
--- a/_ext/stacks.rb
+++ b/_ext/stacks.rb
@@ -7,7 +7,6 @@ require 'awestruct/page'
 require 'awestruct/handlers/layout_handler'
 require 'awestruct/handlers/tilt_handler'
 require 'awestruct/handler_chain'
-require 'parallel'
 
 module JBoss::Developer::Extensions
   class Stacks 
@@ -118,10 +117,10 @@ module JBoss::Developer::Extensions
           commits = commit_info(bom_info['repo'], Pathname.new(bom_info['location']), bom_info.reject {|k,v| k == 'location' || k == 'repo' || k == 'replacedBy'})  # DEVELOPER-320
         end
         #Collect the bom_id of replaced bom
-        replaced_bom_id = nil
+        replaced_bom = nil
         if bom_info and bom_info['replacedBy']
           ga = bom_info['replacedBy'].split(':')
-          replaced_bom_id = yml['availableBoms'].select{ |b| b['groupId'] == ga[0] and b['artifactId'] == ga[1] }.collect{ |b| b['id']}[0]
+          replaced_bom = yml['availableBoms'].select{ |b| b['groupId'] == ga[0] and b['artifactId'] == ga[1] }.first
         end
         metadata = {
           :title => bom['bom']['name'], 
@@ -134,8 +133,8 @@ module JBoss::Developer::Extensions
           :searchisko_id => bom['id'],
           :target_product => product
         }
-        metadata[:replaced_bom] = bom_info['replacedBy'] if bom_info
-        metadata[:replaced_bom_url] = "../#{replaced_bom_id}/" if replaced_bom_id
+        metadata[:replaced_bom] = replaced_bom if bom_info
+        metadata[:replaced_bom_url] = lambda { |replaced| site.pages.find {|p| p.bom && (p.bom['bom']['groupId'] == replaced['groupId'] && p.bom['bom']['artifactId'] == replaced['artifactId'])}} if replaced_bom
         metadata[:published] = DateTime.parse(commits.first[:date]) unless commits.empty?
         metadata[:author] = commits.last[:author] if commits.last
         unless metadata[:current_branch] == 'HEAD'

--- a/_partials/bom-replaced_advise.html.slim
+++ b/_partials/bom-replaced_advise.html.slim
@@ -8,5 +8,4 @@
     a(href="http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22#{page.groupId}%22%20a%3A%22#{page.artifactId}%22")Maven Central. 
   p  
     | Please use the following BOM instead: 
-    /! base_url: #{site.base_url}  replace_bom_url: #{page.replaced_bom_url.call(page.replaced_bom).output_path}
-    a(href="#{URI.join(site.base_url, page.replaced_bom_url.call(page.replaced_bom).output_path)}")#{page.replaced_bom['groupId']}:#{page.replaced_bom['artifactId']}
+    a(href="#{File.join(site.base_url, page.replaced_bom_url.call(page.replaced_bom).output_path)}")#{page.replaced_bom['groupId']}:#{page.replaced_bom['artifactId']}

--- a/_partials/bom-replaced_advise.html.slim
+++ b/_partials/bom-replaced_advise.html.slim
@@ -8,4 +8,5 @@
     a(href="http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22#{page.groupId}%22%20a%3A%22#{page.artifactId}%22")Maven Central. 
   p  
     | Please use the following BOM instead: 
-    a(href="#{page.replaced_bom_url}")#{page.replaced_bom}
+    /! base_url: #{site.base_url}  replace_bom_url: #{page.replaced_bom_url.call(page.replaced_bom).output_path}
+    a(href="#{URI.join(site.base_url, page.replaced_bom_url.call(page.replaced_bom).output_path)}")#{page.replaced_bom['groupId']}:#{page.replaced_bom['artifactId']}


### PR DESCRIPTION
Previously the code to link to a bom which replaced an old bom was
broken and the links did not exist. This fixes that problem, though I've
just thought of another solution: Why send boms to the DCP which have
replaced product boms anyway? Yes, we'd need to erase the current set of
BOMs in the DCP, but if we're going to have a link to a replacement bom,
why even include the old bom in the first place?