### PR TITLE
Updated product version and links for 6.6

### DIFF
--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Data Grid
 abbreviated_name: JBoss Data Grid
 product_logo: data-grid.png
-current_version: 6.5.0.GA
+current_version: 6.6.0.GA
 product_category: application-development
 intro_video: https://vimeo.com/95291413
 vimeo_album: http://vimeo.com/album/2982379
@@ -18,9 +18,9 @@ guides:
   API_Documentation:
     formats:
       html:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.5/html/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.6/html/API_Documentation/index.html
       html-single:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.5/html-single/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.6/html-single/API_Documentation/index.html
   Developer_Guide:
   Getting_Started_Guide:
   Infinispan_Query_Guide:


### PR DESCRIPTION
Need to update the developers.redhat.com documentation links for JDG 6.6.