### PR TITLE
[DEVELOPER-1960] Support for Drupal Pull Requests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -408,7 +408,8 @@ task :blinkr, [:host_to_test, :report_path, :report_host, :verbose] do |task, ar
   sha = ENV['ghprbActualCommit']
   should_update_status = sha.to_s != ""
   puts "should_update_status:#{should_update_status}"
-  options = {:context => 'Blinkr', :description => 'Blinkr pending', :target_url => ENV["BUILD_URL"]}
+  context = host_to_test.include?('drupal') ? 'Drupal:Blinkr' : 'Blinkr'
+  options = {:context => context, :description => 'Blinkr pending', :target_url => ENV["BUILD_URL"]}
 
   begin
     if should_update_status

--- a/_docker/environments/awestruct-dev/docker-compose.yml
+++ b/_docker/environments/awestruct-dev/docker-compose.yml
@@ -84,6 +84,15 @@ services:
     links:
      - mysql
 
+  #
+  # Testing
+  #
+  unit_tests:
+     build: ../../awestruct
+     volumes:
+           - ../../../:/home/awestruct/developer.redhat.com
+     entrypoint: "bundle exec rake test"
+
   acceptance_tests:
     build: ../../awestruct
     volumes:

--- a/_docker/environments/awestruct-pull-request/docker-compose.yml
+++ b/_docker/environments/awestruct-pull-request/docker-compose.yml
@@ -55,6 +55,35 @@ services:
     links:
      - mysql
 
+  #
+  # Testing
+  #
+  unit_tests:
+   build: ../../awestruct
+   volumes:
+    - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "bundle exec rake test"
+   environment:
+    - google_api_key
+    - dcp_user
+    - dcp_password
+    - vimeo_client_secret
+    - vimeo_access_token_secret
+    - vimeo_access_token
+    - cache_password
+    - cache_url
+    - site_base_path
+    - site_path_suffix
+    - cdn_prefix
+    - cache_user
+    - github_token
+    - ACCESSIBLE_SLAVE_IP
+    - SEARCHISKO_HOST_PORT
+    - ghprbActualCommit
+    - github_status_api_token
+    - BUILD_URL
+    - AWE_PROC_COUNT=10
+
   acceptance_tests:
     build: ../../awestruct
     volumes:

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -102,18 +102,22 @@ services:
   #
   # Testing
   #
+  unit_tests:
+   build: ../../awestruct
+   volumes:
+    - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "bundle exec rake test"
+
   acceptance_tests:
     build: ../../awestruct
     volumes:
       - ../../../:/home/awestruct/developer.redhat.com
-#    links:
-#      - selhub:hub
     environment:
       - ghprbActualCommit
       - github_status_api_token
       - PARALLEL_TEST
       - CUCUMBER_TAGS
-      - SELENIUM_HOST=http://hub:4444/wd/hub
+      - SELENIUM_HOST=http://selhub:4444/wd/hub
       - RHD_JS_DRIVER
       - RHD_DOCKER_DRIVER
       - BUILD_URL

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -31,13 +31,7 @@ services:
       - github_token
       - drupal_user
       - drupal_password
-      - ACCESSIBLE_SLAVE_IP
-      - SEARCHISKO_HOST_PORT
-      - DRUPAL_HOST_PORT
-      - DRUPAL_HOST_IP
-      - ghprbActualCommit
-      - github_status_api_token
-      - BUILD_URL
+
 
   drupal:
     build:
@@ -56,10 +50,6 @@ services:
     environment:
       - http_proxy=proxy01.util.phx2.redhat.com:8080
       - https_proxy=proxy01.util.phx2.redhat.com:8080
-      - DB_NAME=drupal
-      # TODO: Drop these once we have rhd.settings.php working correctly
-      - DB_USER=drupal
-      - DB_PASSWORD=drupal
 
   #
   # Environment actions

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -57,9 +57,9 @@ services:
   backup:
    build:
     context: ../../awestruct
