### PR TITLE
[DEVELOPER-2936] Updated Gemfile to use HTTPS to fetch Git dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 
 # GEMS
 #gem 'awestruct', '0.5.7'
-gem 'awestruct', github: 'lightguard/awestruct', branch: 'feature/perf-testing-large-site'
+gem 'awestruct', git: 'https://github.com/lightguard/awestruct', branch: 'feature/perf-testing-large-site'
 #gem 'awestruct', path: '~/projects/ruby/awestruct'
 gem 'slim', '~> 3.0'
 gem 'kramdown', '~> 1.0.1'
@@ -52,7 +52,7 @@ gem 'uuid'
 #
 # From a location on your disk:
 #
-gem 'aweplug', github: 'awestruct/aweplug'
+gem 'aweplug', git: 'https://github.com/awestruct/aweplug'
 
 group :test do
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/awestruct/aweplug.git
+  remote: https://github.com/awestruct/aweplug
   revision: 23a8c06f42e5b73cfe122fffd0023b2975cadf72
   specs:
     aweplug (1.0.0.a24)
@@ -19,7 +19,7 @@ GIT
       xml-simple (~> 1.1)
 
 GIT
-  remote: git://github.com/lightguard/awestruct.git
+  remote: https://github.com/lightguard/awestruct
   revision: 1f0bba05cda0ed7452cb8e0e5c0eceb63f78e0e0
   branch: feature/perf-testing-large-site
   specs:


### PR DESCRIPTION
Whilst trying to get things to build on the new VMs for the Drupal environment, a persistent stumbling block was the fact that a couple of dependencies are pulled in using the git:// protocol.

The problem occurs on the VMs in that they are behind a proxy and I could not get bundle install to work behind the proxy.

As soon as I moved fetching the dependencies to using HTTPs, then everything works absolutely fine. It would also appear that HTTPS is the recommended approach for Git dependencies as-per the "Security" section on this page: http://bundler.io/git.html