### PR TITLE
Specific update to blinkr due to failures with our local development …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,9 @@ GIT
 
 GIT
   remote: git://github.com/awestruct/awestruct.git
-  revision: 17ea5fc65f9364523569d3fa1dfb1085c75951be
+  revision: fdb9369446530019a7fcc8550cf5dcd895a83617
   specs:
-    awestruct (0.5.6)
+    awestruct (0.5.6.beta9)
       asciidoctor (~> 1.5, >= 1.5.2)
       colorize (~> 0.7, >= 0.7.1)
       compass (~> 1, >= 1.0.1)
@@ -95,15 +95,15 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    cucumber (2.1.0)
+    cucumber (2.0.2)
       builder (>= 2.1.2)
-      cucumber-core (~> 1.3.0)
+      cucumber-core (~> 1.2.0)
       diff-lcs (>= 1.1.3)
-      gherkin3 (~> 3.1.0)
+      gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    cucumber-core (1.3.0)
-      gherkin3 (~> 3.1.0)
+    cucumber-core (1.2.0)
+      gherkin (~> 2.12.0)
     curb (0.8.8)
     daybreak (0.3.0)
     diff-lcs (1.2.5)
@@ -123,7 +123,8 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     ffi (1.9.10)
     formatador (0.2.5)
-    gherkin3 (3.1.1)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
     git (1.2.9.1)
     google-api-client (0.8.6)
       activesupport (>= 3.2)
@@ -228,7 +229,7 @@ GEM
     rake (10.4.2)
     rb-fchange (0.0.6)
       ffi
-    rb-fsevent (0.9.6)
+    rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     ref (2.0.0)


### PR DESCRIPTION
…setup

This is a targeted update of blinker as opposed to a complete 'bundle update' carried out here https://github.com/redhat-developer/developers.redhat.com/pull/393. 

This change works with
```bash
'bundle exec ./control.rb -b --run-the-stack'
```

After https://github.com/redhat-developer/developers.redhat.com/pull/393 it was failing with ERR connection refused.