-     args:
-      http_proxy: proxy01.util.phx2.redhat.com:8080
-      https_proxy: proxy01.util.phx2.redhat.com:8080
+    args:
+     http_proxy: proxy01.util.phx2.redhat.com:8080
+     https_proxy: proxy01.util.phx2.redhat.com:8080
    entrypoint: ruby _docker/lib/backup/backup.rb
    environment:
     - http_proxy=proxy01.util.phx2.redhat.com:8080
@@ -74,7 +74,7 @@ services:
   export:
    user: root
    build:
-   context: ../../awestruct
+    context: ../../awestruct
     args:
      http_proxy: proxy01.util.phx2.redhat.com:8080
      https_proxy: proxy01.util.phx2.redhat.com:8080
@@ -82,3 +82,16 @@ services:
    volumes:
     - /data/drupal-export:/export
     - /credentials/rsync:/home/awestruct/.ssh
+
+   #
+   # Testing
+   #
+   unit_tests:
+    build:
+     context: ../../awestruct
+     args:
+      http_proxy: proxy01.util.phx2.redhat.com:8080
+      https_proxy: proxy01.util.phx2.redhat.com:8080
+    volumes:
+     - ../../../:/home/awestruct/developer.redhat.com
+    entrypoint: "bundle exec rake test"

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -48,11 +48,6 @@ services:
       - ../../drupal/themes/:/var/www/html/themes
       - ../../drupal/modules/custom/:/var/www/html/modules/custom
       - ./rhd.settings.php:/var/www/html/sites/default/rhd.settings.php
-    environment:
-      - DB_NAME=drupal
-      # TODO: Drop these once we have rhd.settings.php working correctly
-      - DB_USER=drupal
-      - DB_PASSWORD=drupal
 
   drupalmysql:
     image: mariadb:10.0.15
@@ -94,11 +89,18 @@ services:
  export:
      user: root
      build: ../../awestruct
+     command: "ruby _docker/lib/export/export.rb stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}"
      volumes:
       - ../../../:/home/awestruct/developer.redhat.com
       - ../../awestruct/overlay/ssh-key:/home/awestruct/.ssh
       - export:/export
-     entrypoint: "ruby _docker/lib/export/export.rb stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}"
+     entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
+     environment:
+      - github_status_api_token
+      - github_status_context="Drupal:Site Preview"
+      - github_status_repo=redhat-developer/developers.redhat.com
+      - github_status_target_url="${site_base_path}:${site_path_suffix}"
+      - github_status_sha1=${ghprbActualCommit}
 
 #
 # Testing
@@ -107,17 +109,18 @@ services:
     build: ../../awestruct
     volumes:
       - ../../../:/home/awestruct/developer.redhat.com
-    links:
-      - selhub:hub
+    entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
     environment:
-      - ghprbActualCommit
       - github_status_api_token
+      - github_status_context="Drupal:Acceptance Tests"
+      - github_status_repo=redhat-developer/developers.redhat.com
+      - github_status_target_url=${BUILD_URL}
+      - github_status_sha1=${ghprbActualCommit}
       - PARALLEL_TEST
       - CUCUMBER_TAGS
-      - SELENIUM_HOST=http://hub:4444/wd/hub
+      - SELENIUM_HOST=http://selhub:4444/wd/hub
       - RHD_JS_DRIVER
       - RHD_DOCKER_DRIVER
-      - BUILD_URL
 
 #
 # Volumes

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -83,44 +83,57 @@ services:
       - DB_PASSWORD=searchisko
     links:
      - mysql
-#
-# Environment actions
-#
- export:
+
+  #
+  # Environment actions
+  #
+  export:
      user: root
      build: ../../awestruct
-     command: "ruby _docker/lib/export/export.rb stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}"
      volumes:
       - ../../../:/home/awestruct/developer.redhat.com
       - ../../awestruct/overlay/ssh-key:/home/awestruct/.ssh
       - export:/export
