### PR TITLE
DEVELOPER-3273 - Updated products to no longer list GA variables

### DIFF
--- a/_config/blinkr.yaml
+++ b/_config/blinkr.yaml
@@ -35,6 +35,8 @@ skips:
 ignores:
   - code: 202
   - code: 203
+  - code: 403
+  - code: 502
   - snippet: !ruby/regexp /f\.vimeocdn\.com/ # I don't see this error in real browsers
   - url: https://library.oreilly.com/book/0636920025368/continuous-enterprise-development-in-java/toc # works fine in a browser, not an error
   - url: http://venturebeat.com/2014/12/16/whats-in-a-container-you-dont-know-and-thats-a-problem/ # also not an error

--- a/products/amq/_common/product.yml
+++ b/products/amq/_common/product.yml
@@ -1,6 +1,6 @@
 name: Red Hat JBoss A-MQ
 abbreviated_name: JBoss A-MQ
-current_version: 6.2.0.GA
+current_version: 6.2.0
 documentation_path: Red_Hat_JBoss_A-MQ
 product_category: application-development
 product_logo: a-mq.png

--- a/products/amq/get-started.adoc
+++ b/products/amq/get-started.adoc
@@ -20,7 +20,7 @@ Prerequisites
 == Step1 Content
 
 1. *Install JBoss Developer Studio*
-a. Download link:#{site.download_manager_file_base_url}/jboss-devstudio-8.1.0.GA-jar_universal.jar?tp=amq[JBoss Developer Studio 8.1.0.GA] and execute its installer.
+a. Download link:#{site.download_manager_file_base_url}/jboss-devstudio-8.1.0.GA-jar_universal.jar?tp=amq[JBoss Developer Studio 8.1.0] and execute its installer.
 * On Mac / Windows development hosts: Right click on `jboss-devstudio-8.1.0.GA-installer-eap.jar`, select _Open With -> Jar Launcher_
 * On Red Hat Enterprise Linux: Use the terminal to go to the folder where you have downloaded JBoss Developer Studio, and execute the installer with the following command:
 +

--- a/products/bpmsuite/_common/product.yml
+++ b/products/bpmsuite/_common/product.yml
@@ -2,7 +2,7 @@ name: Red Hat JBoss BPM Suite
 abbreviated_name: JBoss BPM Suite
 product_logo: bpm-suite.png
 has_installer: true
-current_version: 6.2.0.GA
+current_version: 6.2.0
 documentation_minor_version: 6.2
 product_category: application-development
 xpaas_url: https://www.openshift.com/developers/jboss-bpms

--- a/products/brms/_common/product.yml
+++ b/products/brms/_common/product.yml
@@ -2,7 +2,7 @@ name: Red Hat JBoss BRMS
 abbreviated_name: JBoss BRMS
 product_logo: brms.png
 has_installer: true
-current_version: 6.2.0.GA
+current_version: 6.2.0
 documentation_minor_version: 6.2
 product_category: application-development
 xpaas_url: https://developers.openshift.com/en/xpaas-business-rules-management-system.html

--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Data Grid
 abbreviated_name: JBoss Data Grid
 product_logo: data-grid.png
-current_version: 6.6.0.GA
+current_version: 6.6.0
 product_category: application-development
 intro_video: https://vimeo.com/95291413
 vimeo_album: http://vimeo.com/album/2982379

--- a/products/datavirt/_common/product.yml
+++ b/products/datavirt/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Data Virtualization
 abbreviated_name: JBoss Data Virtualization
 product_logo: data-virtualization.png
-current_version: 6.2.0.GA
+current_version: 6.2.0
 product_category: application-development
 documentation_minor_version: 6.2
 xpaas_url: https://www.openshift.com/developers/jboss-data-virtualization

--- a/products/datavirt/get-started.adoc
+++ b/products/datavirt/get-started.adoc
@@ -34,7 +34,7 @@ A summary of the installation is displayed. Click *Next* for the installation to
 == Step2 Content
 
 1.	Install the Java SE Development Kit (JDK), we recommend OpenJDK or Oracle JDK.
-2.	Download JBoss Developer Studio 8.1.0.GA
+2.	Download JBoss Developer Studio 8.1.0
 3.	Run JBoss Developer Studio installer
 .. For MAC/Linux:
 ... Go to the folder where you have downloaded JBoss Developer Studio, and execute the installer

--- a/products/devstudio/_common/product.yml
+++ b/products/devstudio/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Developer Studio
 abbreviated_name: JBoss Developer Studio
 product_logo: developer-studio.png
-current_version: 10.0.0.GA
+current_version: 10.0.0
 product_category: application-development
 intro_video: https://vimeo.com/95444954
 vimeo_album: http://vimeo.com/album/2982449

--- a/products/devstudio/get-started.adoc
+++ b/products/devstudio/get-started.adoc
@@ -15,7 +15,7 @@ Prerequisites &#38; Required Dependencies Checklist
 
 == Step1 Content
 1.  Install the Java SE Development Kit (JDK) version 8. We recommend using the OpenJDK or the Oracle JDK.
