### PR TITLE
Removing bundler tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,5 +353,3 @@ DEPENDENCIES
   uglifier (~> 2.0.1)
   wraith (~> 1.3.0)
 
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
We are having problems with the Gemfile.lock on the build servers. Currently they are running bundler version 1.10.4 or earlier. This causes a miss match with people running 1.10.5 or later. https://github.com/bundler/bundler/issues/3697

The real fix will be to upgrade all the bundles on the build servers, but this will fix it for now. I'll probably go through this with you on Wednesday @paulrobinson.