### PR TITLE
[WIP] [HOLD] DEVELOPER-3049 RHSCL 2.2 Updates with included text

### DIFF
--- a/products/softwarecollections/_includes/get-started-rhel7-prereq.adoc
+++ b/products/softwarecollections/_includes/get-started-rhel7-prereq.adoc
@@ -1,0 +1,10 @@
+## Prerequisites section title
+Introduction and Prerequisites
+
+## Prerequisites section
+In this tutorial, you will set your system up to install software from Red Hat Software Collections (RHSCL), which provides the latest development technologies for Red Hat Enterprise Linux. Then, you will install {tthw-langlong} and run a simple “Hello, World” application. The whole tutorial should take less than 10 minutes to complete.
+
+Before you begin, you will need a current Red Hat Enterprise Linux {tthw-rhelver} server or workstation subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through link:#{site.base_url}/[developers.redhat.com]. 
+
+If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
+

--- a/products/softwarecollections/_includes/get-started-rhel7-step1.adoc
+++ b/products/softwarecollections/_includes/get-started-rhel7-step1.adoc
@@ -1,0 +1,34 @@
+In this step you will configure your system to obtain software, including the latest dynamic languages, from the RHSCL software repository. Instructions are provided for both the command line (CLI) and graphical user interface (GUI).
+
+### Using the Red Hat Subscription Manager GUI
+
+Red Hat Subscription Manager can be started from the _System Tools_ group of the _Applications_ menu. Alternatively, you can start it from the command prompt by typing `subscription-manager-gui`. +
+
+Select _Repositories_ from the _System_ menu of the subscription manager. In the list of repositories, check the _Enabled_ column for _rhel-server-rhscl-7-rpms_ and _rhel-7-server-optional-rpms_. If you are using a desktop version of Red Hat Enterprise Linux, the repositories will be named _rhel-desktop-rhscl-7-rpms_ and _rhel-7-desktop-optional-rpms_. Note: After clicking, it might take several seconds for the check mark to appear in the enabled column. +
+
+If you don’t see any RHSCL repositories in the list, your subscription might not include it. +
+image:#{cdn(site.base_url + '/images/products/softwarecollections/rhel7/manage-repositories.png')}[Manage Repositories]
+
+See <<troubleshooting,Troubleshooting and FAQ>> for more information. +
+
+
+### Using subscription-manager from the command line
+
+You can add or remove software repositories from the command line using the `subscription-manager` tool as the root user. Use the `--list` option to view the available software repositories and verify that you have access to RHSCL:
+
+[.code-block]
+```
+$ su -
+# subscription-manager repos --list | egrep rhscl
+```
+
+If you don’t see any RHSCL repositories in the list, your subscription might not include it. See <<troubleshooting,Troubleshooting and FAQ>> for more information.
+
+If you are using a workstation edition of Red Hat Enterprise Linux, change `-server-` to `-workstation-` in the following commands:
+
+[.code-block]
+```
+# subscription-manager repos --enable rhel-server-rhscl-7-rpms
+# subscription-manager repos --enable rhel-7-server-optional-rpms
+```
+

--- a/products/softwarecollections/get-started-rhel7-nodejs.adoc
+++ b/products/softwarecollections/get-started-rhel7-nodejs.adoc
@@ -1,7 +1,11 @@
 :awestruct-layout: product-get-started-multipath
 :awestruct-interpolate: true
-:title: "Software Collections - Get started developing with Node.js 0.10 on RHEL 7"
-:awestruct-description: "Get started developing with Node.js 0.10 from Red Hat Software Collections on Red Hat Enterprise Linux 7 in under 10 minutes."
+:tthw-rhelver: 7
+:tthw-langshort: Node.js
+:tthw-langlong: Node.js v4
+:tthw-sclname: rh-nodejs4
+:title: "Software Collections - Get started developing with {tthw-langlong} on RHEL {tthw-rhelver}"
+:awestruct-description: "Get started developing with {tthw-langlong} from Red Hat Software Collections on Red Hat Enterprise Linux {tthow-rhelver} in under 10 minutes."
 
 ## Path Name
 Node.js
