### PR TITLE
cdk/resources and megamenu fixes

### DIFF
--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -187,7 +187,7 @@
                   a(href="#{site.base_url}/community/contributor/")
                     | Content Contributors
                     span.page-description Share your knowledge. Contribute content to Red Hat Developers.
-              li(class=(page.url.include?('resources') ? 'active' : ''))
+              li(class=((page.url.include?('/resources')) && !(page.url.include?('/products/')) ? 'active' : ''))
                 a(href="#{site.base_url}/resources/") Resources
               li(class=(page.url.include?('downloads') ? 'active' : ''))
                 a(href="#{site.base_url}/downloads/") Downloads

--- a/products/cdk/resources.adoc
+++ b/products/cdk/resources.adoc
@@ -19,4 +19,3 @@ Please join the mailing list, container-tools@redhat.com and use it to submit yo
 * link:https://access.redhat.com/articles/1353773[Creating a Kubernetes Cluster to Run Docker Formatted Container Images]
 * link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-security-guide/[Container Security Guide]
 * link:http://tools.jboss.org/blog/2015-03-30-Eclipse_Docker_Tooling.html[Learn about the Eclipse Docker tooling]
-* Other link:#{site.base_url}/products/atomic/docs-and-apis/[documentation] for Red Hat Atomic and Red Hat containers.


### PR DESCRIPTION
Removed broken link from cdk/resources and fixed highlighting of
‘Resources’ from megamenu when cdk/resources is active