### PR TITLE
DEVELOPER-3288 - Removing the display_submitted text

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/node.type.rhd_microsite.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/node.type.rhd_microsite.yml
@@ -13,4 +13,4 @@ description: 'A microsite isn''t much more than raw content'
 help: 'Add a new instance of this type to create a new microsite'
 new_revision: true
 preview_mode: 1
-display_submitted: true
+display_submitted: false


### PR DESCRIPTION
All of the created node types should have this set to false, looks like
this one missed it.

I fixed this in production drupal, but this should fix it even if creating a new drupal instance from scratch.