-2.  Download link:#{site.download_manager_base_url}/download-manager/file/devstudio-10.0.0.GA-installer-eap.jar[JBoss Developer Studio 10.0.0.GA with JBoss EAP]
+2.  Download link:#{site.download_manager_base_url}/download-manager/file/devstudio-10.0.0.GA-installer-eap.jar[JBoss Developer Studio 10.0.0 with JBoss EAP]
 3.  Run the JBoss Developer Studio installer.
 .. For Mac/Windows Development Hosts:
 ...  Go to the folder that contains the downloadeded JBoss Developer Studio JAR file.

--- a/products/devsuite/_common/product.yml
+++ b/products/devsuite/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat Development Suite
 abbreviated_name: DevSuite
 product_logo: enterprise-app-platform.png
-current_version: 7.0.0.GA
+current_version: 7.0.0
 documentation_path: red-hat-jboss-enterprise-application-platform
 product_category: application-development
 xpaas_url: https://www.openshift.com/developers/jboss

--- a/products/eap/_common/product.yml
+++ b/products/eap/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Enterprise Application Platform
 abbreviated_name: JBoss EAP
 product_logo: enterprise-app-platform.png
-current_version: 7.0.0.GA
+current_version: 7.0.0
 documentation_path: red-hat-jboss-enterprise-application-platform
 product_category: application-development
 xpaas_url: https://www.openshift.com/developers/jboss

--- a/products/eap/get-started.adoc
+++ b/products/eap/get-started.adoc
@@ -15,7 +15,7 @@ Prerequisites &#38; Required Dependencies Checklist
 
 == Step1 Content
 1.  Install the Java SE Development Kit (JDK) version 8. We recommend using the OpenJDK or the Oracle JDK.
-2.  Download link:#{site.download_manager_base_url}/download-manager/file/devstudio-10.0.0.GA-installer-eap.jar[JBoss Developer Studio 10.0.0.GA with JBoss EAP]
+2.  Download link:#{site.download_manager_base_url}/download-manager/file/devstudio-10.0.0.GA-installer-eap.jar[JBoss Developer Studio 10.0.0 with JBoss EAP]
 3.  Run the JBoss Developer Studio installer.
 .. For Mac/Windows Development Hosts:
 ...  Go to the folder that contains the downloadeded JBoss Developer Studio JAR file.

--- a/products/fuse/_common/product.yml
+++ b/products/fuse/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Fuse
 abbreviated_name: JBoss Fuse
 product_logo: fuse.png
-current_version: 6.2.0.GA
+current_version: 6.2.0
 product_category: application-development
 default_download_artifact_type: zip
 skip_installation_instructions: true

--- a/products/mobileplatform/_common/product.yml
+++ b/products/mobileplatform/_common/product.yml
@@ -1,6 +1,6 @@
 name: Red Hat Mobile Application Platform
 abbreviated_name: Mobile Application Platform
-current_version: 1.0.0.GA
+current_version: 1.0.0
 product_category: application-development
 intro_youtube: https://www.youtube.com/v=Dw-Z-R2C51U
 youtube_album: https://www.youtube.com/playlist?list=PLf3vm0UK6HKroZy6oqmmS1uBXRbq8QiS9

--- a/products/openshift/_common/product.yml
+++ b/products/openshift/_common/product.yml
@@ -1,7 +1,7 @@
 name: OpenShift Enterprise by Red Hat
 abbreviated_name: OpenShift
 product_logo: portal.png
-current_version: 2.2.0.GA
+current_version: 2.2.0
 product_category: application-development
 customer_portal_download_url: https://rhn.redhat.com/rhn/software/channel/downloads/Download.do?cid=21355
 documentation_path: OpenShift_Enterprise

--- a/products/rhel/_common/product.yml
+++ b/products/rhel/_common/product.yml
@@ -2,7 +2,7 @@ name: Red Hat Enterprise Linux
 abbreviated_name: RHEL
 name_append:  "For traditional development, includes Software Collections and Developer Toolset."
 product_logo: portal.png
-current_version: 7.0.0.GA
+current_version: 7.0.0
 product_category: it-infrastructure
 documentation_path: Red_Hat_Enterprise_Linux
 youtube_album: https://www.youtube.com/playlist?list=PLf3vm0UK6HKqLP5eJxZJIZJXtSk-neHhH

--- a/products/softwarecollections/_common/product.yml
+++ b/products/softwarecollections/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat Software Collections
 abbreviated_name: Software Collections
 product_logo: portal.png
-current_version: 2.0.0.GA
+current_version: 2.0.0
 indented_product: false
 documentation_path: Red_Hat_Software_Collections
 product_category: it-infrastructure

--- a/products/webserver/_common/product.yml
+++ b/products/webserver/_common/product.yml
@@ -4,7 +4,7 @@ product_logo: web-server.png
 documentation_path: JBoss_Enterprise_Web_Server
 full_subscription_required: true
 documentation_minor_version: 2
-current_version: 2.0.0.GA
+current_version: 2.0.0
 product_category: application-development
 skip_quickstart_link: true
 vimeo_album: http://vimeo.com/album/2982377


### PR DESCRIPTION
All products should now show up without GA; however, I need to review Blinkr to make sure that this doesn't cause problems with the documentation.