### PR TITLE
[DEVELOPER-3323] Added re-write of form action URLs as part of export

### DIFF
--- a/_docker/lib/export/export.rb
+++ b/_docker/lib/export/export.rb
@@ -7,6 +7,7 @@ require_relative 'static_export_rsync'
 require_relative 'export_inspector'
 require_relative 'export_archiver'
 require_relative 'export_archive_pruner'
+require_relative 'form_action_rewrite'
 
 #
 # Class that acts as a controller of the export process from Drupal
@@ -64,7 +65,7 @@ if $0 == __FILE__
   process_runner = ProcessRunner.new
   cron_invoker = CronInvoker.new(drupal_host)
   page_url_list_generator = DrupalPageUrlListGenerator.new(drupal_host, @DEFAULT_EXPORT_LOCATION)
-  export_strategy = HttrackExportStrategy.new(process_runner, ExportInspector.new)
+  export_strategy = HttrackExportStrategy.new(process_runner, ExportInspector.new, FormActionRewrite.new)
   rsync_handler = StaticExportRsync.new(process_runner, ExportArchiver.new(@DEFAULT_EXPORT_ARCHIVE_LOCATION, ExportArchivePruner.new(@DEFAULT_EXPORT_ARCHIVE_LOCATION)))
   log = DefaultLogger.logger
 

--- a/_docker/lib/export/form_action_rewrite.rb
+++ b/_docker/lib/export/form_action_rewrite.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'nokogiri'
 require_relative '../default_logger'
 
@@ -35,9 +36,9 @@ class FormActionRewrite
 
       if modified
         @log.info("- Modified form target(s) in file '#{html_file}', flushing output to disk")
-        html_to_write = File.open(html_file,'w')
-        doc.write_to(html_to_write)
-        html_to_write.close
+        File.open(html_file,'w') do | file |
+          file.write(CGI::unescape(doc.to_html))
+        end
       else
         @log.info("- No modifications required to file '#{html_file}'")
       end

--- a/_docker/lib/export/form_action_rewrite.rb
+++ b/_docker/lib/export/form_action_rewrite.rb
@@ -1,0 +1,52 @@
+require 'nokogiri'
+require_relative '../default_logger'
+
+#
+# This class is used to post-process an httrack export of a site. It will recursively
+# search the passed directory and look for any .html files. Within those HTML files, it
+# look for any <form> elements and rewrite the 'target' attribute if it is set to the host from
+# from which the site was originally exported, setting the target to be relative to the export instead.
+#
+class FormActionRewrite
+
+  def initialize
+    @log = DefaultLogger.logger
+  end
+
+  def rewrite_form_target_urls(drupal_host, export_directory)
+
+    @log.info("Beginning re-write for form action attributes in export directory '#{export_directory}'...")
+
+    Dir.glob("#{export_directory}/**/*.html") do | html_file |
+
+      @log.info("- Processing HTML file '#{html_file}'...")
+
+      doc = File.open(html_file) do | file |
+        Nokogiri::HTML(file)
+      end
+
+      modified = false
+      doc.css("form[action^=\"http://#{drupal_host}\"]").each do | form |
+        new_action_value = form.attributes['action'].value.gsub("http://#{drupal_host}",'')
+        @log.info("-- Modifying form action '#{form.attributes['action']}' to '#{new_action_value}'")
+        form.attributes['action'].value = new_action_value
+        modified = true
+      end
+
+      if modified
+        @log.info("- Modified form target(s) in file '#{html_file}', flushing output to disk")
+        html_to_write = File.open(html_file,'w')
+        doc.write_to(html_to_write)
+        html_to_write.close
+      else
+        @log.info("- No modifications required to file '#{html_file}'")
+      end
+    end
+
+    @log.info("Completed re-write of form actions in export directory '#{export_directory}'.")
+
+  end
+
+end
+
+

--- a/_docker/lib/export/httrack_export_strategy.rb
+++ b/_docker/lib/export/httrack_export_strategy.rb
@@ -1,4 +1,5 @@
 require_relative '../default_logger'
+require_relative 'form_action_rewrite'
 
 #
 # A class that delegates to Httrack to export a site given the list of URLs.
@@ -10,9 +11,10 @@ require_relative '../default_logger'
 #
 class HttrackExportStrategy
 
-  def initialize(process_runner, export_inspector)
+  def initialize(process_runner, export_inspector, form_action_rewrite)
     @process_runner = process_runner
     @export_inspector = export_inspector
+    @form_action_rewrite = form_action_rewrite
     @log = DefaultLogger.logger
   end
 
@@ -67,6 +69,7 @@ class HttrackExportStrategy
     end
 
     exported_to = "#{export_directory}/#{determine_export_directory_from_drupal_host(drupal_host)}"
+    @form_action_rewrite.rewrite_form_target_urls(drupal_host, exported_to)
     @export_inspector.inspect_export(links_file, exported_to)
     exported_to
   end

--- a/_docker/tests/export/test_export_form_rewrite/containers.html
+++ b/_docker/tests/export/test_export_form_rewrite/containers.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Containers!!!</title>
+</head>
+<body>
+<!-- This should get re-written -->
+<form id="modify" action="http://docker/search">
+
+</form>
+
+<!-- This should not get re-written -->
+<form id="no-modify" action="http://myotherhost.com/savemefromdocker">
+
+</form>
+
+</body>
+</html>

--- a/_docker/tests/export/test_export_form_rewrite/containers.html
+++ b/_docker/tests/export/test_export_form_rewrite/containers.html
@@ -15,5 +15,7 @@
 
 </form>
 
+<a id="angular-link" href="{{blah.test[0]}}">Testing Angular Link</a>
+
 </body>
 </html>

