### PR TITLE
Environment variables for stage searchisko

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -102,8 +102,8 @@ profiles:
   # Pull Request configuration
   staging:
     <<: *profile
-    dcp_base_protocol_relative_url: //10.3.9.71:32778/
-    dcp_base_url: http://10.3.9.71:32778/
+    dcp_base_protocol_relative_url: //<%= ENV['STAGE_SEARCHISKO_HOST'] %>:<%= ENV['STAGE_SEARCHISKO_PORT'] %>/
+    dcp_base_url: http://<%= ENV['STAGE_SEARCHISKO_HOST'] %>:<%= ENV['STAGE_SEARCHISKO_PORT'] %>/
     dcp2_base_url: http://dcp2-searchisko.rhcloud.com/
     dcp2_base_protocol_relative_url: //dcp2-searchisko.rhcloud.com/
     metrics: false


### PR DESCRIPTION
The environment variables are now set in the build https://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/jboss.org/job/developers.redhat.com-pull-player-executor/configure

Currently these are
```
STAGE_SEARCHISKO_HOST=10.3.9.71
STAGE_SEARCHISKO_PORT=32778
```