### PR TITLE
Disabled autoPlay on DevNation 2016 page

### DIFF
--- a/events/devnation/2016/index.html.slim
+++ b/events/devnation/2016/index.html.slim
@@ -63,7 +63,7 @@ section.wide.wide-hero(class="#{page.hero_class}")
       .row
         .large-24.columns.divider
           h3.caps DevOps Live
-          iframe.video(src="https://www.ustream.tv/embed/22461912?html5ui&autoplay=true" style="border: 0 none transparent;"  webkitallowfullscreen allowfullscreen frameborder="no" width="720" height="405")
+          iframe.video(src="https://www.ustream.tv/embed/22461912?html5ui&autoplay=false" style="border: 0 none transparent;"  webkitallowfullscreen allowfullscreen frameborder="no" width="720" height="405")
           br
           a(href="https://www.ustream.tv/" style="padding: 2px 0px 4px; width: 400px; background: #ffffff; display: block; color: #000000; font-weight: normal; font-size: 10px; text-decoration: underline; text-align: center;" target="_blank")theCUBE Red Hat Channel
           p A live demonstration of Container-based microservices pushed through a continuous deployment pipeline.


### PR DESCRIPTION
This is a simple fix to stop the third video auto-playing. See: http://developers.redhat.com/events/devnation/2016/ for what it shouldn't do.

@insectengine should be able to approve this, as he spotted it.