### PR TITLE
Fixed some broken links and ignored links that have issues raised

### DIFF
--- a/_config/blinkr.yaml
+++ b/_config/blinkr.yaml
@@ -8,6 +8,8 @@ skips:
   - !ruby/regexp /-YOUR_DOMAIN\.rhcloud\.com/
     # <app-name>-<domain-name>.rhcloud.com or &lt;app-name&gt;-&lt;domain-name&gt;.rhcloud.com
   - !ruby/regexp /(.+?)app-name(.+?)-(.+?)domain-name(.+?)\.rhcloud\.com/
+    # Prevent localhost errors
+  - !ruby/regexp /^http:\/\/logout@127.0.0.1:8080\/.*/
     # Prevent any stray mailto and irc links appearing
   - !ruby/regexp /^mailto:/
   - !ruby/regexp /^irc:/
@@ -144,6 +146,11 @@ ignores:
   - url: https://access.redhat.com/site/documentation/en-US/JBoss_Portal_Platform/6.1/html/Development_Guide/chap-JSF_Portlet_Development_with_RichFaces.html #JDF-773.
   - url: https://access.redhat.com/site/documentation/en-US/JBoss_Portal_Platform/6.1/html/Development_Guide/Google.html #JDF-773.
   - url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.1/html/Apache_Camel_Component_Reference/files/_IDU_HazelcastComponent.html #DEVELOPER-1148
+  - url: https://github.com/jboss-developer/jboss-eap-quickstarts/tree/cd0505f/cdi-stereotype/../cdi_interceptors/README.md #Issue-1671 - Github
+  - url: https://github.com/jbossdemocentral/brms-realtime-decicion-server-demo/archive/master.zip #PR opened https://github.com/jbossdemocentral/brms-loan-realtime-decision-server-demo/pull/7
+  - url: https://infinispan.ci.cloudbees.com/ #ISPN-4600
+  - url: http://fisheye.jboss.org/browse/Guvnor #GUVNOR-2113
+  - url: https://jboss.org/jbossas/osgi #JBAS-9573
 max_page_retys: 5
 max_retrys: 5
 browser: phantomjs

--- a/products/datavirt/download.adoc
+++ b/products/datavirt/download.adoc
@@ -7,5 +7,5 @@ http://teiiddesigner.jboss.org[Teiid Designer] +
 http://modeshape.jboss.org[ModeShape] +
 http://overlord.jboss.org[Overload S-RAMP]
 
-Visit the http://teiid.jboss.org/downloads[Teiid project download] page, the http://teiiddesigner.jboss.org/downloads[Teiid Designer project download] page, the http://modeshape.jboss.org/downloads[ModeShape project download] page, or the http://www.projectoverlord.io/s-ramp/versions.html[Overload S-RAMP project download] page for more options and all versions.
+Visit the http://teiid.jboss.org/downloads[Teiid project download] page, the http://modeshape.jboss.org/downloads[ModeShape project download] page, or the http://www.projectoverlord.io/s-ramp/versions.html[Overload S-RAMP project download] page for more options and all versions.
 

--- a/products/devstudio/_common/product.yml
+++ b/products/devstudio/_common/product.yml
@@ -13,7 +13,6 @@ index:
 guides:
   Release_Notes:
   Install_Red_Hat_JBoss_Developer_Studio:
-  Start_Developing:
   Update_Red_Hat_JBoss_Developer_Studio:
 default_download_artifact_type: jar_universal
 description: 'A development environment that provides superior support for your entire development lifecycle. It includes a broad set of tooling capabilities and support for multiple programming models and frameworks.'

--- a/solutions/devops/adoption.adoc
+++ b/solutions/devops/adoption.adoc
@@ -27,7 +27,6 @@ Combining siloed teams helps eliminate the pursuit of different—and often conf
 |link:https://blog.openshift.com/what-is-devops-really/[What is DevOps Really?]
 |link:https://blog.openshift.com/your-devops-journey-starts-with-business/[Your DevOps Journey Starts With Business]
 |link:http://www.redhat.com/en/about/events/transforming-organizational-culture-through-devops-and-paas[Transforming organizational culture through DevOps and PaaS]
-|link:http://devops.com/2015/06/03/redhat-culture-keeping-devops-faith/[Red Hat Keeping the DevOps Faith]
 |link:http://developerblog.redhat.com/2013/12/10/red-hat-begins-devops-journey/[Red Hat IT Begins Its DevOps Journey]
 |link:http://www.businessinsider.com/red-hat-ceo-it-is-in-fight-for-its-life-2015-2[Red Hat CEO: Today's IT department is in a fight for its life]
 |Learn more about DevOps culture at link:https://developerblog.redhat.com/category/devops/[developerblog.redhat.com].


### PR DESCRIPTION
A couple of things.

- I ignored some of the upstream project broken links that already have issues raised.
- http://vertx.io/docs.html should be pulling http://vertx.io/docs.  I don't know why it isn't.  The project.properties list the latter as the link.
- I am working with Sandy on a fix for https://github.com/jboss-developer/jboss-eap-quickstarts/tree/cd0505f/cdi-stereotype/../cdi_interceptors/README.md.  Jason fixed the link, but it is not under the 6.4.0.GA scope, so the change isn't recognized on RHD.
- I submitted a PR for https://github.com/jbossdemocentral/brms-realtime-decicion-server-demo/archive/master.zip to fix the spelling error.  Once that is merged, this error should no longer show up.