### PR TITLE
Fixes RHD-764 allow 1+ target_products in demos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/awestruct/aweplug.git
-  revision: 08c6c80f5188a1797d71ad22431bcde3e95274ec
+  revision: a2822b455ec3fcd03cd06505a0e05e5aac8ddafa
   specs:
     aweplug (1.0.0.a24)
       curb (~> 0.8.5)

--- a/_ext/jboss_developer.rb
+++ b/_ext/jboss_developer.rb
@@ -117,17 +117,22 @@ module JBoss
                     else
                       if (page.metadata[:browse].include?('blob') || page.metadata[:browse].include?('tree'))
                         if (page.metadata[:product] && page.output_path.include?(page.metadata[:product]))
+                          # TODO: What do we do here if there's more than one product??
                           a['href'] = page.metadata[:browse] + '/' + page.output_path.split(page.metadata[:product]).last.gsub('index.html', '') + url
                         else
                           a['href'] = page.metadata[:browse] + '/' + page.output_path.split('/').last.gsub('index.html', '') + url
                         end
                       altered = true
                       else
-                        if (page.metadata[:product] && page.output_path.include?(page.metadata[:product]))
+                        # TODO: What do we do here if there's more than one product??
+                        if (page.metadata[:product] && page.metadata[:product].size == 1 && page.output_path.include?(page.metadata[:product].first))
+                          # TODO: What do we do here if there's more than one product??
                           a['href'] = page.metadata[:browse] + '/blob/master' + page.output_path.split(page.metadata[:product]).last.gsub('index.html', '') + url
                         else
+                          # TODO: What do we do here if there's more than one product??
                           a['href'] = page.metadata[:browse] + '/blob/master' + page.output_path.split('/').last.gsub('index.html', '') + url
                         end
+                        # TODO: What do we do here if there's more than one product??
                         a['href'] = page.metadata[:browse] + '/blob/master/' + page.output_path.split('/').last.gsub('index.html', '') + url
                         altered = true
                       end

--- a/_layouts/get-started-item.html.slim
+++ b/_layouts/get-started-item.html.slim
@@ -8,8 +8,6 @@ issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
   - page.title = page.metadata[:title]
   - page.description = page.metadata[:summary]
   - page.author = page.metadata[:author]
-  - if page.metadata[:product] && site[:products][page.metadata[:product]]
-    - page.product = site[:products][page.metadata[:product]]
   - page.primary_section = 'get-started'
   - page.disqus_identifier = "#{page.url}"
   - if page.metadata.thumbnail
@@ -58,7 +56,7 @@ issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
         - if page.metadata[:target_product] && !page.metadata[:target_product].empty?
           li: strong
             | Target Product:
-            span itemprop="about" =page.metadata[:target_product]
+            span itemprop="about" =(page.metadata[:target_product].is_a?(String) ? page.metadata[:target_product] : page.metadata[:target_product].join(", "))
   .row.content
     .columns.large-24
       .columns.medium-4


### PR DESCRIPTION
This does conflict a bit with the work I've done in
LightGuard/developers.redhat.com/feature/ongoing-blinkr-fixes, but
ultimately I think the fix there is correct and should be used.