@@ -11,17 +15,7 @@ Node.js
 image:#{cdn(site.base_url + '/images/products/multipath/nodejs-logo.png')}[Node.js Logo]
 
 [.large-18.columns#PathIntroSection]
-Get started developing with Node.js from Red Hat Software Collections in under 10 minutes.
-
-## Prerequisites section title
-Introduction and Prerequisites
-
-## Prerequisites section
-In this tutorial, you will set your system up to install software from Red Hat Software Collections (RHSCL), which provides the latest development technologies for Red Hat Enterprise Linux. Then, you will install Node.js and run a simple “Hello, World” application. The whole tutorial should take less than 10 minutes to complete.
-
-Before you begin, you will need a current Red Hat Enterprise Linux 7 workstation or server subscription that allows you to download software and get updates from Red Hat. If you don’t have an active subscription, register and obtain the RHEL Developer Suite (includes RHEL server) from here.
-
-If you have problems at any point, see <<troubleshooting,Troubleshooting and FAQ>>.
+Get started developing with {tthw-langlong} from Red Hat Software Collections in under 10 minutes.
 
 ## Step1 Duration
 2 minutes
@@ -41,114 +35,95 @@ Setup your development environment
 ## Step3 Title
 Hello World and your first application
 
+:leveloffset:0
+include::products/softwarecollections/_includes/get-started-rhel7-prereq.adoc[]
+
+
 ## Step1 Content
 
-In this step you will configure your system to obtain software, including the latest dynamic languages, from the RHSCL software repository. Instructions are provided for both the command line (CLI) and graphical user interface (GUI).
-
-### Using the Red Hat Subscription Manager GUI
-
-Red Hat Subscription Manager can be started from the _System Tools_ group of the _Applications_ menu. Alternatively, you can start it from the command prompt by typing `subscription-manager-gui`. +
-
-Select _Repositories_ from the _System_ menu of the subscription manager. In the list of repositories, check the _Enabled_ column for _rhel-server-rhscl-7-rpms_ and _rhel-7-server-optional-rpms_. If you are using a desktop version of Red Hat Enterprise Linux, the repositories will be named _rhel-desktop-rhscl-7-rpms_ and _rhel-7-desktop-optional-rpms_. +
-
-If you don’t see any RHSCL repositories in the list, your subscription might not include it. +
-image:#{cdn(site.base_url + '/images/products/softwarecollections/rhel7/manage-repositories.png')}[Manage Repositories]
-
-See <<troubleshooting,Troubleshooting and FAQ>> for more information. +
-
-
-### Using subscription-manager from the command line
-
-You can add or remove software repositories from the command line using the `subscription-manager` tool as the root user. Use the `--list` option to view the available software repositories and verify that you have access to RHSCL:
-
-[.code-block]
-```
-$ su -
-# subscription-manager repos --list | egrep rhscl
-```
-
-If you don’t see any RHSCL repositories in the list, your subscription might not include it. See <<troubleshooting,Troubleshooting and FAQ>> for more information.
-
-If you are using a desktop edition of Red Hat Enterprise Linux, change `-server-` to `-desktop-` in the following commands:
-
-[.code-block]
-```
-# subscription-manager repos --enable rhel-server-rhscl-7-rpms
-# subscription-manager repos --enable rhel-7-server-optional-rpms
-```
+:leveloffset:0
+include::products/softwarecollections/_includes/get-started-rhel7-step1.adoc[]
 
 
 ## Step2 Content
 
-In this next step you will install Node.js 0.10 from RHSCL:
+In this next step you will install {tthw-langlong} from RHSCL:
 
 [.code-block]
 ```
 $ su -
-# yum install nodejs010
+# yum install {tthw-sclname}
 ```
 
-Note: The V8 JavaScript runtime is installed automatically as a dependency. +
+Note: In {tthw-langlong}, the JavaScript v8 runtime is built in. A separate package is no longer required. +
 
 If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
 
 ## Step3 Content
 
-Under your normal user ID, start a _Terminal_ window. First, use `scl enable` to add Node.js to your environment, then start  `node` to check the version.
+Under your normal user ID, start a _Terminal_ window. First, use `scl enable` to add {tthw-langlong} to your environment, then run {tthw-langshort} to check the version.
 
 [.code-block]
 ```
-$ scl enable nodejs010 bash
+$ scl enable {tthw-sclname} bash
 $ node --version
-v0.10.35
+v4.4.2
 ```
 
-The next step is to create a JavaScript program that can be run from the command line. Using your preferred text editor, create a file named `hello.js`:
+The next step is to create a {tthw-langshort} program that can be run from the command line. Using a text editor such as `vi`, `nano`, or `gedit` create a file named `hello.js` with the following content:
 
-`$ nano hello.js`
+// doesn't seem to work correctly in rhdev env.
+// [source,javascript]
 
-Add the following text to the file:
-
-[.code-block]
-```
-console.log("Hello, Red Hat Developers World!")
-```
+.hello.js
+----
+console.log("Hello, Red Hat Developers World from Node " + process.version)
+----
 
 Save it and exit the editor. Run it with the `node` command:
 [.code-block]
 ```
 $ node ./hello.js
-Hello, Red Hat Developers World
+Hello, Red Hat Developers World from Node v4.4.2
 ```
 
-If you get the error: _node command not found_, you need to run `scl enable nodejs010 bash` first.
+If you get the error: _node command not found_, you need to run `scl enable rh-nodejs4 bash` first.
 
-The next step is to try a slightly larger Node.js example that implements a tiny web server.  Using your preferred text editor, create a file named `hello-http.js`:
+The next step is to try a slightly larger {tthw-langshort} example that implements a tiny web server.  Using your preferred text editor, create a file named `hello-http.js` with the following content:
 
-`$ nano hello-http.js`
+// doesn't seem to work correctly in rhdev env.
+// [source,javascript]
 
-Add the following text to the file:
-
-[.code-block]
-```
+.hello-http.js
+----
 var http = require('http');
+var port = 8000;
+var laddr = '0.0.0.0';
 http.createServer(function (req, res) {
     res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.end('Hello, Red Hat Developers World!\n');
-}).listen(8000, '127.0.0.1');
-console.log('Server running at http://127.0.0.1:8000/');
-```
+    res.end('Hello, Red Hat Developers World from ' +
+	    process.version + '!\n');
+    console.log('Processed request for '+ req.url);
+}).listen(port, laddr);                                                                                                                
+console.log('Server running at http://' + laddr + ':' + port + '/');  
+----
 
 Save it and exit the editor. Run it with the `node` command:
 
 `$ node ./hello-http.js`
 
