### PR TITLE
Gemfile compatible with bundler < 1.9.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,3 @@ DEPENDENCIES
   therubyracer
   uglifier (~> 2.0.1)
   wraith (~> 1.3.0)
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
Seems we have 1.9.9 or less on the build servers.