### PR TITLE
[DEVELOPER-2991] Remove Docker network when a pull request is closed

### DIFF
--- a/_lib/reaper.rb
+++ b/_lib/reaper.rb
@@ -30,6 +30,7 @@ class Reaper
   #
   # Deletes the Docker network associated with the pull request. This assumes the network will be named "rhdpr{#pr}_default"
   # Ideally this should be done through docker-compose down, but that is a larger change to the build and this will work
+  # and help prevent Docker from running out of networks
   #
   def self.clean_pr_network(pr)
     

--- a/_lib/reaper.rb
+++ b/_lib/reaper.rb
@@ -7,15 +7,43 @@ class Reaper
     to_kill = extract_prs(containers, prs_to_reap)
     ids = to_kill.map{|c| c.id}
 
-    puts "Going to kill and remove #{ids.join(',')}"
+    puts "Going to kill and remove containers with ids: #{ids.join(',')}"
 
     to_kill.each do |c|
-      puts "Killing and removing #{c.id}"
+      puts "Killing and removing container with id: '#{c.id}'"
       c.kill
       c.remove
     end
 
+    clean_pr_networks(prs_to_reap)
+
     ids
+  end
+
+  #
+  # Deletes the docker network associated with each of the given pull requests
+  #
+  def self.clean_pr_networks(prs_to_reap)
+    prs_to_reap.each { |pr| clean_pr_network(pr) }
+  end 
+
+  #
+  # Deletes the Docker network associated with the pull request. This assumes the network will be named "rhdpr{#pr}_default"
+  # Ideally this should be done through docker-compose down, but that is a larger change to the build and this will work
+  #
+  def self.clean_pr_network(pr)
+    
+    networkName="rhdpr#{pr}_default"
+    puts "Deleting Docker network '#{networkName}' for pull request '#{pr}'"
+
+    begin
+      network = Docker::Network.get(networkName)
+      network.delete()
+      puts "Successfully deleted Docker network '#{networkName}' for pull request '#{pr}'"
+    rescue Docker::Error::NotFoundError
+      puts "Failed to delete Docker network '#{networkName}' for pull request '#{pr}' as it does not exist."
+    end
+
   end
 
   def self.extract_prs(containers, prs_to_reap)
@@ -24,6 +52,6 @@ class Reaper
     end
   end
 
-  private_class_method :extract_prs
+  private_class_method :extract_prs, :clean_pr_networks, :clean_pr_network
 
 end

--- a/_tests/test_reaper.rb
+++ b/_tests/test_reaper.rb
@@ -27,41 +27,72 @@ class TestOptions < Minitest::Test
     end
   end
 
+  # Fake class for Docker::Network instance
+  class MyFakeNetwork
+    attr_reader :deleted, :pr
+    def initialize(pr)
+      @pr = pr
+      @deleted = false
+    end  
+
+    def delete
+      @deleted = true
+    end
+  end
+
+
   def test_reap_of_existing
     prs = [1,2,3]
     containers = prs.map{|pr| MyFakeContainer.new(pr)}
+    networks = prs.map{|pr| MyFakeNetwork.new(pr)}
+    
     Docker::Container.stubs(:all).returns containers
+    Docker::Network.stubs(:get).with("rhdpr1_default").returns networks[0]
+    Docker::Network.stubs(:get).with("rhdpr2_default").returns networks[1]
+    Docker::Network.stubs(:get).with("rhdpr3_default").returns networks[2]
 
     pulls = Reaper.kill_and_remove_prs(prs)
-
 
     assert_equal(['id1', 'id2', 'id3'], pulls)
     assert(containers.all?{|x| x.removed})
     assert(containers.all?{|x| x.killed})
+    assert(networks.all?{|n| n.deleted})
   end
 
   def test_does_not_remove_if_not_needed
     prs = [1,2,3]
     containers = prs.map{|pr| MyFakeContainer.new(pr)}
+    networks = [MyFakeNetwork.new(6.7), MyFakeNetwork.new(8)]
+    
     Docker::Container.stubs(:all).returns containers
-
+    Docker::Network.stubs(:get).with("rhdpr6.7_default").returns networks[0]
+    Docker::Network.stubs(:get).with("rhdpr8_default").returns networks[1]
+    
     pulls = Reaper.kill_and_remove_prs([6.7,8])
 
     assert_equal([], pulls)
     assert(containers.none?{|x| x.removed})
     assert(containers.none?{|x| x.killed})
+    assert(networks.all?{|n| n.deleted})
   end
 
   def test_only_kills_what_its_supposed_to
     prs = [1,2,3]
     containers = [MyFakeContainer.new('77')].concat prs.map{|pr| MyFakeContainer.new(pr)}
     containers.push(MyFakeContainer.new(99))
+
+    networks = prs.map{|pr| MyFakeNetwork.new(pr)}
+
     Docker::Container.stubs(:all).returns containers
+    Docker::Network.stubs(:get).with("rhdpr1_default").returns networks[0]
+    Docker::Network.stubs(:get).with("rhdpr2_default").returns networks[1]
+    Docker::Network.stubs(:get).with("rhdpr3_default").returns networks[2]
 
     pulls = Reaper.kill_and_remove_prs(prs)
 
     assert_equal(['id1', 'id2', 'id3'], pulls)
     assert_equal([false, true, true, true, false], containers.map{|x| x.removed})
     assert_equal([false, true, true, true, false], containers.map{|x| x.killed})
+    assert(networks.all?{|n| n.deleted})
   end
 end


### PR DESCRIPTION
An update to the Reaper class to ensure that is also deletes the Docker network associated with a pull request.

