### PR TITLE
Removed quotes from around OpenJDK descriptions

### DIFF
--- a/products/openjdk/_common/product.yml
+++ b/products/openjdk/_common/product.yml
@@ -6,5 +6,5 @@ skip_installation_instructions: true
 skip_maven_instructions: true
 index:
   desc: |
-    'A Tried, Tested and Trusted open source implementation of the Java platform'
-description: 'A Tried, Tested and Trusted open source implementation of the Java platform'
+    A Tried, Tested and Trusted open source implementation of the Java platform
+description: A Tried, Tested and Trusted open source implementation of the Java platform


### PR DESCRIPTION
Removed the single quotes from around the description  of OpenJDK, as seen on http://developers.redhat.com/products/. We should check all the locations that these config entries are used and make sure it looks right.