-     entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
+     entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'ruby _docker/lib/export/export.rb stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}'"
      environment:
       - github_status_api_token
-      - github_status_context="Drupal:Site Preview"
+      - github_status_context=Drupal:Site Preview
       - github_status_repo=redhat-developer/developers.redhat.com
-      - github_status_target_url="${site_base_path}:${site_path_suffix}"
+      - github_status_target_url=${site_base_path}:${site_path_suffix}
       - github_status_sha1=${ghprbActualCommit}
 
-#
-# Testing
-#
+  #
+  # Testing
+  #
+  unit_tests:
+   build: ../../awestruct
+   volumes:
+    - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'bundle exec rake test'"
+   environment:
+    - github_status_api_token
+    - github_status_context=Drupal:Unit Tests
+    - github_status_repo=redhat-developer/developers.redhat.com
+    - github_status_target_url=${BUILD_URL}
+    - github_status_sha1=${ghprbActualCommit}
+    - github_status_initialise=Drupal:Unit Tests,Drupal:Acceptance Tests,Drupal:Site Preview,Drupal:Blinkr
+
   acceptance_tests:
-    build: ../../awestruct
-    volumes:
-      - ../../../:/home/awestruct/developer.redhat.com
-    entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
-    environment:
-      - github_status_api_token
-      - github_status_context="Drupal:Acceptance Tests"
-      - github_status_repo=redhat-developer/developers.redhat.com
-      - github_status_target_url=${BUILD_URL}
-      - github_status_sha1=${ghprbActualCommit}
-      - PARALLEL_TEST
-      - CUCUMBER_TAGS
-      - SELENIUM_HOST=http://selhub:4444/wd/hub
-      - RHD_JS_DRIVER
-      - RHD_DOCKER_DRIVER
+   build: ../../awestruct
+   volumes:
+     - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
+   environment:
+     - github_status_api_token
+     - github_status_context=Drupal:Acceptance Tests
+     - github_status_repo=redhat-developer/developers.redhat.com
+     - github_status_target_url=${BUILD_URL}
+     - github_status_sha1=${ghprbActualCommit}
+     - PARALLEL_TEST
+     - CUCUMBER_TAGS
+     - SELENIUM_HOST=http://selhub:4444/wd/hub
+     - RHD_JS_DRIVER
+     - RHD_DOCKER_DRIVER
 
 #
 # Volumes

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -64,3 +64,16 @@ services:
   volumes:
    - /data/drupal-export:/export
    - /credentials/rsync:/home/awestruct/.ssh
+
+   #
+   # Testing
+   #
+   unit_tests:
+    build:
+     context: ../../awestruct
+     args:
+      http_proxy: proxy01.util.phx2.redhat.com:8080
+      https_proxy: proxy01.util.phx2.redhat.com:8080
+    volumes:
+     - ../../../:/home/awestruct/developer.redhat.com
+    entrypoint: "bundle exec rake test"

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -31,13 +31,6 @@ services:
       - github_token
       - drupal_user
       - drupal_password
-      - ACCESSIBLE_SLAVE_IP
-      - SEARCHISKO_HOST_PORT
-      - DRUPAL_HOST_PORT
-      - DRUPAL_HOST_IP
-      - ghprbActualCommit
-      - github_status_api_token
-      - BUILD_URL
 
   drupal:
     build:
@@ -56,10 +49,7 @@ services:
     environment:
       - http_proxy=proxy01.util.phx2.redhat.com:8080
       - https_proxy=proxy01.util.phx2.redhat.com:8080
-      - DB_NAME=drupal
-      # TODO: Drop these once we have rhd.settings.php working correctly
-      - DB_USER=drupal
-      - DB_PASSWORD=drupal
+
  #
  # Environment actions
  #

