### PR TITLE
Updated references for JDG 7.0.0 GA

### DIFF
--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -1,7 +1,7 @@
 name: Red Hat JBoss Data Grid
 abbreviated_name: JBoss Data Grid
 product_logo: data-grid.png
-current_version: 6.6.0
+current_version: 7.0.0
 product_category: application-development
 intro_video: https://vimeo.com/95291413
 vimeo_album: http://vimeo.com/album/2982379
@@ -19,12 +19,14 @@ guides:
   API_Documentation:
     formats:
       html:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.6/html/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/7.0/html/API_Documentation/index.html
       html-single:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.6/html-single/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/7.0/html-single/API_Documentation/index.html
   Developer_Guide:
+  Feature_Support_Document:
   Getting_Started_Guide:
-  Infinispan_Query_Guide:
+  Migration_Guide:
+  Performance_Tuning_Guide:
 default_download_artifact_type: zip
 description: 'An intelligent, distributed caching solution that boosts application performance, provides greater deployment flexibility, and minimizes the overhead of standing up new applications.'
 downloads:


### PR DESCRIPTION
JDG 7.0.0 GA'd yesterday, and I have updated the references to point to the latest docs.  Note that the Infinispan Query guide has been removed, while a few additional books have been added to this list.