### PR TITLE
Fixes DEVELOPER-2947 (fuse connector page)

### DIFF
--- a/_docker/drupal/modules/custom/redhat_developers/config/install/filter.format.as_is_html.yml
+++ b/_docker/drupal/modules/custom/redhat_developers/config/install/filter.format.as_is_html.yml
@@ -1,0 +1,28 @@
+uuid: 5610f355-4f75-4ee8-a600-b605c9f99a53
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+name: 'As-is HTML'
+format: as_is_html
+weight: 0
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 0
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }

--- a/_ext/jboss_developer.rb
+++ b/_ext/jboss_developer.rb
@@ -413,7 +413,7 @@ module Aweplug
          _links: {type: {href: File.join(@base_url, '/rest/type/node/', drupal_type)}},
          body: [{value: content,
                  summary: page.description,
-                 format: 'full_html'}],
+                 format: 'as_is_html'}],
          path: {alias: File.join('/', path)}
         }
       end

--- a/_tests/test_drupal8service.rb
+++ b/_tests/test_drupal8service.rb
@@ -73,7 +73,7 @@ class TestDrupal8Service < Minitest::Test
     stub_exists_call_good
 
     stub_request(:post, 'http://testing/entity/node')
-        .with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"full_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
+        .with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"as_is_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
              headers: {'Authorization' => 'Basic dGVzdGluZzp0ZXN0aW5n',
                        'Content-Type' => 'application/hal+json'})
         .to_return(status: 201)
@@ -93,7 +93,7 @@ class TestDrupal8Service < Minitest::Test
     stub_exists_call_bad
 
     stub_request(:patch, 'http://testing/article/testing-service?_format=hal_json').
-        with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"full_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
+        with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"as_is_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
              headers: {'Accept' => 'application/hal+json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Basic dGVzdGluZzp0ZXN0aW5n', 'Content-Type' => 'application/hal+json', 'User-Agent' => 'Faraday v0.9.2'}).
         to_return(status: 204)
 
@@ -112,7 +112,7 @@ class TestDrupal8Service < Minitest::Test
     stub_exists_call_bad
 
     stub_request(:post, 'http://testing/entity/node')
-        .with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"full_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
+        .with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"as_is_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
               headers: {'Authorization' => 'Basic dGVzdGluZzp0ZXN0aW5n',
                         'Content-Type' => 'application/hal+json'})
         .to_return(status: 201)
@@ -132,7 +132,7 @@ class TestDrupal8Service < Minitest::Test
     stub_exists_call_good
 
     stub_request(:patch, 'http://testing/article/testing-service?_format=hal_json').
-        with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"full_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
+        with(body: "{\"title\":[{\"value\":\"Testing Service\"}],\"_links\":{\"type\":{\"href\":\"http://testing/rest/type/node/page\"}},\"body\":[{\"value\":\"Hello World\",\"summary\":\"Learn how to use the Testing Service\",\"format\":\"as_is_html\"}],\"path\":{\"alias\":\"/article/testing-service\"}}",
              headers: {'Accept' => 'application/hal+json', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Basic dGVzdGluZzp0ZXN0aW5n', 'Content-Type' => 'application/hal+json', 'User-Agent' => 'Faraday v0.9.2'}).
         to_return(status: 204)
 


### PR DESCRIPTION
Please see https://issues.jboss.org/browse/DEVELOPER-2947 for details.

In Drupal it was 'fixing' bad HTML. Well, turns out it thought the HTML
in the script tags was bad (probably because of our template marker
choice), so it did it's best to fix it. Turns out it actually broke it.
I've created a new html text format that only administrators can use
which doesn't do this correction. I named it 'as-is HTML' so Drupal
doesn't try to fix anything.

In order to test this you'll have to start up Drupal:

```
cd _docker
bundle exec ./control.rb -u --run-the-stack
```

Once that finishes you'll need to visit the fuse connectors page to
verify things are working correctly.