### PR TITLE
check if experiments API exists before running variations. 

### DIFF
--- a/javascripts/experiments.js
+++ b/javascripts/experiments.js
@@ -25,6 +25,8 @@ app.pageVariations = [
 ];
 
 $(function() {
-  var chosenVariation = cxApi.chooseVariation();
-  app.pageVariations[chosenVariation]();
+  if(typeof cxApi !== 'undefined') {
+    var chosenVariation = cxApi.chooseVariation();
+    app.pageVariations[chosenVariation]();
+  }
 });


### PR DESCRIPTION
When cxApi (a global var put in there by some A/B testing script) is unavailable, the JS that come after it breaks. 