### PR TITLE
docker env determine_docker_host fix

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -247,12 +247,11 @@ end
 #
 def determine_docker_host_for_container_ports
 
-  docker_host = Resolv.getaddress(Socket.gethostname)
-
   begin
     docker_host = Resolv.getaddress('docker')
     puts "Host alias for 'docker' found. Assuming container ports are exposed on ip '#{docker_host}'"
   rescue
+    docker_host = Resolv.getaddress(Socket.gethostname)
     puts "No host alias for 'docker' found. Assuming container ports are exposed on '#{docker_host}'"
   end
 

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -27,8 +27,9 @@ class TestControl < Minitest::Test
   def test_determine_docker_host_for_container_ports_with_docker_host_alias
 
       host_ip = '10.20.30.40'
-      Socket.expects(:gethostname).returns('localhost')
-      Resolv.expects(:getaddress).with('localhost').returns(host_ip)
+      # won't execute if docker defined.
+      # Socket.expects(:gethostname).returns('localhost')
+      # Resolv.expects(:getaddress).with('localhost').returns(host_ip)
 
       docker_machine_ip = '192.168.0.1'
       Resolv.expects(:getaddress).with('docker').returns(docker_machine_ip)


### PR DESCRIPTION
control.rb::determine_docker_host_for_container_ports was trying to
get the IP address of the system hostname, which might not be defined on
developer's machines, before checking whether the hostname `docker`
would resolve.

The expectation is developer's machines with an RHDev docker
environment will have docker defined as a hostname with an
ip address for localhost.

This workaround will still fail cryptically if the hostname docker isn't
defined and the current hostname doesn't resolve to an ip address.