### PR TITLE
Link direct to .NET preview video

### DIFF
--- a/_layouts/topics-dotnet.html.slim
+++ b/_layouts/topics-dotnet.html.slim
@@ -26,7 +26,7 @@ section.topics-dotted-graphics#dotNet
                   .large-16.columns
                     p #{a.sub_description}
                   .large-8.columns
-                    a.button.inverse.right(href='#{site.base_url}/webinars/registration-confirmation') Watch Now
+                    a.button.inverse.right(href='#{site.base_url}/video/youtube/pIURFD15WJ0/') Watch Now
                 .clearfix
                 - if a.tags
                   span.promo-tags


### PR DESCRIPTION
Now that the .NET webinar vide is live, I think we should link directly to it from the topic page, rather than linking to the webinar registration page.

@lincolnthree can you review please?