### PR TITLE
[DEVELOPER-3361] Missing /quickstarts/sandbox/contributing page in Drupal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/awestruct/aweplug
-  revision: 598e62eef1b187820e74f86b611df5b1c0d7a603
+  revision: 4a7a9a1ef69af7a6cf96d9d517f5b5014d07b578
   specs:
     aweplug (1.0.0.a24)
       curb (~> 0.8.5)


### PR DESCRIPTION
See https://issues.jboss.org/browse/DEVELOPER-3361 for more information.

The fix was applied at
https://github.com/awestruct/aweplug/commit/4a7a9a1ef69af7a6cf96d9d517f5b5014d07b578