### PR TITLE
Fixes DEVELOPER-2795

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -210,9 +210,6 @@ task :internal_deploy_task, [:profile, :tag_name] do |task, args|
   end
   site_host = $config.deploy.host
   rsync(local_path: local_site_path, host: site_host, remote_path: site_path, delete: delete, excludes: $resources + ['.snapshot'])
-  if awestruct_failed
-    exit 1
-  end
 end
 
 desc 'Clean out generated site and temporary files'

--- a/Rakefile
+++ b/Rakefile
@@ -165,13 +165,8 @@ task :internal_deploy_task, [:profile, :tag_name] do |task, args|
   begin
     run_awestruct "-P #{args[:profile]} -g --force -w"
   rescue
-    if args[:profile] != 'production'
-      msg 'awestruct_failed'
-      awestruct_failed = true
-    else
-      msg 'awestruct_failed, exit'
-      exit 1
-    end
+    msg 'awestruct_failed, exit'
+    exit 1
   end
 
   $config ||= config args[:profile]


### PR DESCRIPTION
We're now exiting with an error regardless of the enviroment we're
building. Previously we only failed if we were in production. We'd still
push a broken site.