### PR TITLE
Fix the regex for urlFix (DEVELOPER-2436)

### DIFF
--- a/javascripts/developer-materials.angular.js
+++ b/javascripts/developer-materials.angular.js
@@ -210,7 +210,7 @@ dcp.filter('urlFix', function() {
     else if (str.contains("access.redhat.com") || str.contains("hub-osdevelopers.rhcloud.com")) {
       return str;
     } else {
-      return str.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?/, '#{site.base_url}');
+      return str.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?(\/docker-nightly)?/, '#{site.base_url}');
     }
   }
 });


### PR DESCRIPTION
I've added in the case for docker-nightly. Here's the output of the
console testing I've done. I think everything looks correct.

    > dcp_url = "http://it-developers-pr.stage.redhat.com/pr/684/build/500/video/youtube/Cl3SiavsBF4"
    "http://it-developers-pr.stage.redhat.com/pr/684/build/500/video/youtube/Cl3SiavsBF4"
    > base_url = "http://it-developers-pr.stage.redhat.com/docker-nightly"
    "http://it-developers-pr.stage.redhat.com/docker-nightly"
    > dcp_url.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?/, base_url)
    "http://it-developers-pr.stage.redhat.com/docker-nightly/video/youtube/Cl3SiavsBF4"
    > dcp_url_2 = base_url
    "http://it-developers-pr.stage.redhat.com/docker-nightly"
    > base_url_2 = "http://it-developers-pr.stage.redhat.com/pr/684/build/500"
    "http://it-developers-pr.stage.redhat.com/pr/684/build/500"
    > dcp_url_2.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?/, base_url_2)
    "http://it-developers-pr.stage.redhat.com/pr/684/build/500/docker-nightly"
    > regex = /^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?/
    RegExp /^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?/
    > regex = /^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?(\/docker-nightly)?/
    RegExp /^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+)?(\/docker-nightly)?/
    > dcp_url_2.replace(regex, base_url_2)
    "http://it-developers-pr.stage.redhat.com/pr/684/build/500"
    > dcp_url.replace(regex, base_url)
    "http://it-developers-pr.stage.redhat.com/docker-nightly/video/youtube/Cl3SiavsBF4"
    > dcp_url.replace(regex, base_url_2)
    "http://it-developers-pr.stage.redhat.com/pr/684/build/500/video/youtube/Cl3SiavsBF4"
    > dcp_url_2.replace(regex,base_url)