### PR TITLE
Alternative fix for bundler issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,3 +353,5 @@ DEPENDENCIES
   uglifier (~> 2.0.1)
   wraith (~> 1.3.0)
 
+BUNDLED WITH
+   1.99.99


### PR DESCRIPTION
This is a bit ugly, but I've tested locally and it does work with bundler 1.10.4 and 1.10.5 mixups