### PR TITLE
[DEVELOPER-3022] Deploy Awestruct content changes into Drupal

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -80,10 +80,52 @@ profiles:
 <% end %>
     push_to_searchisko: true
 
-  drupal:
+  drupal_dev:
     <<: *docker
-    base_url: http://<%= ENV['DRUPAL_HOST_IP'] || 'docker' %>:<%= ENV['DRUPAL_HOST_PORT'] %>/
+    base_url: http://<%= ENV['DRUPAL_HOST_IP']%>/
+    dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     drupal_base_url: http://drupal/
+
+  drupal_pull_request:
+    <<: *docker
+    base_url: http://<%= ENV['ACCESSIBLE_SLAVE_IP']%>:<%= ENV['DRUPAL_HOST_PORT'] %>/
+    dcp_base_protocol_relative_url: //<%= ENV['ACCESSIBLE_SLAVE_IP'] %>:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
+    drupal_base_url: http://drupal/
+
+  drupal_staging:
+    <<: *profile
+    base_url: http://developer-drupal.web.stage.ext.phx2.redhat.com/
+    drupal_base_url: http://drupal/
+    download_manager_file_base_url: //developers.stage.redhat.com/download-manager/file/
+    download_manager_base_url: https://developers.stage.redhat.com
+    dcp_base_url: http://dcp.stage.jboss.org/
+    dcp_base_protocol_relative_url: //dcp.stage.jboss.org/
+    keycloak_account_url: https://developers.stage.redhat.com/auth/realms/rhd/account/
+    keycloak_auth_url: https://developers.stage.redhat.com/auth/
+    metrics: true
+    client_side_error_logging: true
+    build_threads: 1
+    dtm_code: //assets.adobedtm.com/2b327a0a54b320bf1bcdb5fa39a2b896027067d9/satelliteLib-9ec3c34e9d660fa2fcb85ced512c3a48dc09c0c5-staging.js
+    deploy:
+      <<: *deploy
+      path: /stg_htdocs/it-rhd-stg-main
+
+  drupal_production:
+    <<: *profile
+    base_url: http://developer-drupal.web.prod.ext.phx2.redhat.com/
+    drupal_base_url: http://drupal/
+    dcp_base_protocol_relative_url: //dcp2.jboss.org/
+    dcp_base_url: http://dcp2.jboss.org/
+    require_tag: true
+    metrics: true
+    client_side_error_logging: true
+    disqus: jdf
+    dtm_mode: //assets.adobedtm.com/2b327a0a54b320bf1bcdb5fa39a2b896027067d9/satelliteLib-9ec3c34e9d660fa2fcb85ced512c3a48dc09c0c5.js
+    robots:
+      disallow: false
+    deploy:
+      <<: *deploy
+      path: /www_htdocs/it-rhd
 
   development_cdn:
     <<: *development

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -82,7 +82,7 @@ profiles:
 
   drupal_dev:
     <<: *docker
-    base_url: http://<%= ENV['DRUPAL_HOST_IP']%>/
+    base_url: http://<%= ENV['DRUPAL_HOST_IP']%>:<%= ENV['DRUPAL_HOST_PORT'] %>/
     dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     drupal_base_url: http://drupal/
 

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -256,9 +256,8 @@ end
 #
 def start_and_wait_for_supporting_services(environment, supporting_services, system_exec)
 
-  puts "Starting all required supporting services..."
-
   unless supporting_services.nil? or supporting_services.empty?
+    puts "Starting all required supporting services..."
 
     environment.create_template_resources
     system_exec.execute_docker_compose(environment, :up, %w(-d --no-recreate).concat(supporting_services))
