### PR TITLE
[DEVELOPER-2861] Bumped jwt dependency to 1.5.4 to fix build issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
     image_size (1.4.2)
     iso8601 (0.9.0)
     json (1.8.3)
-    jwt (1.5.3)
+    jwt (1.5.4)
     kramdown (1.0.2)
     launchy (2.4.3)
       addressable (~> 2.3)


### PR DESCRIPTION
Updated the jwt dependency to version 1.5.4 as version 1.5.3 has been yanked from the repository.