### PR TITLE
Using the nightly build searchisko location

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -102,8 +102,8 @@ profiles:
   # Pull Request configuration
   staging:
     <<: *profile
-    dcp_base_protocol_relative_url: //dcpbeta-searchisko.rhcloud.com/
-    dcp_base_url: http://dcpbeta-searchisko.rhcloud.com/
+    dcp_base_protocol_relative_url: //10.3.13.63:32778/
+    dcp_base_url: http://10.3.13.63:32778/
     dcp2_base_url: http://dcp2-searchisko.rhcloud.com/
     dcp2_base_protocol_relative_url: //dcp2-searchisko.rhcloud.com/
     metrics: false


### PR DESCRIPTION
Undoing what we did here. https://github.com/redhat-developer/developers.redhat.com/commit/2e6cbad311446a3d259712b51bef0ff3ae864ac6.
This is because the nightly build now has a stable port 