### PR TITLE
[DEVELOPER-3081] Ensured that we invoke npm install during Drupal builds

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -181,13 +181,23 @@ def copy_project_dependencies_for_awestruct_image
 end
 
 #
+# Wrapper around calls out to npm
+#
+def run_npm_command(cmd, error_message)
+
+  puts " -- Running command '#{cmd}'..."
+  out, status = Open3.capture2e("#{cmd}")
+  Kernel.abort("#{error_message}: #{out}") unless status.success?
+end
+
+#
 # Delegates out to Gulp to build the CSS and JS for Drupal
 #
 def build_css_and_js_for_drupal
   puts '- Building CSS and JS for Drupal...'
 
-  out, status = Open3.capture2e('$(npm bin)/gulp')
-  Kernel.abort("Error building CSS / JS for Drupal: #{out}") unless status.success?
+  run_npm_command('npm install',"Failed to run 'npm install'. Do you have npm installed?")
+  run_npm_command('$(npm bin)/gulp', 'Failed to run Gulp to build CSS and JS for Drupal')
 
   puts '- Successfully built CSS and JS for Drupal'
 end

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -158,17 +158,31 @@ class TestControl < Minitest::Test
   def test_build_css_and_js_for_drupal
     status = mock()
 
-    status.expects(:success?).returns(true)
+    status.expects(:success?).returns(true).twice
+    Open3.expects(:capture2e).with('npm install').returns(['out',status])
     Open3.expects(:capture2e).with('$(npm bin)/gulp').returns(['out',status])
 
     build_css_and_js_for_drupal
 
   end
 
-  def test_should_abort_if_cannot_build_css_and_js_for_drupal
+  def test_should_abort_if_cannot_build_css_and_js_running_npm_install
+
     status = mock()
 
     status.expects(:success?).returns(false)
+    Open3.expects(:capture2e).with('npm install').returns(['out',status])
+
+    assert_raises(SystemExit){
+      build_css_and_js_for_drupal
+    }
+  end
+
+  def test_should_abort_if_cannot_build_css_and_js_for_drupal_running_gulp
+    status = mock()
+
+    status.expects(:success?).twice.returns(true).then.returns(false)
+    Open3.expects(:capture2e).with('npm install').returns(['out',status])
     Open3.expects(:capture2e).with('$(npm bin)/gulp').returns(['Oh dear!',status])
 
     assert_raises(SystemExit){


### PR DESCRIPTION
Small update to control.rb to ensure that we invoke 'npm install' if we're running in a Drupal-based environment.