@@ -267,8 +266,6 @@ def start_and_wait_for_supporting_services(environment, supporting_services, sys
     environment.template_resources
 
     puts "Started all required supporting services."
-  else
-    puts "No supporting services to start."
   end
 end
 

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   awestruct:
     build: ../../awestruct
     command:
-      - "rake git_setup clean preview[docker]"
+      - "rake git_setup clean gen[drupal_dev]"
     links:
       - drupal
       - searchisko

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   drupal:
     build: ../../drupal
     ports:
-      - "80:80"
+      - "32769:80"
     links:
       - drupalmysql
       - searchisko
@@ -80,7 +80,7 @@ services:
     expose:
      - "8080"
     ports:
-     - "8080"
+     - "32772:8080"
     environment:
       - DB_NAME=searchisko
       - DB_USER=searchisko

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   awestruct:
     build: ../../awestruct
     command:
-      - "rake git_setup clean preview[docker]"
+      - "rake git_setup clean gen[drupal_production]"
     links:
       - drupal
     volumes:

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   awestruct:
     build: ../../awestruct
     command:
-      - "rake git_setup clean preview[docker]"
+      - "rake git_setup clean gen[drupal_pull_request]"
     links:
       - drupal
       - searchisko

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   awestruct:
     build: ../../awestruct
     command:
-      - "rake git_setup clean preview[docker]"
+      - "rake git_setup clean gen[drupal_staging]"
     links:
       - drupal
     volumes:

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -5,7 +5,6 @@ class Options
   def self.parse(args)
     tasks = {}
     tasks[:environment_name] = 'awestruct-pull-request'
-    tasks[:awestruct_command_args] = %w(--rm --service-ports awestruct)
 
     opts_parse = OptionParser.new do |opts|
       opts.banner = 'Usage: control.rb [options]'
@@ -48,11 +47,12 @@ class Options
 
       opts.on('-g', '--generate', 'Run awestruct (clean gen)') do |r|
         tasks[:decrypt] = true
+        tasks[:awestruct_command_args] = %w(--rm --service-ports awestruct)
       end
 
       opts.on('-p', '--preview', 'Run awestruct (clean preview)') do |r|
         tasks[:decrypt] = true
-        tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean preview[profile]"]
+        tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean preview[docker]"]
       end
 
       opts.on('--stage-pr PR_NUMBER', Integer, 'build for PR Staging') do |pr|
@@ -103,6 +103,7 @@ class Options
         tasks[:unit_tests] = unit_test_tasks
         tasks[:build] = true
         tasks[:kill_all] = true
+        tasks[:awestruct_command_args] = %w(--rm --service-ports awestruct)
       end
 
       # No argument, shows at tail.  This will print an options summary.
@@ -121,18 +122,6 @@ class Options
     testing_directory = File.expand_path('../environments/testing',File.dirname(__FILE__))
     environment = RhdEnvironments.new(File.expand_path('../environments',File.dirname(__FILE__)), testing_directory).load_environment(tasks[:environment_name])
     tasks[:environment] = environment
-
-    # TODO - Can this be pulled into the environment specific docker-compose files?
-    # change the profile awestruct runs with
-    if tasks[:awestruct_command_args]
-      if environment.is_drupal_environment?
-        tasks[:awestruct_command_args][-1].gsub! 'profile', 'drupal'
-        tasks[:awestruct_command_args][-1].gsub! 'preview', 'gen'
-      else
-        tasks[:awestruct_command_args][-1].gsub! 'profile', 'docker'
-      end
-    end
-
 
     #
     # Set the list of supporting services to be started from the environment, unless the options above explicitly set it first

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -5,6 +5,7 @@ class Options
   def self.parse(args)
     tasks = {}
     tasks[:environment_name] = 'awestruct-pull-request'
+    tasks[:awestruct_command_args] = %w(--rm --service-ports awestruct)
 
     opts_parse = OptionParser.new do |opts|
       opts.banner = 'Usage: control.rb [options]'
@@ -47,18 +48,11 @@ class Options
 
       opts.on('-g', '--generate', 'Run awestruct (clean gen)') do |r|
         tasks[:decrypt] = true
-        tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[profile]"]
       end
 
       opts.on('-p', '--preview', 'Run awestruct (clean preview)') do |r|
         tasks[:decrypt] = true
         tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean preview[profile]"]
-      end
-
-      opts.on('--drupal-nightly', 'Start up and enable drupal') do |u|
-        tasks[:build] = true
-        tasks[:kill_all] = true
-        tasks[:awestruct_command_args] = ['--no-deps', '--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"]
       end
 
       opts.on('--stage-pr PR_NUMBER', Integer, 'build for PR Staging') do |pr|
@@ -109,7 +103,6 @@ class Options
         tasks[:unit_tests] = unit_test_tasks
         tasks[:build] = true
         tasks[:kill_all] = true
-        tasks[:awestruct_command_args] = ['--rm', '--service-ports', 'awestruct', "rake git_setup clean preview[profile]"]
       end
 
       # No argument, shows at tail.  This will print an options summary.

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -126,27 +126,27 @@ class TestOptions < Minitest::Test
   end
 
   def test_awestruct_command_drupal_dev
-    tasks = Options.parse ['-e drupal-dev', '-p','-u']
+    tasks = Options.parse ['-e drupal-dev', '-p']
     # If we're using drupal, we don't need to do a preview in awestruct
-    ['--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"].each do |commands|
+    %w(--rm --service-ports awestruct).each do |commands|
       assert_includes tasks[:awestruct_command_args], commands
     end
 
-    tasks = Options.parse ['-e drupal-dev', '-g' ,'-u']
-    ['--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"].each do |commands|
+    tasks = Options.parse ['-e drupal-dev', '-g']
+    %w(--rm --service-ports awestruct).each do |commands|
       assert_includes tasks[:awestruct_command_args], commands
     end
   end
 
   def test_awestruct_command_drupal_pull_request_environment
-    tasks = Options.parse ['-e drupal-pull-request', '-p','-u']
+    tasks = Options.parse ['-e drupal-pull-request', '-p']
     # If we're using drupal, we don't need to do a preview in awestruct
-    ['--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"].each do |commands|
+    %w(--rm --service-ports awestruct).each do |commands|
       assert_includes tasks[:awestruct_command_args], commands
     end
 
-    tasks = Options.parse ['-e drupal-pull-request', '-g' ,'-u']
-    ['--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"].each do |commands|
+    tasks = Options.parse ['-e drupal-pull-request', '-g']
+    ['--rm', '--service-ports', 'awestruct'].each do |commands|
       assert_includes tasks[:awestruct_command_args], commands
     end
   end
@@ -155,22 +155,22 @@ class TestOptions < Minitest::Test
     tasks = Options.parse (['-e awestruct-dev', "--stage-pr", "6"])
     assert_equal(["--rm", "--service-ports", "awestruct", "bundle exec rake create_pr_dirs[pr,build,6] clean deploy[staging_docker]"], tasks[:awestruct_command_args])
     tasks = Options.parse (['-e awestruct-dev',"--run-the-stack"])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
     tasks = Options.parse (['-e awestruct-dev',"-p"])
     assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
     tasks = Options.parse (['-e awestruct-dev',"-g"])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean gen[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
 
   def test_awestruct_command
     tasks = Options.parse (["--stage-pr", "6"])
     assert_equal(["--rm", "--service-ports", "awestruct", "bundle exec rake create_pr_dirs[pr,build,6] clean deploy[staging_docker]"], tasks[:awestruct_command_args])
     tasks = Options.parse (["--run-the-stack"])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
     tasks = Options.parse (["-p"])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct','rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
     tasks = Options.parse (["-g"])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean gen[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
 
   def test_acceptance_test_target_task
@@ -240,7 +240,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert_equal(%w(mysql searchisko), tasks[:supporting_services])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
+    assert_equal(%w(--rm --service-ports awestruct), tasks[:awestruct_command_args])
   end
 
   def test_run_the_stack_drupal_dev
@@ -249,7 +249,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert_equal(%w(mysql searchisko drupalmysql drupal), tasks[:supporting_services])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean gen[drupal]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
 
   def test_run_the_stack_drupal_pull_request
@@ -260,7 +260,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert_equal(%w(mysql searchisko drupalmysql drupal), tasks[:supporting_services])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean gen[drupal]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
 
 
@@ -270,7 +270,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
     assert_equal(%w(mysql searchisko), tasks[:supporting_services])
-    assert_equal(['--rm', '--service-ports', 'awestruct', 'rake git_setup clean preview[docker]'], tasks[:awestruct_command_args])
+    assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
 
   def test_test_task
@@ -290,17 +290,6 @@ class TestOptions < Minitest::Test
   def test_docker_url
     tasks = Options.parse (["-d", "SOMETHING"])
     assert_equal("SOMETHING",tasks[:docker])
-  end
-
-  def test_drupal_nightly
-    tasks = Options.parse (['-e drupal-pull-request', '--drupal-nightly'])
-
-    assert_equal(tasks[:awestruct_command_args], ['--no-deps', '--rm', '--service-ports', 'awestruct', "rake git_setup clean gen[drupal]"])
-    refute(tasks[:decrypt])
-    assert(tasks[:kill_all])
-    assert_includes tasks, :supporting_services
-    assert_includes tasks[:supporting_services], 'drupal'
-    assert_includes tasks[:supporting_services], 'drupalmysql'
   end
 
   private def expected_unit_test_tasks

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -76,45 +76,49 @@ class TestOptions < Minitest::Test
     tasks = Options.parse (["-b"])
     assert(tasks[:build])
     assert_equal([], tasks[:supporting_services])
-
-    tasks = Options.parse (["--run-the-stack"])
-    assert(tasks[:build])
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill
     tasks = Options.parse (["-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(mysql searchisko))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill_awestruct_dev
     tasks = Options.parse (['-e awestruct-dev',"-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(mysql searchisko))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill_drupal_dev
     tasks = Options.parse (['-e drupal-dev',"-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(mysql searchisko drupalmysql drupal))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill_drupal_pull_request
     tasks = Options.parse (['-e drupal-pull-request',"-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(mysql searchisko drupalmysql drupal))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill_drupal_staging
     tasks = Options.parse (['-e drupal-staging',"-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(drupal))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_kill_drupal_production
     tasks = Options.parse (['-e drupal-production',"-r"])
     assert(tasks[:kill_all])
     assert_equal(tasks[:supporting_services], %w(drupal))
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_supporting_services
@@ -278,6 +282,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:build])
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_run_tests_awestruct_dev
@@ -285,6 +290,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:build])
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
+    assert_equal(nil, tasks[:awestruct_command_args])
   end
 
   def test_docker_url


### PR DESCRIPTION
This pull request introduces the following changes:

- Creates an Awestruct profile for each of the Drupal environments
- Moves the default Awestruct command to be run into the docker-compose.yml file for each environment
- Removes support for the --drupal-nightly option in control.rb
- Correctly sets the Drupal and Searchisko ports in drupal-dev environment to support hard-coded endpoints in twig files
- Updates to options.rb to support the above