### PR TITLE
Update README.md to reflect staging branch changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,13 +346,12 @@ If merge conflicts exist, you will need to do the fiollowing steps to fix the co
 
 1. If you don't have this branch already fetched on your laptop, run:
 
-        git fetch upstream <branch name>
-        git checkout upstream/<branch name>
-        git checkout -b <branch name>
+        git fetch upstream
+        git checkout -b <branch name> upstream/<branch name>
 
 2. Now merge the master branch:
 
-        git pull upstream master
+        git merge upstream master
       
 3. Fix any merge conflicts
 4. Push the branch to your fork.

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ If merge conflicts exist, you will need to do the fiollowing steps to fix the co
 
 2. Now merge the master branch:
 
-        git merge upstream master
+        git merge upstream/master
       
 3. Fix any merge conflicts
 4. Push the branch to your fork.

--- a/README.md
+++ b/README.md
@@ -338,29 +338,28 @@ If you add a new recipient to the file, ensure you update the list above.
 ## Updating the Staging Integration Branch
 developers.stage.redhat.com hosts a build of the site that uses staging instances of Download Manager and KeyCloak. After the migration to DCP 2, it will also use the staging instance of the DCP. The purpose of this environment is to test new versions of the back-end services before they go into production. 
 
-This build is also used for long-term site changes that need to be tested by the wider team, prior to going live into production. Currently it is being used for the CDK 2 Beta site changes. These changes live on the `cdk_beta` branch which needs to be regularly updated with new commits in the `master` branch. 
+This build is also used for long-term site changes that need to be tested by the wider team, prior to going live into production.
 
-The simplest way to update the branch, is by raising a PR from 'master' onto `cdk_beta` branch. This can simply be merged, if there are no merge conflicts. Use [this link](https://github.com/redhat-developer/developers.redhat.com/compare/cdk_beta...master?expand=1) to raise the PR. 
+The simplest way to update the branch, is by raising a PR from 'master' onto the new long running branch. This can simply be merged, if there are no merge conflicts. 
 
 If merge conflicts exist, you will need to do the fiollowing steps to fix the conflicts:
 
 1. If you don't have this branch already fetched on your laptop, run:
 
-        git fetch upstream cdk_beta
-        git checkout upstream/cdk_beta
-        git checkout -b cdk_beta
+        git fetch upstream <branch name>
+        git checkout upstream/<branch name>
+        git checkout -b <branch name>
 
-2. Now rebase the branch:
+2. Now merge the master branch:
 
-        git pull --rebase upstream master
+        git pull upstream master
       
 3. Fix any merge conflicts
 4. Push the branch to your fork.
 
-        git push <your fork alias> cdk_beta
+        git push <your fork alias> <branch name>
       
-5. Raise a PR from your `cdk_beta` branch onto the `cdk_beta` branch in upstream. Note that the PR tests will fail, as they don't expect a PR to be raised on a branch other than 'master'.
-      
+5. Raise a PR from your branch onto the long running branch in upstream. Note that the PR tests will fail, as they don't expect a PR to be raised on a branch other than 'master'.
 
 ## <a name="CommonIssues"></a>Common issues
 This area documents fixes to common issues:


### PR DESCRIPTION
I'm making some small changes to the README regarding long running branches, or the staging integration branch. I took out the names of the branches as I didn't see the point in 1) exposing our upcoming secrets to the world, even though this is a public repo 2) trying to keep these up to date every time we need a new staging branch