-Now use Firefox or your preferred browser to connect to the Node.js web server `http://localhost:8000/`.
+Now use curl, or a browser such as Firefox, to connect to the Node.js web server `http://localhost:8000/`:
+
+[.code-block]
+```
+$ curl http://localhost:8000/
+Hello, Red Hat Developers World from v4.4.2!
+```
 
 
 ### Working with RHSCL packages
 
-The software packages in RHSCL are designed to allow multiple versions of software to be installed concurrently. To accomplish this, the desired package is added to your runtime environment as needed with the `scl enable` command. When `scl enable` runs, it modifies environment variables and then runs the specified command. The environmental changes only affect the command that is run by `scl` and any processes that are run from that command. The steps in this tutorial run the command `bash` to start a new interactive shell to work in the updated environment. The changes aren’t permanent. Typing `exit` will return to the original shell with the original environment. Each time you login, or start a new terminal sesssion, `scl enable` needs to be run again.
+The software packages in RHSCL are designed to allow multiple versions of software to be installed concurrently. To accomplish this, the desired package is added to your runtime environment as needed with the `scl enable` command. When `scl enable` runs, it modifies environment variables and then runs the specified command. The environmental changes only affect the command that is run by `scl` and any processes that are run from that command. The steps in this tutorial run the command `bash` to start a new interactive shell to work in the updated environment. The changes aren’t permanent. Typing `exit` will return to the original shell with the original environment. Each time you login, or start a new terminal session, `scl enable` needs to be run again.
 
 While it is possible to change the system profile to make RHSCL packages part of the system’s global environment, this is not recommended. Doing this can cause conflicts and unexpected problems with other applications because the system version of the package is obscured by having the RHSCL version in the path first.
 
@@ -157,9 +132,13 @@ While it is possible to change the system profile to make RHSCL packages part of
 
 To make one or more RHSCL packages a permanent part of your development environment, you can add it to the login script for your specific user ID. this is the recommend approach for development as only processes run under your user ID will be affected.
 
-Using your preferred text editor, add the following line to `~/.bashrc`:
+Using your preferred text editor, add the following line to your `~/.bashrc`:
 
