### PR TITLE
Hacking around vimeo limits

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -51,7 +51,8 @@ profile_base: &profile
     :cdn_version: *cdn_version
   authenticate_google_books_api: true
   build_threads: 40
-  cache_type: :external
+  # HACK!! Hacking around vimeo rate limit for now by using a local cache
+  cache_type: :local
 
 profiles:
   development: &development


### PR DESCRIPTION
I'm attempting to hack around vimeo limits by using a local cache that
we'll pull from a know location in the build pipeline.