### PR TITLE
Made description unique

### DIFF
--- a/community/contributor/signup.html.slim
+++ b/community/contributor/signup.html.slim
@@ -1,7 +1,7 @@
 ---
 layout: base
 body_class: fullbleed
-title: Red Hat Developers Content Contributors
+title: Red Hat Developers Content Contributors Sign Up
 ---
 
 section.contributors-main


### PR DESCRIPTION
This is simple change to prevent two pages having the same description. I'm checking that making this fix percolates through the DCP instances and improves the site search.