### PR TITLE
base/Dockerfile Red Hat GPG key location URL update

### DIFF
--- a/_docker/base/Dockerfile
+++ b/_docker/base/Dockerfile
@@ -13,5 +13,5 @@ RUN yum-config-manager --add-repo http://yum.engineering.redhat.com/pub/yum/repo
     yum-config-manager --add-repo http://yum.engineering.redhat.com/pub/yum/repo_files/rhel6-supplementary.repo && \
     yum-config-manager --add-repo http://yum.engineering.redhat.com/pub/yum/repo_files/rhel6-updates.repo
 
-RUN curl https://www.redhat.com/security/fd431d51.txt > /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+RUN curl https://www.redhat.com/security/data/fd431d51.txt > /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 


### PR DESCRIPTION
* curl of /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release was failing
  silently due to a 301. curl doesn't follow the rediect by default.
* Changed URL from https://www.redhat.com/security/data/fd431d51.txt
  to https://www.redhat.com/security/data/fd431d51.txt