### PR TITLE
[DEVELOPER-2937] No supporting services for backup

### DIFF
--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -23,6 +23,7 @@ class Options
       opts.on('--backup [BACKUP_NAME]', String, 'Take a backup of the environment') do |backup|
         tasks[:build] = true
         tasks[:awestruct_command_args] = ['--rm', 'backup', "#{backup}"]
+        tasks[:supporting_services] = []
       end
 
       opts.on('-r', '--restart', 'Restart the containers') do |r|

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -64,12 +64,14 @@ class TestOptions < Minitest::Test
     tasks = Options.parse (["--backup"])
     assert(tasks[:build])
     assert_equal(['--rm', 'backup',''], tasks[:awestruct_command_args])
+    assert_equal(%w(), tasks[:supporting_services])
   end
 
   def test_backup_with_supplied_backup_name
     tasks = Options.parse (["--backup", "my-backup-name"])
     assert(tasks[:build])
     assert_equal(['--rm', 'backup', 'my-backup-name'], tasks[:awestruct_command_args])
+    assert_equal(%w(), tasks[:supporting_services])
   end
 
   def test_set_build


### PR DESCRIPTION
When taking a backup, we do not need to start or wait for any supporting services.