--- a/_docker/lib/default_logger.rb
+++ b/_docker/lib/default_logger.rb
@@ -14,7 +14,7 @@ class DefaultLogger
     log = Logger.new(STDOUT)
     log.formatter = proc do |severity, datetime, _, msg|
       date_format = datetime.strftime('%Y-%m-%d %H:%M:%S')
-      "[#{date_format}] #{severity} - #{msg}\n"
+      "[#{date_format}] #{severity} - #{msg.gsub("\n",'')}\n"
     end
     log
   end

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -145,7 +145,7 @@ class Options
   end
 
   def self.unit_test_tasks
-    ['--no-deps', '--rm', 'awestruct', 'bundle exec rake test']
+    %w(--no-deps --rm unit_tests)
   end
 
 end

--- a/_docker/lib/process_runner.rb
+++ b/_docker/lib/process_runner.rb
@@ -50,12 +50,12 @@ class ProcessRunner
         threads = []
         threads << Thread.new(stdout) do |i|
           while ( ! i.eof? )
-            @log.info("(Console): #{i.readline}")
+            @log.info(i.readline)
           end
         end
         threads << Thread.new(stderr) do |i|
           while ( ! i.eof? )
-            @log.error("(Console): #{i.readline}")
+            @log.error(i.readline)
           end
         end
         threads.each{|t|t.join}

