### PR TITLE
DEVELOPER-2475 - Password reset Acceptance test is randomly failing causing unnecessary PR fails

### DIFF
--- a/_cucumber/lib/helpers/customer.rb
+++ b/_cucumber/lib/helpers/customer.rb
@@ -12,7 +12,7 @@ module Customer
           name: 'TEST USER-NOT-ACCEPTED-TERMS'
       },
       password_reset: {
-          email: 'redhat-developers-testers+94hl7e5x0h@redhat.com',
+          email: %w(redhat-developers-testers+94hl7e5x0h@redhat.com redhat-developers-testers+94hl7e5x0h@redhat.com redhat-developers-testers+309mnmdlbk@redhat.com redhat-developers-testers+16w9dg8gbh@redhat.com redhat-developers-testers+fbdtyoup2g@redhat.com redhat-developers-testers+0c454lss3r@redhat.com redhat-developers-testers+s01kvdw5oh@redhat.com redhat-developers-testers+0enem3f750@redhat.com redhat-developers-testers+s6vbvqai66@redhat.com redhat-developers-testers+zmqgdx7ie3@redhat.com redhat-developers-testers+k0k481z5d7@redhat.com").sample,
           password: 'P@$$word01',
           name: 'TEST USER'
       }


### PR DESCRIPTION
fixing randomly failed test for forgot password.

adding wip

added more password reset users