### PR TITLE
RHD-1625 replace "contact us" email to developers@redhat.com

### DIFF
--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -264,7 +264,7 @@
                   li
                     a(href="#{site.base_url}/about") About us
                   li
-                    a(href="mailto:developer@redhat.com") Contact us
+                    a(href="mailto:developers@redhat.com") Contact us
               .large-12.columns
                 ul.social-nav
                   li: a(href="https://plus.google.com/103877536668756379905/posts" target="_blank")


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHD-1625. 

I think this is simple enough to just require an engineering-team review.