--- a/_docker/lib/pull_request/README.md
+++ b/_docker/lib/pull_request/README.md
@@ -1,0 +1,70 @@
+## Github Status API Execution Wrapper
+
+### Pre-requisites 
+
+An introduction to the [Github status API](https://developer.github.com/v3/repos/statuses/)
+
+### About
+
+This directory contains the implementation of the Github Status API wrapper. The purpose of this class is to faciliate running Docker containers within a pull request environment
+when you want to report the result of the container execution as a Github status. For example, you want to run some unit tests within a Docker container and report the outcome of these
+as a Github status with context 'Unit Tests'. Whilst the tests are running you want the status to be 'pending'. If the tests succeed, the status should be updated to 'success'. If they
+fail, the status should be updated to 'failure'.
+
+### Basic operation
+
+The execution wrapper will take the command that you want to run in the container and firstly create a 'pending' Github Status check for the command. It will then execute the command
+and if the command succeeds i.e. exits with a 0 status code, it will update the status to 'success'. If the command exits with a non-zero exit code, it will update the status to 'failure'
+
+### Configuring the wrapper to execute
+
+The wrapper should be configured as the `entrypoint` on your Docker container. The command you want to run can either be appended after the wrapper definition, or defined as the `command`
+to your Docker statement. For example:
+
+```
+service:
+ testing:
+  entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'bundle exec rake test'"
+```
+
+or
+
+```
+service:
+ testing:
+  command: "bundle exec rake test"
+  entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb"
+```
+
+### Configuring the Github status reported by the wrapper
+
+The configure the status reported by the wrapper, you set environment variables on your Docker container definition. The following variables are supported:
+
+|Environment Variable|Description|
+|--------------------|-----------|
+|github_status_api_token|The API token to be used to interact with the Github API|
+|github_status_context|The context that should be reported for this container|
+|github_status_repo|The repository against which the pull request is being raised in the form &lt;username&gt;/&lt;repo&gt; e.g. robpblake/developers.redhat.com|
+|github_status_target_url|The target URL to be reported by Github as link on the pull request checks tab|
+|github_status_sha1|The SHA1 of the Pull request to update with the status|
+|github_status_initialise|A comma separated list of contexts to initialise when this container runs. Typically this will be set on the first container in your build pipeline|
+
+
+As an example of a container that sets the status for the `Unit Tests` context and initialises the `Acceptance Tests` context:
+
+```
+unit_tests:
+   build: ../../awestruct
+   volumes:
+    - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'bundle exec rake test'"
+   environment:
+    - github_status_api_token
+    - github_status_context=Unit Tests
+    - github_status_repo=redhat-developer/developers.redhat.com
+    - github_status_target_url=${BUILD_URL}
+    - github_status_sha1=${ghprbActualCommit}
+    - github_status_initialise=Unit Tests,Acceptance Tests
+```
+From the above you can see that it is possible to reference environment variables set by your CI server as well to ensure that any information related to the pull request is
+correctly reported.

--- a/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb
+++ b/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb
@@ -1,0 +1,139 @@
+#
+# This class wraps a command line process and reports its progress and outcome to GitHub using
+# the status API.
+#
+# This class is designed to be used in pull request environments that run Docker containers. This class
+# should be set as the entrypoint for your container and the command you wish to run passed in via the
+# Docker command argument.
+#
+# The GitHub status API updates are controlled via environment variables set on your container definition. The supported
+# env args are:
+# - github_status_api_token -> The API token that should be used to communicate with the Github status API
+# - github_status_repo -> The GitHub repo to use in the format <user>/<repo>
+# - github_status_target_url -> The URL to set as the target_url in the status update
+# - github_status_context -> The context to use for the status update
+# - github_status_sha1 -> The SHA1 of the commit that the status update should be applied to
+# - github_status_initialise -> A comma separated list of contexts that should be set to pending by this container
+#
+# This class will set the initial state of the context to 'pending' before executing the command. If the command succeeds, then
+# it will be updated to 'success'. If it fails, then it will be updated to 'failure'
+#
+# If the 'github_status_initialise' property is set on the container definition in which this class is running, then it will set
+# all of the contexts within the variable to the 'pending' state.
+#
+# @author rblake@redhat.com
+#
+
+require 'octokit'
+require_relative '../default_logger'
+
+class ExecWithGitHubStatusWrapper
+
+  def initialize(git_repository, git_sha1, context, target_url, process_runner)
+    @git_repository = git_repository
+    @git_sha1 = git_sha1
+    @context = context
+    @target_url = target_url
+    @log = DefaultLogger.logger
+    @process_runner = process_runner
+  end
+
+  #
+  # Initialises all contexts to the pending status and default description
+  #
+  def initialise_contexts(contexts=[])
+    @log.info("Initialising '#{contexts.length}' contexts for pull request '#{@git_sha1}'")
+    contexts.each do | context |
+        update_status(context, 'pending')
+    end
+    @log.info("Successfully initialised '#{contexts.length}' contexts for pull request '#{@git_sha1}'")
+  end
+
+  #
+  # Creates the status update options for the given context and status
+  #
+  def create_options(context, status)
+
+    description = "#{context} is pending..."
+
+    case status
+      when 'success'
+        description = "#{context} completed successfully."
+      when 'failed'
+        description = "#{context} failed."
+    end
+
+    {:context => context, :description => description, :target_url => @target_url}
+  end
+
+  #
+  # Updates the status of the given context
+  #
+  def update_status(context, status)
+    options = create_options(context, status)
+    Octokit.create_status(@git_repository, @git_sha1, status, options)
+  end
+
+  #
+  # Executes the given command and updates the GitHub Status API with the result
+  #
+  def execute_command_and_update_status!(command)
+    begin
+      @process_runner.execute!(command)
+      update_status(@context, 'success')
+    rescue => e
+      update_status(@context, 'failed')
+      raise e
+    end
+  end
+
+end
+
+#
+# Gets a value from the environment. Can be configured to optionally raise an exception if this
+# value is not set
+#
+def get_env_value(key, fail_if_not_present)
+  value = ENV[key]
+  if (value.nil? || value.empty?) && fail_if_not_present
+    raise StandardError.new("Required environment variable '#{key}' is not set. Aborting execution.")
+  end
+  value
+end
+
+#
+# Optionally initialises all GitHub statuses if the environment variable has been set
+#
+def initialise_github_statuses(execution_wrapper, contexts_to_initialise)
+  unless contexts_to_initialise.nil? || contexts_to_initialise.empty?
+    execution_wrapper.initialise_contexts(contexts_to_initialise.split(','))
+  end
+end
+
+#
+# Executes the command and wraps progress in the Github status API.
+#
+def execute_command(execution_wrapper, command=[])
+  command_to_execute = command.join(' ')
+  execution_wrapper.execute_command_and_update_status!(command_to_execute)
+end
+
+
+if $0 == __FILE__
+
+  github_status_api_token = get_env_value('github_status_api_token', true)
+  github_status_repo = get_env_value('github_status_repo', true)
+  github_status_target_url = get_env_value('github_status_target_url', true)
+  github_status_context = get_env_value('github_status_context', true)
+  github_status_sha1 = get_env_value('github_status_sha1', true)
+  github_status_initialise = get_env_value('github_status_initialise', false)
+
+  Octokit.configure do |c|
+    c.access_token = github_status_api_token
+    c.connection_options[:ssl] = { :verify => false }
+  end
+
+  execution_wrapper = ExecWithGitHubStatusWrapper.new(github_status_repo, github_status_sha1, github_status_context, github_status_target_url, ProcessRunner.new(true))
+  initialise_github_statuses(execution_wrapper, github_status_initialise)
+  execute_command(execution_wrapper, ARGV)
+end

--- a/_docker/tests/pull_request/test_exec_with_git_hub_status_wrapper.rb
+++ b/_docker/tests/pull_request/test_exec_with_git_hub_status_wrapper.rb
@@ -1,0 +1,128 @@
+require 'octokit'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../../lib/default_logger'
+require_relative '../../lib/pull_request/exec_with_git_hub_status_wrapper'
+require_relative '../test_helper'
+
+class TestExecWithGitHubStatusWrapper < MiniTest::Test
+
+  def setup
+      ENV['foo'] = 'bar'
+      @git_repo = 'redhat-developer/developers.redhat.com'
+      @git_sha1 = 'foo'
+      @context = 'Unit Tests'
+      @target_url = 'http://foo.com'
+      @process_runner = mock()
+      @execution_wrapper = ExecWithGitHubStatusWrapper.new(@git_repo, @git_sha1, @context, @target_url, @process_runner)
+  end
+
+  def teardown
+     ENV['foo'] = nil
+  end
+
+  def test_get_env_variable_if_set
+    assert_equal('bar', get_env_value('foo', false))
+  end
+
+  def test_get_env_variable_if_not_set_dont_raise
+    assert_equal(nil, get_env_value('blob', false))
+  end
+
+  def test_get_env_variable_if_not_set_and_raise
+    assert_raises(StandardError) {
+      get_env_value('blob', true)
+    }
+  end
+
+  def test_initialise_github_statuses
+
+    statuses = 'Blinkr,Acceptance Tests,Unit Tests'
+
+    execution_wrapper = mock()
+    execution_wrapper.expects(:initialise_contexts).with(['Blinkr','Acceptance Tests','Unit Tests'])
+
+    initialise_github_statuses(execution_wrapper, statuses)
+
+  end
+
+  def test_initialise_github_statuses_empty_variable
+
+    execution_wrapper = mock()
+    execution_wrapper.expects(:initialise_contexts).never
+
+    initialise_github_statuses(execution_wrapper, '')
+  end
+
+  def test_initialise_github_statuses_nil_variable
+
+    execution_wrapper = mock()
+    execution_wrapper.expects(:initialise_contexts).never
+
+    initialise_github_statuses(execution_wrapper, nil)
+  end
+
+
+  def test_execute_command
+    command = %w(rake git_setup clean gen[drupal_pull_request])
+    execution_wrapper = mock()
+    execution_wrapper.expects(:execute_command_and_update_status!).with('rake git_setup clean gen[drupal_pull_request]')
+
+    execute_command(execution_wrapper, command)
+  end
+
+  def test_initialise_contexts
+
+    contexts = ['Unit Tests']
+
+    Octokit.expects(:create_status).with do | github_repo, git_sha1, status, options |
+      assert_equal(@git_repo, github_repo)
+      assert_equal(@git_sha1, git_sha1)
+      assert_equal('pending', status)
+      assert_equal(@target_url, options[:target_url])
+      assert_equal('Unit Tests', options[:context])
+      assert_equal('Unit Tests is pending...', options[:description])
+    end
+
+    @execution_wrapper.initialise_contexts(contexts)
+
+  end
+
+  def test_execute_command_that_succeeds
+
+    command = 'rake git_setup clean gen[drupal_pull_request]'
+    @process_runner.expects(:execute!).with(command)
+
+    Octokit.expects(:create_status).with do | github_repo, git_sha1, status, options |
+      assert_equal(@git_repo, github_repo)
+      assert_equal(@git_sha1, git_sha1)
+      assert_equal('success', status)
+      assert_equal(@target_url, options[:target_url])
+      assert_equal('Unit Tests', options[:context])
+      assert_equal('Unit Tests completed successfully.', options[:description])
+    end
+
+    @execution_wrapper.execute_command_and_update_status!(command)
+
+  end
+
+  def test_execute_command_that_fails
+    command = 'rake git_setup clean gen[drupal_pull_request]'
+    @process_runner.expects(:execute!).with(command).raises(StandardError.new)
+
+    Octokit.expects(:create_status).with do | github_repo, git_sha1, status, options |
+      assert_equal(@git_repo, github_repo)
+      assert_equal(@git_sha1, git_sha1)
+      assert_equal('failed', status)
+      assert_equal(@target_url, options[:target_url])
+      assert_equal('Unit Tests', options[:context])
+      assert_equal('Unit Tests failed.', options[:description])
+    end
+
+    assert_raises(StandardError){
+      @execution_wrapper.execute_command_and_update_status!(command)
+    }
+  end
+
+end

--- a/_docker/tests/pull_request/test_exec_with_git_hub_status_wrapper.rb
+++ b/_docker/tests/pull_request/test_exec_with_git_hub_status_wrapper.rb
@@ -114,7 +114,7 @@ class TestExecWithGitHubStatusWrapper < MiniTest::Test
     Octokit.expects(:create_status).with do | github_repo, git_sha1, status, options |
       assert_equal(@git_repo, github_repo)
       assert_equal(@git_sha1, git_sha1)
-      assert_equal('failed', status)
+      assert_equal('failure', status)
       assert_equal(@target_url, options[:target_url])
       assert_equal('Unit Tests', options[:context])
       assert_equal('Unit Tests failed.', options[:description])

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -314,6 +314,6 @@ class TestOptions < Minitest::Test
   end
 
   private def expected_unit_test_tasks
-    ['--no-deps', '--rm', 'awestruct', 'bundle exec rake test']
+    ['--no-deps', '--rm', 'unit_tests']
   end
 end


### PR DESCRIPTION
This pull request adds in initial support for running pull requests against a Drupal-based environment. In particular it adds the ability to be able to send statuses to Github for various parts of the Drupal pull request process without impacting the statuses for the Awestruct build.

The main purpose of this pull request is to make as few changes as possible to the existing Github status framework, whilst integrating the new control.rb functions e.g. --export into status updates.

The main part of this work is more fully documented in the accompanying README.md.

I additionally had to re-add the `unit_tests` service definition in the docker-compose.yml for each environment as I needed a separate container definition to run the tests and run awestruct in the drupal-pull-request environment. I felt it cleaner and easier to follow if the same container definition was introduced back into all environments rather than changing the container name in which we run the tests depending upon the environment that we are running in.

## PLEASE LET BLINKR FINISH FOR THIS PR AS I HAVE MADE CHANGES IN THAT AREA
 
