### PR TITLE
Fixed Vagrant links

### DIFF
--- a/products/cdk/get-started.adoc
+++ b/products/cdk/get-started.adoc
@@ -95,9 +95,9 @@ To provide `ssh` and `rsync` on Microsoft Windows, install http://cygwin.com/ins
 Next, download the environment that matches your virtualization platform:
 
 // FIXME These will need to be updated for GA and later.
-* #{site.download_manager_base_url}download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-virtualbox.box[Red Hat Enterprise Linux 7.2 Vagrant box for VirtualBox, window='_blank']
-* #{site.download_manager_base_url}download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-libvirt.box[Red Hat Enterprise Linux 7.2 Vagrant box for KVM/libvirt, window='_blank']
-* #{site.download_manager_base_url}download-manager/file/rhel-cdk-kubernetes-7.2-26.x86_64.vagrant-hyperv.box[Red Hat Enterprise Linux 7.2 Vagrant box for Hyper-V, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-virtualbox.box[Red Hat Enterprise Linux 7.2 Vagrant box for VirtualBox, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-libvirt.box[Red Hat Enterprise Linux 7.2 Vagrant box for KVM/libvirt, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-26.x86_64.vagrant-hyperv.box[Red Hat Enterprise Linux 7.2 Vagrant box for Hyper-V, window='_blank']
 
 ## Mac And Linux Step3
 


### PR DESCRIPTION
Should fix: http://developers.redhat.com/products/cdk/get-started/#tab-macLinux. See these broken links: https://www.dropbox.com/s/pekrylxagjrqrzp/Screenshot%202016-06-28%2015.03.02.png?dl=0

