### PR TITLE
Using a pre built binary of phantom js

### DIFF
--- a/_docker/awestruct/Dockerfile
+++ b/_docker/awestruct/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /tmp/optipng-0.7.5
 RUN ./configure && make && make install
 
 WORKDIR /tmp
-RUN yum install -y fontconfig freetype freetype-devel fontconfig-devel libstdc++ && \
+RUN yum install -y fontconfig freetype && \
     wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
     mkdir -p /opt/phantomjs && \
     tar -xjvf /tmp/phantomjs-1.9.8-linux-x86_64.tar.bz2 -C /opt/phantomjs/ && \

--- a/_docker/awestruct/Dockerfile
+++ b/_docker/awestruct/Dockerfile
@@ -16,16 +16,12 @@ RUN wget http://prdownloads.sourceforge.net/optipng/optipng-0.7.5.tar.gz?downloa
 WORKDIR /tmp/optipng-0.7.5
 RUN ./configure && make && make install
 
-RUN yum -y install gcc gcc-c++ make flex bison gperf \
-  openssl-devel freetype-devel fontconfig-devel libicu-devel sqlite-devel \
-  libpng-devel libjpeg-devel
-
 WORKDIR /tmp
-RUN git clone git://github.com/ariya/phantomjs.git
-
-WORKDIR /tmp/phantomjs
-RUN git checkout 2.0 && ./build.sh --confirm
-RUN cp bin/phantomjs /usr/local/bin
+RUN yum install -y fontconfig freetype freetype-devel fontconfig-devel libstdc++ && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
+    mkdir -p /opt/phantomjs && \
+    tar -xjvf /tmp/phantomjs-1.9.8-linux-x86_64.tar.bz2 -C /opt/phantomjs/ && \
+    cp /opt/phantomjs/phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/bin/phantomjs
 
 RUN adduser --system --uid=1000 --home-dir /home/awestruct --shell /bin/bash -m -U awestruct
 


### PR DESCRIPTION
Using a binary of phantomjs so the install is quicker. We are not using any 2.0 specific features so we're fine. All the tests run.