### PR TITLE
[DEVELOPER-3134] Reduced the number of chrome nodes to 2 by default

### DIFF
--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -76,7 +76,7 @@ class Options
         end
 
         if ENV['RHD_BROWSER_SCALE'].to_s.empty?
-          ENV['RHD_BROWSER_SCALE'] = '5'
+          ENV['RHD_BROWSER_SCALE'] = '2'
         end
 
         tasks[:kill_all] = false


### PR DESCRIPTION
To try and lower resource contention on stumpjumper, reduce the number of chrome nodes to 2 per pull request.