-`source scl_source enable nodejs010`
+.~/.bashrc
+----
+# Add {tthw-langlong} from RHSCL to my login environment
+source scl_source enable {tthw-sclname}
+----
 
 After making the change, you should log out and log back in again.
 
@@ -169,7 +148,7 @@ When you deliver an application that uses RHSCL packages, a best practice is to 
 
 *Learn Node.js and JavaScript using NodeSchool.io tutorials* +
 
-Now that you have Node.js installed, use the tutorials from link:http://nodeschool.io/#workshopper-list[nodeschool.io] to learn Node.js and JavaScript. You need to have already run `scl enable nodejs010 bash` or have added Node.js permanently to your development environment.
+Now that you have Node.js installed, use the tutorials from link:http://nodeschool.io/#workshopper-list[nodeschool.io] to learn Node.js and JavaScript. You need to have already run `scl enable rh-nodejs4 bash` or have added Node.js permanently to your development environment.
 
 Install the JavaScript and Node.js tutorials into your current directory:
 [.code-block]
@@ -195,18 +174,19 @@ Run the Node.js tutorial:
 link:http://nodejs.org/documentation/[]
 
 *Find additional RHSCL Node.js modules* +
-`$ yum list available nodejs\*`
+`$ yum list available {tthw-sclname}\*`
 
-*View the list of software available in RHSCL* +
+*View the full list of packages available in RHSCL* +
 `$ yum --disablerepo="*" --enablerepo="rhel-server-rhscl-7-rpms" list available`
 
 ## More Resources
 
 * link:https://access.redhat.com/solutions/472793[How to use Red Hat Software Collections (RHSCL) or Red Hat Developer Toolset (DTS)]
-* link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection 2.0 Documentation]
-** link:https://access.redhat.com/site/documentation/en-US/Red_Hat_Software_Collections/2/html/2.0_Release_Notes/index.html[Red Hat Software Collections 2.0 Release Notes]
-** link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/html/Packaging_Guide/index.html[Red Hat Software Collections 2.0 Packaging Guide] +
-_Developers should read this guide to get a more complete understanding of how software collections work, and how to deliver software that uses RHSCL._
+* link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection 2.x Documentation]
+** link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Release Notes]
+** link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2-Beta/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Beta Packaging Guide] +
+_Developers should read the packaging guide to get a more complete understanding of how software collections work, and how to deliver software that uses RHSCL._
+
 
 ### Become a Red Hat developer: developers.redhat.com
 
@@ -217,9 +197,9 @@ Red Hat delivers the resources and ecosystem of experts to help you be more prod
 
 ## Faq section
 
-1. The RHSCL repository is not available or is not found on my system.
+. *The RHSCL repository is not available or is not found on my system.*
 +
-The name of the repository depends on whether you have a server or desktop version of Red Hat Enterprise Linux installed.
+The name of the repository depends on whether you have a server or workstation version of Red Hat Enterprise Linux installed.
 +
 Some Red Hat Enterprise Linux subscriptions do not include access to RHSCL. See link:https://access.redhat.com/solutions/472793[How to use Red Hat Software Collections (RHSCL) or Red Hat Developer Toolset (DTS)].
 +
@@ -231,37 +211,43 @@ $ su -
 # subscription-manager repos --list | egrep rhscl
 ```
 
-2. yum install fails due to a missing dependency.
+. *As a developer, how can I get a Red Hat Enterprise Linux subscription that includes Red Hat Software Collections?*
++
+Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through link:#{site.base_url}/[developers.redhat.com]. We recommend you follow our link:#{site.base_url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt. For more information, see link:#{site.base_url}/articles/no-cost-rhel-faq/[Frequently asked questions: no-cost Red Hat Enterprise Linux Developer Suite].
+
+. *When I run `yum install`, it fails due to a missing dependency*.
 +
 These packages are in the optional RPMs repository, which is not enabled by default. See <<Enable Red Hat Software Collections>> for how to enable both the optional RPMs and RHSCL repositories.
-3. How can I find out what RHSCL packages are installed?
+
+. *How can I find out what RHSCL packages are installed?*
 +
 `scl --list` will show the list of RHSCL packages that have been installed, whether they are enabled or not.
 +
 [.code-block]
 ```
 $ scl --list
