### PR TITLE
[DEVELOPER-3041] Do not expose Awestruct port on Jenkins

### DIFF
--- a/_docker/docker-compose.yml.erb
+++ b/_docker/docker-compose.yml.erb
@@ -62,10 +62,7 @@ services:
     build: ./awestruct
     command:
       - "rake git_setup clean preview[docker]"
-<% if ENV['JENKINS_HOME'] %>
-    ports:
-      - "4242"
-<% else %>
+<% unless ENV['JENKINS_HOME'] %>
     ports:
       - "4242:4242"
 <% end %>


### PR DESCRIPTION
Another attempt to resolve the problem with "port in use" errors. This time we only expose the awestruct port if we're running in a local development environment i.e. not on Jenkins.