### PR TITLE
Remove "beta" from CDK2 info.

### DIFF
--- a/products/cdk/overview.adoc
+++ b/products/cdk/overview.adoc
@@ -4,13 +4,13 @@
 
 == Overview
 
-link:https://www.redhat.com/en/about/blog/introducing-red-hat-container-development-kit-2-beta[Red Hat Container Development Kit] (CDK) is a pre-built container development environment based on Red Hat Enterprise Linux to help you get started developing container-based applications quickly. The containers you build can be easily deployed on any Red Hat container host or platform, including: Red Hat Enterprise Linux, Red Hat Enterprise Linux Atomic Host, and our platform-as-a-service solution, OpenShift Enterprise 3.
+Red Hat Container Development Kit (CDK) is a pre-built container development environment based on Red Hat Enterprise Linux to help you get started developing container-based applications quickly. The containers you build can be easily deployed on any Red Hat container host or platform, including: Red Hat Enterprise Linux, Red Hat Enterprise Linux Atomic Host, and our platform-as-a-service solution, OpenShift Enterprise 3.
 
 === Get started with containers on Mac OS X, Microsoft Windows, or Linux
 
 To save you from having to assemble a container development environment from scratch, CDK delivers the latest container tools in a Red Hat Enterprise Linux virtual machine that you can use on your link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/#installing_the_cdk_on_mac_os_x[Mac OS X], link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/#installing_the_cdk_on_microsoft_windows[Microsoft Windows], link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/#installing_the_cdk_on_fedora_or_red_hat_enterprise_linux[RHEL or Fedora Linux system]. In addition, you have your choice of virtualization platforms (VirtualBox, VMware, and the Linux KVM/libvirt hypervisors are all supported). All of the VM configuration details on your system are handled for you by Vagrant, an open-source tool for creating and distributing portable and reproducible development environments.
 
-Red Hat Container Development Kit 2 beta is available now to customers and partners with select Red Hat Enterprise Linux Developer subscriptions (link:https://www.redhat.com/apps/store/developers/[Red Hat Enterprise Linux Developer Suite, Red Hat Enterprise Linux Developer Support, Enterprise or Professional]) and to partners who join the link:https://connect.redhat.com/zones/containers[Container Zone via the Red Hat Connect for Technology Partners program]. To learn how to install the Red Hat CDK, refer to the link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/[Red Hat CDK Installation Guide].
+Red Hat Container Development Kit 2.0 is available now to customers and partners with select Red Hat Enterprise Linux Developer subscriptions (link:https://www.redhat.com/apps/store/developers/[Red Hat Enterprise Linux Developer Suite, Red Hat Enterprise Linux Developer Support, Enterprise or Professional]) and to partners who join the link:https://connect.redhat.com/zones/containers[Container Zone via the Red Hat Connect for Technology Partners program]. To learn how to install the Red Hat CDK, refer to the link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/[Red Hat CDK Installation Guide].
 
 === Something for all levels of container experience
 
@@ -77,10 +77,10 @@ image:#{cdn(site.base_url + '/images/icons/products/products_tools.png')}["Tools
 
 === Getting the CDK
 
-Red Hat Container Development Kit 2 beta is available now to customers and partners with select Red Hat Enterprise Linux Developer subscriptions (link:https://www.redhat.com/apps/store/developers/[Red Hat Enterprise Linux Developer Suite, Red Hat Enterprise Linux Developer Support, Enterprise or Professional]) and to partners who “join” the link:https://connect.redhat.com/zones/containers[Container Zone via the Red Hat Connect for Technology Partners program].
+Red Hat Container Development Kit 2.0 is available now to customers and partners with select Red Hat Enterprise Linux Developer subscriptions (link:https://www.redhat.com/apps/store/developers/[Red Hat Enterprise Linux Developer Suite, Red Hat Enterprise Linux Developer Support, Enterprise or Professional]) and to partners who “join” the link:https://connect.redhat.com/zones/containers[Container Zone via the Red Hat Connect for Technology Partners program].
 To learn how to install the Red Hat CDK, refer to the link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/container-development-kit-installation-guide/[Red Hat CDK Installation Guide]. Then you can try some container examples from the link:https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/version-7/getting-started-with-container-development-kit/[Getting Started with Container Development Kit] guide.
 
 
 === Give us your feedback and join the discussion
 
-We want your feedback, join the discussion. Get involved. The link:https://www.redhat.com/mailman/listinfo/container-tools[Red Hat Container Tools mailing list] is open to all. Please try the beta and send us your feedback on the container-tools AT redhat.com mailing list.
+We want your feedback, join the discussion. Get involved. The link:https://www.redhat.com/mailman/listinfo/container-tools[Red Hat Container Tools mailing list] is open to all. Please try it and send us your feedback on the container-tools AT redhat.com mailing list.


### PR DESCRIPTION
CDK 2.0 is releasing 2016-04-19 and will no longer be in Beta.