### PR TITLE
[DEVELOPER-3282] Ensure backup.rb commits .gz archive

### DIFF
--- a/_docker/lib/backup/backup.rb
+++ b/_docker/lib/backup/backup.rb
@@ -22,7 +22,7 @@ class Backup
     @backup_directory = backup_directory
     @backup_strategy = backup_strategy
     @drupal_tar_name = 'drupal-filesystem.tar.gz'
-    @drupal_database_sql_dump_name = 'drupal-db.sql'
+    @drupal_database_sql_dump_name = 'drupal-db.sql.gz'
   end
 
   #
@@ -42,7 +42,7 @@ class Backup
   # Creates a SQL dump of the database named @database_name
   #
   def backup_drupal_database
-    sql_dump = "#{@backup_directory}/#{@drupal_database_sql_dump_name}.gz"
+    sql_dump = "#{@backup_directory}/#{@drupal_database_sql_dump_name}"
     @log.info("Creating SQL dump '#{sql_dump}' of Drupal database...")
 
     @process_runner.execute!("mysqldump #{@database_name} | gzip > #{sql_dump}")

--- a/_docker/tests/backup/test_backup.rb
+++ b/_docker/tests/backup/test_backup.rb
@@ -18,7 +18,7 @@ class TestBackup < MiniTest::Test
   def test_should_backup_drupal_filesystem_and_database_to_timestamped_tag
 
     @process_runner.expects(:execute!).with("tar -czf #{@backup_directory}/#{@backup.drupal_tar_name} -C #{@drupal_filesystem} .")
-    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}.gz")
+    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}")
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_tar_name)
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_database_sql_dump_name)
     @git_backup_strategy.expects(:commit_backup).with(is_a(String), regexp_matches(/[0-9]{4}-([0-9]{2}-){3}[0-9]{2}/))
@@ -30,7 +30,7 @@ class TestBackup < MiniTest::Test
   def test_should_backup_drupal_filesystem_and_database_to_timestamped_tag_with_nil_array
 
     @process_runner.expects(:execute!).with("tar -czf #{@backup_directory}/#{@backup.drupal_tar_name} -C #{@drupal_filesystem} .")
-    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}.gz")
+    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}")
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_tar_name)
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_database_sql_dump_name)
     @git_backup_strategy.expects(:commit_backup).with(is_a(String), regexp_matches(/[0-9]{4}-([0-9]{2}-){3}[0-9]{2}/))
@@ -42,7 +42,7 @@ class TestBackup < MiniTest::Test
   def test_should_backup_drupal_filesystem_and_database_to_timestamped_tag_with_empty_value_in_array
 
     @process_runner.expects(:execute!).with("tar -czf #{@backup_directory}/#{@backup.drupal_tar_name} -C #{@drupal_filesystem} .")
-    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}.gz")
+    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}")
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_tar_name)
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_database_sql_dump_name)
     @git_backup_strategy.expects(:commit_backup).with(is_a(String), regexp_matches(/[0-9]{4}-([0-9]{2}-){3}[0-9]{2}/))
@@ -55,7 +55,7 @@ class TestBackup < MiniTest::Test
   def test_should_backup_drupal_filesystem_and_database_to_named_tag
 
     @process_runner.expects(:execute!).with("tar -czf #{@backup_directory}/#{@backup.drupal_tar_name} -C #{@drupal_filesystem} .")
-    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}.gz")
+    @process_runner.expects(:execute!).with("mysqldump #{@database_name} | gzip > #{@backup_directory}/#{@backup.drupal_database_sql_dump_name}")
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_tar_name)
     @git_backup_strategy.expects(:add_file_to_backup).with(@backup.drupal_database_sql_dump_name)
     @git_backup_strategy.expects(:commit_backup).with(includes('my_backup'), equals('my_backup'))


### PR DESCRIPTION
In the code review I missed that the changes to backup were not properly committing the .gz archive of the SQL dump.