--- a/_docker/tests/export/test_export_form_rewrite/nested_directory/more-containers.html
+++ b/_docker/tests/export/test_export_form_rewrite/nested_directory/more-containers.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<!-- This should get re-written -->
+<form id="modify" action="http://docker/search">
+
+</form>
+
+<!-- This should not get re-written -->
+<form id="no-modify" action="http://myotherhost.com/savemefromdocker">
+
+</form>
+</body>
+</html>

--- a/_docker/tests/export/test_form_action_rewrite.rb
+++ b/_docker/tests/export/test_form_action_rewrite.rb
@@ -29,6 +29,12 @@ class TestFormActionRewrite < MiniTest::Test
     html_document.css("##{form_id}").first.attributes['action'].value
   end
 
+  def test_should_rewrite_ok_with_angular_links
+    @form_action_rewrite.rewrite_form_target_urls('docker',@export_directory)
+    containers_html = get_html_document("#{@export_directory}/containers.html")
+    assert_equal('{{blah.test[0]}}',containers_html.css("#angular-link").first.attributes['href'].value)
+  end
+
   def test_should_rewrite_form_action_urls
 
     @form_action_rewrite.rewrite_form_target_urls('docker',@export_directory)

--- a/_docker/tests/export/test_form_action_rewrite.rb
+++ b/_docker/tests/export/test_form_action_rewrite.rb
@@ -1,0 +1,46 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+require 'fileutils'
+require 'nokogiri'
+
+require_relative '../../lib/export/form_action_rewrite'
+require_relative '../test_helper'
+
+class TestFormActionRewrite < MiniTest::Test
+
+  def setup
+    @form_action_rewrite = FormActionRewrite.new
+    @export_directory = Dir.mktmpdir
+    test_export = Dir.open(File.expand_path('test_export_form_rewrite',File.dirname(__FILE__)))
+    FileUtils.cp_r("#{test_export.path}/.", @export_directory)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@export_directory)
+  end
+
+  def get_html_document(html_document_name)
+    containers_html = File.open(html_document_name) do | html_file |
+      Nokogiri::HTML(html_file)
+    end
+  end
+
+  def get_form_action_url_from_html_doc(html_document, form_id)
+    html_document.css("##{form_id}").first.attributes['action'].value
+  end
+
+  def test_should_rewrite_form_action_urls
+
+    @form_action_rewrite.rewrite_form_target_urls('docker',@export_directory)
+
+    containers_html = get_html_document("#{@export_directory}/containers.html")
+    assert_equal('/search',get_form_action_url_from_html_doc(containers_html, 'modify'))
+    assert_equal('http://myotherhost.com/savemefromdocker', get_form_action_url_from_html_doc(containers_html,'no-modify'))
+
+    nested_containers_html = get_html_document("#{@export_directory}/nested_directory/more-containers.html")
+    assert_equal('/search',get_form_action_url_from_html_doc(nested_containers_html, 'modify'))
+    assert_equal('http://myotherhost.com/savemefromdocker', get_form_action_url_from_html_doc(nested_containers_html,'no-modify'))
+
+  end
+
+end

--- a/_docker/tests/export/test_httrack_export_strategy.rb
+++ b/_docker/tests/export/test_httrack_export_strategy.rb
@@ -13,7 +13,8 @@ class TestHttrackExportStrategy < MiniTest::Test
     @export_directory = Dir.mktmpdir
     @process_runner = mock()
     @export_inspector = mock()
-    @httrack_export_strategy = HttrackExportStrategy.new(@process_runner, @export_inspector)
+    @form_action_rewrite = mock()
+    @httrack_export_strategy = HttrackExportStrategy.new(@process_runner, @export_inspector, @form_action_rewrite)
     @url_list_file = File.open("#{@export_directory}/url-list.txt", 'w')
 
   end
@@ -26,6 +27,7 @@ class TestHttrackExportStrategy < MiniTest::Test
   def test_should_run_first_time_export
 
     @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0")
+    @form_action_rewrite.expects(:rewrite_form_target_urls).with(@drupal_host,"#{@export_directory}/drupal_8080")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
@@ -39,6 +41,7 @@ class TestHttrackExportStrategy < MiniTest::Test
     FileUtils.touch("#{@export_directory}/hts-cache/doit.log")
 
     @process_runner.expects(:execute!).with("cd #{@export_directory} && httrack --update")
+    @form_action_rewrite.expects(:rewrite_form_target_urls).with(@drupal_host,"#{@export_directory}/drupal_8080")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
@@ -47,6 +50,7 @@ class TestHttrackExportStrategy < MiniTest::Test
 
   def test_should_run_first_time_export_with_no_host_port
     @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://developer-drupal.web.stage.ext.phx2.redhat.com*\" -\"*/node*\" -o0")
+    @form_action_rewrite.expects(:rewrite_form_target_urls).with('developer-drupal.web.stage.ext.phx2.redhat.com',"#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'developer-drupal.web.stage.ext.phx2.redhat.com', @export_directory)
@@ -59,6 +63,7 @@ class TestHttrackExportStrategy < MiniTest::Test
     FileUtils.touch("#{@export_directory}/hts-cache/doit.log")
 
     @process_runner.expects(:execute!).with("cd #{@export_directory} && httrack --update")
+    @form_action_rewrite.expects(:rewrite_form_target_urls).with('developer-drupal.web.stage.ext.phx2.redhat.com',"#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'developer-drupal.web.stage.ext.phx2.redhat.com', @export_directory)


### PR DESCRIPTION
This PR adds in the re-write of form target URLs to the export process if the target URL for the form matches the Drupal host from which it was exported.