### PR TITLE
[DEVELOPER-3270] Fix failing push of Drupal backup to Github

### DIFF
--- a/_docker/backup/Dockerfile
+++ b/_docker/backup/Dockerfile
@@ -5,13 +5,14 @@ ARG https_proxy
 
 COPY mariadb/MariaDB.repo /etc/yum.repos.d/MariaDB.repo
 
-RUN yum erase -y git
 RUN curl -s https://setup.ius.io/ | bash
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
-RUN yum install -y \
+RUN yum erase -y git \
+    && yum install -y \
     git2u \
     git-lfs \
-    MariaDB-client
+    MariaDB-client \
+    && yum clean all
 RUN groupadd -g 1000 jenkins_developer
 RUN useradd -g jenkins_developer -m -s /bin/bash -u 1000 jenkins_developer
 USER jenkins_developer

--- a/_docker/backup/Dockerfile
+++ b/_docker/backup/Dockerfile
@@ -16,7 +16,7 @@ RUN yum erase -y git \
 RUN groupadd -g 1000 jenkins_developer
 RUN useradd -g jenkins_developer -m -s /bin/bash -u 1000 jenkins_developer
 USER jenkins_developer
-RUN git lfs install
-RUN git config --global user.email "rhd@redhat.com"
-RUN git config --global user.name "Red Hat Developers Backup User"
+RUN git lfs install \
+    && git config --global user.email "rhd@redhat.com" \
+    && git config --global user.name "Red Hat Developers Backup User"
 WORKDIR /home/jenkins_developer

--- a/_docker/backup/Dockerfile
+++ b/_docker/backup/Dockerfile
@@ -1,0 +1,21 @@
+FROM developer.redhat.com/ruby:2.0.0
+
+ARG http_proxy
+ARG https_proxy
+
+COPY mariadb/MariaDB.repo /etc/yum.repos.d/MariaDB.repo
+
+RUN yum erase -y git
+RUN curl -s https://setup.ius.io/ | bash
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
+RUN yum install -y \
+    git2u \
+    git-lfs \
+    MariaDB-client
+RUN groupadd -g 1000 jenkins_developer
+RUN useradd -g jenkins_developer -m -s /bin/bash -u 1000 jenkins_developer
+USER jenkins_developer
+RUN git lfs install
+RUN git config --global user.email "rhd@redhat.com"
+RUN git config --global user.name "Red Hat Developers Backup User"
+WORKDIR /home/jenkins_developer

--- a/_docker/backup/mariadb/MariaDB.repo
+++ b/_docker/backup/mariadb/MariaDB.repo
@@ -1,0 +1,5 @@
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.1/centos6-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -58,7 +58,7 @@ services:
      args:
        http_proxy: proxy01.util.phx2.redhat.com:8080
        https_proxy: proxy01.util.phx2.redhat.com:8080
-    entrypoint: ruby _docker/lib/backup/backup.rb
+    entrypoint: ruby developer.redhat.com/_docker/lib/backup/backup.rb
     environment:
       - http_proxy=proxy01.util.phx2.redhat.com:8080
       - https_proxy=proxy01.util.phx2.redhat.com:8080
@@ -66,8 +66,8 @@ services:
       - ../../../:/home/jenkins_developer/developer.redhat.com
       - /data/drupal:/drupal
       - /git/backups:/backups
-      - /credentials/db/my.cnf:/home/awestruct/.my.cnf
-      - /credentials/git/backups/netrc:/home/awestruct/.netrc
+      - /credentials/db/my.cnf:/home/jenkins_developer/.my.cnf
+      - /credentials/git/backups/netrc:/home/jenkins_developer/.netrc
 
   export:
     build:

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -54,7 +54,7 @@ services:
   #
   backup:
     build:
-     context: ../../awestruct
+     context: ../../backup
      args:
        http_proxy: proxy01.util.phx2.redhat.com:8080
        https_proxy: proxy01.util.phx2.redhat.com:8080
@@ -63,7 +63,7 @@ services:
       - http_proxy=proxy01.util.phx2.redhat.com:8080
       - https_proxy=proxy01.util.phx2.redhat.com:8080
     volumes:
-      - ../../../:/home/awestruct/developer.redhat.com
+      - ../../../:/home/jenkins_developer/developer.redhat.com
       - /data/drupal:/drupal
       - /git/backups:/backups
       - /credentials/db/my.cnf:/home/awestruct/.my.cnf


### PR DESCRIPTION
This PR fixes the failing push of Drupal backups to Github. To do that I have:

1. Introduced a new backup image that has correctly configured version of Git that supports LFS
2. Updated the docker-compose.yml for the drupal-production environment to use this new image.