-nodejs010
-v8314
+{tthw-sclname}
 ```
-4. How do I find out if there is a newer version of Node.js in the RHSCL?
+
+. *How do I find out if there is a newer version of Node.js in RHSCL?*
 +
-How do I find out what version of Node.js is available in the current RHSCL?
+*How do I find out what version of Node.js is available in the current RHSCL?*
 +
-I have the RHSCL repository enabled, but I can’t find the Node.js version listed in this tutorial.
+*I have the RHSCL repository enabled, but I can’t find the Node.js version listed in this tutorial.*
 +
 Use the following command to find packages with matching names:
 +
 `# yum list available nodejs\*`
-5. I’ve installed Node.js from RHSCL, but `node` is not in my path.
+. *I’ve installed Node.js from RHSCL, but `node` is not in my path.*
 +
-I can’t find the `node` command.
+*I can’t find the `node` command.*
 +
-RHSCL does not alter the system path.  You need to use `scl enable` to change the environment for your session:
+RHSCL does not alter the system path. You need to use `scl enable` to change the environment for your session:
 +
-`$ scl enable nodejs010 bash`
+`$ scl enable rh-nodejs4 bash`
 +
-For more information see the link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection 2.0 Documentation].
-6. When I try to run `node`, I get an error about a missing shared library.
+For more information see the link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection documentation].
+
+. *When I try to run `node`, I get an error about a missing shared library.*
 +
 This is due to not having run `scl enable` first. When `scl enable` runs, in addition to setting up the command search PATH, it also sets up the search path for shared libraries, LD_LIBRARY_PATH.

--- a/products/softwarecollections/get-started-rhel7-python.adoc
+++ b/products/softwarecollections/get-started-rhel7-python.adoc
@@ -1,7 +1,11 @@
 :awestruct-layout: product-get-started-multipath
 :awestruct-interpolate: true
-:title: "Software Collections - Get started developing with Python 3.4 on RHEL 7"
-:awestruct-description: "Get started developing with Python 3.4 from Red Hat Software Collections on Red Hat Enterprise Linux 7 in under 10 minutes."
+:tthw-rhelver: 7
+:tthw-langshort: Python
+:tthw-langlong: Python 3.5
+:tthw-sclname: rh-python35
+:title: "Software Collections - Get started developing with {tthw-langlong} on RHEL {tthw-rhelver}"
+:awestruct-description: "Get started developing with {tthw-langlong} from Red Hat Software Collections on Red Hat Enterprise Linux {tthw-rhelver} in under 10 minutes."
 
 ## Path Name
 Python
