### PR TITLE
Fix book download JS errors

### DIFF
--- a/javascripts/book-download.js
+++ b/javascripts/book-download.js
@@ -22,9 +22,14 @@ app.bookDownload = {
         tcDownloadURL.startsWith('https://access.cdn.redhat.com/')) {
       tcDownloadURL = $.encoder.canonicalize(window.location.href.substr(window.location.href.indexOf("tcDownloadURL=") + 14));
 
+      $('.promotion-header').prepend("<div class='alert-box success'><p><a href='"+tcDownloadURL+"'>Click here</a> if your download does not begin automatically.</p></div>")
+
       $("a#tcDownloadLink").attr("href", tcDownloadURL);
 
-      $.fileDownload(tcDownloadURL);
+      if(!app.utils.isMobile.any()){
+        // only try download on desktop - mobile users will tap the banner
+        $.fileDownload(tcDownloadURL);
+      }
 
       // Inform GTM that we have requested a product download
       window.dataLayer = window.dataLayer || [];

--- a/javascripts/extensions.js
+++ b/javascripts/extensions.js
@@ -6,7 +6,7 @@ jQuery.ajaxSettings.traditional = true;
 
 String.prototype.format = function() {
   var args = arguments;
-  return this.replace(/{(\d+)}/g, function(match, number) { 
+  return this.replace(/{(\d+)}/g, function(match, number) {
     return typeof args[number] != 'undefined'
       ? args[number]
       : match
@@ -79,22 +79,22 @@ Array.prototype.peek = function() {
 // John Resig - http://ejohn.org/ - MIT Licensed
 (function(){
   var cache = {};
- 
+
   String.prototype.template = function (data) {
     // Figure out if we're getting a template, or if we need to
     // load the template - and be sure to cache the result.
     var fn = !/\W/.test(this) ?
       cache[this] = cache[this] ||
         tmpl(document.getElementById(this).innerHTML) :
-     
+
       // Generate a reusable function that will serve as a template
       // generator (and which will be cached).
       new Function("obj",
         "var p=[],print=function(){p.push.apply(p,arguments);};" +
-       
+
         // Introduce the data as local variables using with(){}
         "with(obj){p.push('" +
-       
+
         // Convert the template into pure JavaScript
         this
           .replace(/[\r\t\n]/g, " ")
@@ -105,7 +105,7 @@ Array.prototype.peek = function() {
           .split("!>").join("p.push('")
           .split("\r").join("\\'")
       + "');}return p.join('');");
-   
+
     // Provide some basic currying to the user
     return data ? fn( data ) : fn;
   };
@@ -136,7 +136,7 @@ app.utils.getParametersFromHash = function() {
       urlParams = {};
 
 
-  
+
   while (match = search.exec(query)) {
      urlParams[decode(match[1])] = decode(match[2]);
   }
@@ -237,6 +237,19 @@ app.utils.diplayPagination = function(currentPage, totalPages, pagesToShow) {
   }
   return display;
 };
+
+app.utils.isMobile = {
+  Android: function() {
+    return !!navigator.userAgent.match(/Android/i);
+  },
+  iOS: function() {
+    return !!navigator.userAgent.match(/iPhone|iPad|iPod/i);
+  },
+  any: function() {
+    return (app.utils.isMobile.Android() || app.utils.isMobile.iOS());
+  }
+}
+
 
 // TODO Move this somewhere else
 function roundHalf(num) {

--- a/javascripts/terms-and-conditions.js
+++ b/javascripts/terms-and-conditions.js
@@ -25,7 +25,8 @@ app.termsAndConditions = {
     var tcDownloadURL = $.encoder.canonicalize(app.termsAndConditions.urlParam('tcDownloadURL'));
     var tcDownloadFileName = $.encoder.canonicalize(app.termsAndConditions.urlParam('tcDownloadFileName'));
     var product = $.encoder.canonicalize(app.termsAndConditions.urlParam('p'));
-    var tcProduct = $.encoder.canonicalize(product).replace(/\+/g, ' ');
+    var tcProduct = $.encoder.canonicalize(product) || '';
+    tcProduct = tcProduct.replace(/\+/g, ' ');
 
 
     if (tcWhenSigned) {
@@ -101,7 +102,7 @@ app.termsAndConditions = {
 $(function() {
 
   //The download is now triggered from the success callback from KeyCloak in sso.js. This ensures that KeyCloak is initialised before doing the download.
-  
+
   //Display the Ts&Cs banner
   if ($('#_developer_program_terms_conditions').length) {
     app.termsAndConditions.banner();

--- a/stylesheets/_global-wrapper.scss
+++ b/stylesheets/_global-wrapper.scss
@@ -428,6 +428,9 @@ body.overlay-open {
   &.warning {
     background-color:#cc0000;
   }
+  p {
+    margin-bottom: 0;
+  }
 }
 
 


### PR DESCRIPTION
This is where 70% of our errors were coming from in Sentry and were most likely causing the user from not being able to download the book and other products. See JIRA for more info. 