### PR TITLE
[DEVELOPER-2898] Updated to the latest revision of the awestruct gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: git://github.com/lightguard/awestruct.git
-  revision: 1e8d7b90006bdc8b2562d2e697cf6f59f3ba5bae
+  revision: 1f0bba05cda0ed7452cb8e0e5c0eceb63f78e0e0
   branch: feature/perf-testing-large-site
   specs:
     awestruct (0.6.0.alpha)


### PR DESCRIPTION
Fixed the revision of the awestruct gem that is referenced in Gemfile.lock so that builds will work on machines without the old revision cached.