### PR TITLE
[DEVELOPER-3175] Fix Drupal Backups

### DIFF
--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -67,9 +67,9 @@ services:
   backup:
    build:
     context: ../../awestruct
-     args:
-      http_proxy: proxy01.util.phx2.redhat.com:8080
-      https_proxy: proxy01.util.phx2.redhat.com:8080
+    args:
+     http_proxy: proxy01.util.phx2.redhat.com:8080
+     https_proxy: proxy01.util.phx2.redhat.com:8080
    entrypoint: ruby _docker/lib/backup/backup.rb
    environment:
     - http_proxy=proxy01.util.phx2.redhat.com:8080
@@ -85,9 +85,9 @@ services:
    user: root
    build:
    context: ../../awestruct
-    args:
-     http_proxy: proxy01.util.phx2.redhat.com:8080
-     https_proxy: proxy01.util.phx2.redhat.com:8080
+   args:
+    http_proxy: proxy01.util.phx2.redhat.com:8080
+    https_proxy: proxy01.util.phx2.redhat.com:8080
    entrypoint: "ruby _docker/lib/export/export.rb developer-drupal.web.prod.ext.phx2.redhat.com"
    volumes:
     - /data/drupal-export:/export

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -84,10 +84,10 @@ services:
   export:
    user: root
    build:
-   context: ../../awestruct
-   args:
-    http_proxy: proxy01.util.phx2.redhat.com:8080
-    https_proxy: proxy01.util.phx2.redhat.com:8080
+    context: ../../awestruct
+    args:
+     http_proxy: proxy01.util.phx2.redhat.com:8080
+     https_proxy: proxy01.util.phx2.redhat.com:8080
    entrypoint: "ruby _docker/lib/export/export.rb developer-drupal.web.prod.ext.phx2.redhat.com"
    volumes:
     - /data/drupal-export:/export


### PR DESCRIPTION
YAML formatting to ensure that Docker Compose can parse the docker-compose.yml for drupal-production environment. 