### PR TITLE
use current keycloak by inlining js RHD-1347 

### DIFF
--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -29,6 +29,7 @@ require 'events'
 require 'vault'
 require 'aweplug/helpers/define'
 require 'active_support' # HACK for autosupport required by duration
+require 'slim/include'
 
 Awestruct::Extensions::Pipeline.new do
   

--- a/register.html.slim
+++ b/register.html.slim
@@ -1,6 +1,7 @@
 html
 head
-  script src="//static.jboss.org/rhd/1.2-build-1200/javascripts/vendor/keycloak.js"
+  script
+    include javascripts/vendor/keycloak.js
   javascript:
     var keycloak = Keycloak({
       url: "https://developers.redhat.com/auth",


### PR DESCRIPTION
Okay - the reason we were linking to a static version of keycloak is because our build process doesn't serve up individual JS files - just a bundle of everything. 

The register page only needs keycloak.js so a simple solution to that is to just inline the JS at build time. 