### PR TITLE
Updated Morning Keynote to fixed video

### DIFF
--- a/events/devnation/2016/_common/event.yml
+++ b/events/devnation/2016/_common/event.yml
@@ -1,7 +1,7 @@
 live_events:
   - title: "Watch Live: Morning General Session"
     date: 06/27/2016 16:30:00 UTC
-    youtube_id: nxnIpgHQ-Gw
+    youtube_id: MiUrYH3ybX0
     abstract:
         "In the general session, Red Hat will be joined by some of the best and brightest minds in industry participating in a vision of how new technologies and ways of building software will evolve.  Be the first to hear the latest announcements, watch some cool demos and learn of Red Hat’s involvement in many of the tools that developers commonly use today."
     speaker: Harry Mower, Todd Mancini, Mark Little - Red Hat; Tyler Jewel - Codenvy & Scott Hanselman - Microsoft


### PR DESCRIPTION
This should fix the issue where the morning session refuses to play, claiming that the live event has ended.