### PR TITLE
DEVELOPER-3017 Fix broken link due to rename

### DIFF
--- a/products/softwarecollections/updates.adoc
+++ b/products/softwarecollections/updates.adoc
@@ -34,7 +34,7 @@ The Dockerfiles used to build the RHSCL container images are available as RHSCL 
 
 link:https://access.redhat.com/site/documentation/en-US/Red_Hat_Software_Collections/2-Beta/html-single/2.2_Release_Notes/index.html#chap-Installation.[Installation instructions] that cover adding the RHSCL 2.2 Beta software repository to Red Hat Enterprise Linux are available in the link:https://access.redhat.com/site/documentation/en-US/Red_Hat_Software_Collections/2-Beta/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Beta Release Notes].
 
-Use our link:#{site.base_url}/products/softwarecollections/get-started-rhel7-nodejs-beta/[Get Started Guide] to be up and running with Node.js v4 from RHSCL 2.2 Beta in under 10 minutes.
+Use our link:#{site.base_url}/products/softwarecollections/get-started-rhel7-nodejsbeta/[Get Started Guide] to be up and running with Node.js v4 from RHSCL 2.2 Beta in under 10 minutes.
 
 *Helpful Resources* +
 link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2-Beta/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Beta Release Notes] +


### PR DESCRIPTION
* PR #1090 renamed `products/softwarecollections/get-started-rhel7-nodejs-beta.adoc -> get-started-rhel7-nodejsbeta.adoc`
* Fix  `products/softwarecollections/updates.adoc` to point to the new name.