### PR TITLE
[DEVELOPER-3366] Navigation is broken while in Admin

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -75,6 +75,7 @@
 {% if (rhd_dtm_code) %}
   <script type="text/javascript">_satellite.pageBottom();</script>
 {% endif %}
+ {{ page_top}}
  <div class="site-wrapper">
     <header class="main clearfix">
         <div class="row header-wrap">
@@ -184,7 +185,6 @@
             </nav>
         </div>
     </header>
-    {{ page_top}}
     <div class="wrapper clearfix">
       <div class="content-wrapper">
         {{ page }}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DEVELOPER-3366 for more information.

This moves the page top section in Drupal to the very top of the page,
above our navigation.