### PR TITLE
[DEVELOPER-3025] Only wait for Drupal and Searchisko if necessary

### DIFF
--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -17,7 +17,7 @@ class Options
         tasks[:decrypt] = true
         tasks[:set_ports] = true
         tasks[:kill_all] = true
-        tasks[:supporting_services] += %w(mysql searchisko drupal drupalmysql)
+        tasks[:supporting_services] += %w(mysql searchisko)
       end
 
       opts.on('-t', '--unit-test', 'Run the unit tests') do |b|
@@ -67,7 +67,7 @@ class Options
         tasks[:build] = true
         tasks[:unit_tests] = unit_test_tasks
         tasks[:set_ports] = true
-        tasks[:supporting_services] += %w(mysql searchisko drupal drupalmysql)
+        tasks[:supporting_services] += %w(mysql searchisko)
       end
 
       opts.on('--acceptance_test_target HOST_TO_TEST', String, 'runs the cucumber features against the specified HOST_TO_TEST') do |host|
@@ -107,7 +107,7 @@ class Options
         tasks[:build] = true
         tasks[:set_ports] = true
         tasks[:unit_tests] = unit_test_tasks
-        tasks[:supporting_services] += %w(mysql searchisko drupal drupalmysql)
+        tasks[:supporting_services] += %w(mysql searchisko)
       end
 
       opts.on('--run-the-stack', 'build, restart and preview') do |rts|
@@ -116,7 +116,7 @@ class Options
         tasks[:unit_tests] = unit_test_tasks
         tasks[:build] = true
         tasks[:kill_all] = true
-        tasks[:supporting_services] += %w(mysql searchisko drupal drupalmysql)
+        tasks[:supporting_services] += %w(mysql searchisko)
         tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean preview[profile]"]
       end
 

--- a/_docker/test/test_control.rb
+++ b/_docker/test/test_control.rb
@@ -1,0 +1,24 @@
+require 'minitest/autorun'
+require_relative '../control'
+
+class TestControl < Minitest::Test
+
+  def test_returns_true_when_supporting_service_in_list
+    supporting_services = %w"drupal mysql searchisko drupalmysql"
+    assert_equal(true, check_supported_service_requested(supporting_services, 'drupal'))
+  end
+
+  def test_returns_false_when_supporting_service_not_in_list
+    supporting_services = %w"mysql searchisko"
+    assert_equal(false, check_supported_service_requested(supporting_services, 'drupal'))
+  end
+
+  def test_returns_false_when_supporting_service_list_is_empty
+    assert_equal(false, check_supported_service_requested([], 'drupal'))
+  end
+
+  def test_returns_false_when_supporint_service_list_is_nil
+    assert_equal(false, check_supported_service_requested(nil, 'drupal'))
+  end
+
+end

--- a/_docker/test/test_options.rb
+++ b/_docker/test/test_options.rb
@@ -85,10 +85,10 @@ class TestOptions < Minitest::Test
 
   def test_supporting_services
     tasks = Options.parse (["-r"])
-    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko drupal drupalmysql))
+    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko))
 
     tasks = Options.parse (["--run-the-stack"])
-    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko drupal drupalmysql))
+    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko))
 
     tasks = Options.parse (['-u'])
     assert_includes tasks[:supporting_services], 'drupal'
@@ -149,7 +149,7 @@ class TestOptions < Minitest::Test
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert(tasks[:set_ports])
     assert(tasks[:build])
-    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko drupal drupalmysql))
+    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko))
   end
 
   def test_run_stage_pr
@@ -159,7 +159,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:build])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert(tasks[:set_ports])
-    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko drupal drupalmysql))
+    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko))
   end
 
   def test_run_the_stack
@@ -167,7 +167,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:kill_all])
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
-    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko drupal drupalmysql))
+    assert_equal(tasks[:supporting_services], %w(-d mysql searchisko))
     assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
 
     tasks = Options.parse %w(-u --run-the-stack)


### PR DESCRIPTION
The PR reaper job is failing: http://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/jboss.org/job/developers.redhat.com-pr_reaper/

This is because the job is trying to wait for searchisko to start, but there is no searchisko container for that scenario.

This update to control.rb ensure that we only wait for Drupal and Searchisko if they are part of the supporting_services required by the job that is executing.