@@ -11,17 +15,7 @@ Python
 image:#{cdn(site.base_url + '/images/products/multipath/python-logo.png')}[Python Logo]
 
 [.large-18.columns#PathIntroSection]
-Get started developing with Python 3.4 from Red Hat Software Collections in under 10 minutes.
-
-## Prerequisites section title
-Introduction and Prerequisites
-
-## Prerequisites section
-In this tutorial, you will set your system up to install software from Red Hat Software Collections (RHSCL), which provides the latest development technologies for Red Hat Enterprise Linux. Then, you will install Python 3.4 and run a simple “Hello, World” application. The whole tutorial should take less than 10 minutes to complete.
-
-Before you begin, you will need a current Red Hat Enterprise Linux 7 workstation or server subscription that allows you to download software and get updates from Red Hat. If you don’t have an active subscription, register and obtain the RHEL Developer Suite (includes RHEL server) from here.
-
-If you encounter difficulties at any point, see <<troubleshooting,Troubleshooting and FAQ>>.
+Get started developing with {tthow-langlong} from Red Hat Software Collections in under 10 minutes.
 
 ## Step1 Duration
 2 minutes
@@ -40,6 +34,17 @@ Setup your development environment
 
 ## Step3 Title
 Hello World and your first application
+
+## Prerequisites section title
+Introduction and Prerequisites
+
+## Prerequisites section
+In this tutorial, you will set your system up to install software from Red Hat Software Collections (RHSCL), which provides the latest development technologies for Red Hat Enterprise Linux. Then, you will install {tthw-langlong} and run a simple “Hello, World” application. The whole tutorial should take less than 10 minutes to complete.
+
+Before you begin, you will need a current Red Hat Enterprise Linux {tthw-rhelver} server or workstation subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through link:#{site.base_url}/[developers.redhat.com]. 
+
+If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
+
 
 ## Step1 Content
 
@@ -79,51 +84,56 @@ If you are using a desktop edition of Red Hat Enterprise Linux, change `-server-
 
 ## Step2 Content
 
-In this next step you will install Python 3.4 from RHSCL:
+In this next step you will install {tthw-langlong} from RHSCL:
 
 `$ su -` +
-`# yum install rh-python34`
+`# yum install {tthw-sclname}`
 
 If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
 
 ## Step3 Content
 
-Under your normal user ID, start a _Terminal_ window. First, use `scl enable` to add Python 3 to your environment, then run Python 3 in interactive mode to see the version number:
+Under your normal user ID, start a _Terminal_ window. First, use `scl enable` to add {tthw-langlong} to your environment, then run {tthw-langshort} in interactive mode to see the version number:
 
 [.code-block]
 ```
-$ scl enable rh-python34 bash
+$ scl enable {tthw-sclname} bash
 $ python3
-Python 3.4.2 (default, Mar 25 2015, 04:25:42)
+Python 3.5.1 (default, Apr 27 2016, 04:21:56)
 >>> print("Hello, Red Hat Developers World")
 Hello, Red Hat Developers World
 >>> quit()
 ```
 
-The next step is to create a Python program that can be run from the command line. Using your preferred text editor, create a file named `hello.py`:
+The next step is to create a {tthw-langshort} program that can be run from the command line. Using your preferred text editor, create a file named `hello.py`:
 
 `$ nano hello.py`
 
 Add the following text to the file:
-[.code-block]
-```
+
+// doesn't seem to work correctly in rhdev env.
+// [source,python]
+
+.hello.py
+----
 #!/usr/bin/env python3
 
 import sys
 
 version = "Python %d.%d" % (sys.version_info.major, sys.version_info.minor)
 print("Hello, Red Hat Developers World from",version)
-```
+----
 
 Save it and exit the editor. Then make the script executable and run it:
+
 [.code-block]
 ```
 $ chmod +x hello.py
 $ ./hello.py
-Hello, Red Hat Developers World from Python 3.4
+Hello, Red Hat Developers World from {tthw-langlong}
 ```
 
-If you get the error: _python3 command not found_, you need to run `scl enable rh-python34 bash` first.
+If you get the error: _python3 command not found_, you need to run `scl enable {tthw-sclname} bash` first.
 
 
 ### Working with RHSCL packages
@@ -138,7 +148,7 @@ To make one or more RHSCL packages a permanent part of your development environm
 
 Using your preferred text editor, add the following line to the end of `~/.bashrc`:
 
-`source scl_source enable rh-python34`
+`source scl_source enable {tthw-sclname}`
 
 After making the change, you should log out and log back in again.
 
@@ -151,7 +161,7 @@ When you deliver an application that uses RHSCL packages, a best practice is to 
 link:https://docs.python.org/3/tutorial/[]
 
 *Find additional Python components* +
-`$ yum list available rh-python34-\*`
+`$ yum list available {tthw-sclname}-\*`
 
 *View the list of software available in RHSCL* +
 `$ yum --disablerepo="*" --enablerepo="rhel-server-rhscl-7-rpms" list available`
@@ -188,11 +198,9 @@ These packages are in the optional RPMs repository, which is not enabled by defa
 [.code-block]
 ```
 $ scl --list
-rh-perl520
-rh-php56
-rh-python34
-rh-ruby22
+{tthw-sclname}
 ```
+
 4. How do I find out if there is a newer version of Python in the RHSCL?
 +
 How do I find out what version of Python is available in the RHSCL?


### PR DESCRIPTION
* The goals are RHSCL 2.2 updates and making the 30+ get started guides easier to maintain.
* Working: using AsciiDoc to parameterize the text where possible.
* Not Working: Trying to include redundant text from a file. The includes are being rendered as links instead of showing the text.  I can make this work on a plain .adoc processed through awestruct, with no explicit layout or slim file.
* See products/softwarecollections/get-started-rhel7-node.js/  to see how it is failing.   I suspect the layout might be tripping this up.  Hoping @LightGuard, @adelasofia, or someone else could shed some light on this.