### PR TITLE
[DEVELOPER-3324] Workaround default hostname in drupal sitemap.xml

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/robots.txt
+++ b/_docker/drupal/drupal-filesystem/web/robots.txt
@@ -44,7 +44,6 @@ Disallow: /admin/
 Disallow: /comment/reply/
 Disallow: /filter/tips/
 Disallow: /node/add/
-Disallow: /search/
 Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/

--- a/_docker/lib/export/drupal_page_url_list_generator.rb
+++ b/_docker/lib/export/drupal_page_url_list_generator.rb
@@ -39,7 +39,8 @@ class DrupalPageUrlListGenerator
     document = Nokogiri::XML(sitemap_contents)
     links = []
     document.css('url loc').each do | link |
-      links << link.content
+      uri = URI.parse(link.content)
+      links << "http://#{@drupal_host}#{uri.path}"
     end
 
     links.uniq!

--- a/_docker/tests/export/magic_drupal_sitemap.xml
+++ b/_docker/tests/export/magic_drupal_sitemap.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test sitemap.xml that has hostname set to 'default' as Drupal seems want to do every now and then -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://default:32769/</loc>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://default:32769/articles/no-cost-rhel-faq</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://default:32769/about</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://default:32769/articles/rhel-what-you-need-to-know</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://default:32769/community/contributor</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://default:32769/community/contributor/signup</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:32-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://default:32769/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+  <!-- Test to ensure duplicates are removed from the list of urls to fetch -->
+  <url>
+    <loc>http://default:32769/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
This PR works around the fact that at times, the hostname in the Drupal sitemap.xml gets re-written to be 'default'. It parses the list of links from the sitemap.xml and then ensures that it replaces the 'default' hostname with the one specified in the initialisation of the export process.