### PR TITLE
Enable livereload and on-demand building

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ end
 
 desc 'Build and preview the site locally in development mode'
 task :preview, [:profile] => :check do |task, args|
-  run_awestruct "-P #{args[:profile] || 'development'} -a -s --force -q --auto --no-livereload -b 0.0.0.0"
+  run_awestruct "-P #{args[:profile] || 'development'} -a -s --force -q --auto --livereload -b 0.0.0.0"
 end
 
 desc 'Generate the site using the defined profile, or development if none is given'


### PR DESCRIPTION
With this change the site runs through the pipeline but doesn't generate
anything until you actually access the page.