### PR TITLE
[DEVELOPER-3284] Allow comparison of Drupal sitemap to current RHD site

### DIFF
--- a/_docker/lib/export/sitemap_diff.rb
+++ b/_docker/lib/export/sitemap_diff.rb
@@ -1,0 +1,81 @@
+require 'nokogiri'
+require 'net/http'
+
+#
+# This class will perform a diff between the sitemap.xml at developers.redhat.com and any given sitemap.xml. This is
+# useful to see which pages are in for example a Drupal instance, but not on the current developers.redhat.com site.
+#
+#
+class SitemapDiff
+
+  def initialize
+    @developers_sitemap = "http://developers.redhat.com/sitemap.xml"
+  end
+
+  def get_sitemap_links(sitemap_location)
+    sitemap_content = fetch_sitemap(sitemap_location)
+    get_links_from_sitemap(sitemap_content)
+  end
+
+  def fetch_sitemap(sitemap_location)
+    sitemap_url = URI.parse(sitemap_location)
+    sitemap_contents = Net::HTTP.get_response(sitemap_url)
+    raise StandardError.new("Failed to fetch sitemap.xml from '#{sitemap_location}'. Got status: '#{sitemap_contents.code}'") if sitemap_contents.code.to_i != 200
+    sitemap_contents.body
+  end
+
+  def get_links_from_sitemap(sitemap_content)
+    document = Nokogiri::XML(sitemap_content)
+    links = []
+    document.css('url loc').each do | link |
+      uri_path = URI.parse(link.content).path
+      if uri_path != '/' and uri_path.end_with?('/')
+        uri_path = uri_path[0..-2]
+      end
+      links << uri_path
+    end
+
+    links
+  end
+
+  def compare_links_in_sitemaps(compared_sitemap, existing_links, sitemap_to_compare)
+    links_in_existing_not_in_compared = existing_links - sitemap_to_compare
+    links_in_compared_not_in_existing = sitemap_to_compare - existing_links
+
+    puts "=== The following pages are in the sitemap of http://developers.redhat.com/sitemap.xml but not in the sitemap at #{compared_sitemap}: ==="
+    links_in_existing_not_in_compared.each do | link |
+      puts "- #{link}"
+    end
+
+    puts "=== The following pages are in the sitemap at '#{compared_sitemap}' but not in the http://developers.redhat.com/sitemap.xml sitemap: ==="
+    links_in_compared_not_in_existing.each do | link |
+      puts "- #{link}"
+    end
+
+  end
+
+  def compare_existing_sitemap_to(sitemap_to_compare)
+
+    current_sitemap_links = get_sitemap_links(@developers_sitemap)
+    compared_sitemap_links = get_sitemap_links(sitemap_to_compare)
+    compare_links_in_sitemaps(sitemap_to_compare, current_sitemap_links, compared_sitemap_links)
+
+  end
+
+  private :compare_links_in_sitemaps, :get_links_from_sitemap, :fetch_sitemap, :get_sitemap_links
+
+end
+
+if $0 == __FILE__
+
+  sitemap_to_compare = ARGV[0]
+  if sitemap_to_compare.nil? or sitemap_to_compare.empty?
+    puts "Usage: ruby sitemap_diff.rb http://<your_sitemap_url>"
+    Kernel.exit(1)
+  end
+
+  sitemap_diff = SitemapDiff.new
+  sitemap_diff.compare_existing_sitemap_to(sitemap_to_compare)
+  Kernel.exit(0)
+
+end

--- a/_docker/tests/export/diff-sitemap-1.xml
+++ b/_docker/tests/export/diff-sitemap-1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://192.168.99.100:32769/</loc>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/articles/no-cost-rhel-faq</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/about</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/articles/rhel-what-you-need-to-know</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/community/contributor</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/community/contributor/signup</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:32-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+</urlset>

--- a/_docker/tests/export/diff-sitemap-2.xml
+++ b/_docker/tests/export/diff-sitemap-2.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://192.168.99.100:32769/</loc>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/about</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/articles/rhel-what-you-need-to-know</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/community/contributor</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/community/contributor/signup</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:32-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://192.168.99.100:32769/foobar</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+</urlset>

--- a/_docker/tests/export/test_sitemap_diff.rb
+++ b/_docker/tests/export/test_sitemap_diff.rb
@@ -1,0 +1,41 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../../../_docker/tests/test_helper'
+require_relative '../../lib/export/sitemap_diff'
+
+class TestSitemapDiff < MiniTest::Test
+
+  def build_mock_for_sitemap_request_to(sitemap_url, desired_sitemap_file_to_return)
+
+    sitemap_contents = mock()
+    sitemap_contents.expects(:code).returns(200)
+    sitemap_contents.expects(:body).returns(File.open(File.expand_path(desired_sitemap_file_to_return,File.dirname(__FILE__))).read)
+    sitemap_contents
+
+  end
+
+
+  def test_list_differences_between_sitemaps
+
+      developers_redhat_sitemap = build_mock_for_sitemap_request_to('http://developers.redhat.com/sitemap.xml', 'diff-sitemap-1.xml')
+      compared_sitemap = build_mock_for_sitemap_request_to('http://docker/sitemap.xml', 'diff-sitemap-2.xml')
+
+      Net::HTTP.expects(:get_response).twice.returns(developers_redhat_sitemap).then.returns(compared_sitemap)
+
+      expected_output = <<EOD
+=== The following pages are in the sitemap of http://developers.redhat.com/sitemap.xml but not in the sitemap at http://docker/sitemap.xml: ===
+- /articles/no-cost-rhel-faq
+=== The following pages are in the sitemap at 'http://docker/sitemap.xml' but not in the http://developers.redhat.com/sitemap.xml sitemap: ===
+- /foobar
+EOD
+
+      sitemap_diff = SitemapDiff.new
+
+      assert_output(expected_output) {
+        sitemap_diff.compare_existing_sitemap_to('http://docker/sitemap.xml')
+      }
+  end
+
+  private :build_mock_for_sitemap_request_to
+end


### PR DESCRIPTION
A small utility class that allows us to manually compare the sitemap.xml within a Drupal instance to that of the current developers.redhat.com site. This is to give us extra confidence that all expected content is in place.