### PR TITLE
[DEVELOPER-2855] Temporary @ignore email based tests due to Gmail blocking new build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Red Hat Developers Site
+# Red Hat Developers Site!
 
 Powering the [Red Hat Developers site](http://developers.redhat.com/).
 

--- a/_cucumber/features/login_register/basic_login.feature
+++ b/_cucumber/features/login_register/basic_login.feature
@@ -29,14 +29,14 @@ Feature: Login Page
     When I click the Logout link
     Then I should be logged out
 
-  @password_reset @javascript @teardown
+  @password_reset @javascript @teardown @ignore
   Scenario: A customer who has forgotten their login details can request a password reset
     Given I am on the Login page
     When I request a password reset
     Then I should see a confirmation message: "You will receive an email shortly with instructions on how to create a new password. TIP: Check your junk or spam folder if you are unable to find the email."
     And I should receive an email containing a password reset link
 
-  @password_reset @javascript @logout
+  @password_reset @javascript @logout @ignore
   Scenario: A customer can successfully reset their password
     Given I am on the Login page
     And I request a password reset


### PR DESCRIPTION
GMail seems to be blocking connection attempts from the new build slaves. We have manually approved the new IP address and also ensured that the GMail account settings are set to allow connections.

After discussing with Ian, we have decided to temporarily ignore the tests as they often cause failures on the build due to timeouts, emails not showing up on time etc.