### PR TITLE
Improving ExportInspector

### DIFF
--- a/_docker/lib/export/export_inspector.rb
+++ b/_docker/lib/export/export_inspector.rb
@@ -1,3 +1,5 @@
+require 'uri/http'
+
 #
 # The purpose of this class is to inspect an export directory to ensure that all pages that should be there, are in fact there.
 #
@@ -9,8 +11,8 @@ class ExportInspector
   # Determines the filesystem path at which the .html page export should exist
   #
   def determine_expected_filesystem_path(url)
-    first_slash = url.index('/', 'http://'.length)
-    page_path = url[first_slash..url.length]
+    uri = URI.parse url
+    page_path = uri.path
     if page_path == '/'
       '/index.html'
     else
@@ -22,8 +24,8 @@ class ExportInspector
   # Checks to see if the path exists at the expected path in the export directory
   #
   def check_if_path_exists(url, expected_file_path, export_directory)
-    expected_path = "#{export_directory}#{expected_file_path}"
-    exists = FileTest.exist?(expected_path)
+    expected_path = File.join export_directory, expected_file_path
+    exists = File.exist?(expected_path)
     unless exists
       puts "WARNING: Cannot locate export of '#{url}' at expected path: '#{expected_path}'"
     end
@@ -35,7 +37,7 @@ class ExportInspector
   #
   def inspect_export(url_list, export_directory)
 
-    puts "================================ EXPORT SUMMARY ================================"
+    puts '================================ EXPORT SUMMARY ================================'
 
     total_pages = 0
     missing_pages = 0

--- a/_docker/tests/export/test_export_inspector.rb
+++ b/_docker/tests/export/test_export_inspector.rb
@@ -1,0 +1,55 @@
+require_relative '../test_helper'
+require_relative '../../lib/export/export_inspector'
+require 'fileutils'
+
+class TestExportInspector < MiniTest::Test
+  def setup
+    @export_directory = Dir.mktmpdir
+    @url_list = File.new(File.join(@export_directory, 'url-list.txt'), 'w+')
+
+    links = <<EOD
+http://developer-drupal.web.stage.ext.phx2.redhat.com/
+http://developer-drupal.web.stage.ext.phx2.redhat.com/about
+http://developer-drupal.web.stage.ext.phx2.redhat.com/events/devnation/2016
+http://developer-drupal.web.stage.ext.phx2.redhat.com/community/contributor/signup
+http://developer-drupal.web.stage.ext.phx2.redhat.com/articles/rhel-what-you-need-to-know
+EOD
+
+    @url_list.write links
+    @url_list.flush
+    @inspector = ExportInspector.new
+  end
+
+  def teardown
+    FileUtils.remove_entry_secure @export_directory
+  end
+
+  def test_all_links_are_valid
+    # Go through and create the files that are expected
+    expected_files = %w(index.html about.html events/devnation/2016.html community/contributor/signup.html articles/rhel-what-you-need-to-know.html)
+
+    expected_files.each do |file|
+      FileUtils.mkdir_p File.join(@export_directory, File.dirname(file))
+      FileUtils.touch File.join(@export_directory, file)
+    end
+
+    assert_output("================================ EXPORT SUMMARY ================================\n") do
+      @inspector.inspect_export @url_list, @export_directory
+    end
+  end
+
+  def test_no_links_are_valid
+    expected_output = <<EOD
+================================ EXPORT SUMMARY ================================
+WARNING: Cannot locate export of 'http://developer-drupal.web.stage.ext.phx2.redhat.com/' at expected path: '#{@export_directory}/index.html'
+WARNING: Cannot locate export of 'http://developer-drupal.web.stage.ext.phx2.redhat.com/about' at expected path: '#{@export_directory}/about.html'
+WARNING: Cannot locate export of 'http://developer-drupal.web.stage.ext.phx2.redhat.com/events/devnation/2016' at expected path: '#{@export_directory}/events/devnation/2016.html'
+WARNING: Cannot locate export of 'http://developer-drupal.web.stage.ext.phx2.redhat.com/community/contributor/signup' at expected path: '#{@export_directory}/community/contributor/signup.html'
+WARNING: Cannot locate export of 'http://developer-drupal.web.stage.ext.phx2.redhat.com/articles/rhel-what-you-need-to-know' at expected path: '#{@export_directory}/articles/rhel-what-you-need-to-know.html'
+WARNING: Of '5' pages, '5' are not found in the export.
+EOD
+    assert_output(expected_output) do
+      @inspector.inspect_export @url_list, @export_directory
+    end
+  end
+end


### PR DESCRIPTION
In trying the staging export I ran into this error:

/home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:13:in `determine_expected_filesystem_path': bad value for range (ArgumentError)
 from /home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:47:in `block (2 levels) in inspect_export'
 from /home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:44:in `each_line'
 from /home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:44:in `block in inspect_export'
 from /home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:43:in `open'
 from /home/awestruct/developer.redhat.com/_docker/lib/export/export_inspector.rb:43:in `inspect_export'
 from /home/awestruct/developer.redhat.com/_docker/lib/export/httrack_export_strategy.rb:70:in `export!'
 from _docker/lib/export/export.rb:35:in `export!'
 from _docker/lib/export/export.rb:68:in `<main>''

This should fix that issue. I've also added a test for the
ExportInspector class which didn't have one before.