### PR TITLE
[DEVELOPER-3389] Fixes Drupal not booting in production

### DIFF
--- a/_docker/drupal/scripts/drupal_install_checker.rb
+++ b/_docker/drupal/scripts/drupal_install_checker.rb
@@ -113,7 +113,7 @@ class DrupalInstallChecker
 
   def update_db
     puts 'Executing drush dbup'
-    process_executor.exec!('/var/www/drupal/vendor/bin/drush', ['--root=/var/www/drupal/web', '--entity-updates', 'updb'])
+    process_executor.exec!('/var/www/drupal/vendor/bin/drush', ['-y','--root=/var/www/drupal/web', '--entity-updates', 'updb'])
     process_executor.exec!('/var/www/drupal/vendor/bin/drupal', ['--root=/var/www/drupal/web', 'cache:rebuild', 'all'])
   end
 end

--- a/_docker/tests/drupal/drupal_install_checker_test.rb
+++ b/_docker/tests/drupal/drupal_install_checker_test.rb
@@ -190,7 +190,7 @@ class DrupalInstallCheckerTest < Minitest::Test
 
   def test_update_db
     @process_exec.expect :exec!, nil, ['/var/www/drupal/vendor/bin/drush',
-                                       %w(--root=/var/www/drupal/web --entity-updates updb)]
+                                       %w(-y --root=/var/www/drupal/web --entity-updates updb)]
     @process_exec.expect :exec!, nil, ['/var/www/drupal/vendor/bin/drupal',
                                        %w(--root=/var/www/drupal/web cache:rebuild all)]
 


### PR DESCRIPTION
Ensures that we automatically answer 'yes' to any prompt from the drush updb command. This prevents the update process from failing otherwise.