### PR TITLE
[DO NOT MERGE] Testing change of docker host alias on Stumpjumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Red Hat Developers Site!
+# Red Hat Developers Site
 
 Powering the [Red Hat Developers site](http://developers.redhat.com/).
 


### PR DESCRIPTION
The 'docker' host on stumpjumper resolves to 127.0.0.1. This probably won't work for the Drupal-based pull requests, so I've moved it over to resolve to the FQDN of stumpjumper.

This is just a small test to make sure nothing breaks by doing this.