### PR TITLE
Using correct docker link

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -103,7 +103,7 @@ profiles:
   # Docker staging configuration (PR and Nightly)
   staging_docker:
     <<: *profile
-    dcp_base_url: http://<%= ENV['ACCESSIBLE_SLAVE_IP'] %>:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
+    dcp_base_url: http://searchisko:8080/
     dcp_base_protocol_relative_url: //<%= ENV['ACCESSIBLE_SLAVE_IP'] %>:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     keycloak_account_url: https://it-developers.stage.redhat.com/auth/realms/rhd/account/
     keycloak_auth_url: https://it-developers.stage.redhat.com/auth/


### PR DESCRIPTION
@paulrobinson We'll need this merged for the nightly to work. I'll fill you in tomorrow but we were very lucky/unlucky with a change and the last build.

I also suspect that dcp_base_protocol_relative_url is no longer used, but we can look at this tomorrow outside of this PR. 

https://github.com/redhat-developer/developers.redhat.com/search?utf8=%E2%9C%93&q=dcp_base_protocol_relative_url