### PR TITLE
[DEVELOPER-3326] Disabled automatic Cron execution

### DIFF
--- a/_docker/environments/drupal-dev/rhd.settings.php
+++ b/_docker/environments/drupal-dev/rhd.settings.php
@@ -5,6 +5,7 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
 $config['system.performance']['css']['preprocess'] = FALSE;
 $config['system.performance']['js']['preprocess'] = FALSE;
+$config['automated_cron.settings']['interval'] = 0;
 
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';

--- a/_docker/environments/drupal-pull-request/rhd.settings.php
+++ b/_docker/environments/drupal-pull-request/rhd.settings.php
@@ -6,6 +6,7 @@ if (file_exists(__DIR__ . '/rhd.settings.yml')) {
   $config['redhat_developers'] = $yml_settings;
 }
 
+$config['automated_cron.settings']['interval'] = 0;
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 $settings['install_profile'] = 'standard';
 $config_directories['sync'] = 'sites/default/files/config_BbPlfGDu86LJqlRwhA9RbCf38VZMDijNF-owvfhuzVL73hk7BtWwy3kfIlqKLXeiSgTA-MHeVw/sync';


### PR DESCRIPTION
This PR disables automatic execution of cron in the dev and pull request environments.

To test:

1. bundle exec ./control.rb -e drupal-dev --run-the-stack
2. Navigate to http://docker/admin/config/system/cron
3. Notice that "Run cron every" setting is set to "Never".
