### PR TITLE
Fixes DEVELOPER-3397 (topic text formats)

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/field.field.node.topic.field_blue_card_description.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/field.field.node.topic.field_blue_card_description.yml
@@ -15,4 +15,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string_long
+field_type: text_long

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/field.field.node.topic.field_topic_sub_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/redhat_developers/config/install/field.field.node.topic.field_topic_sub_title.yml
@@ -18,4 +18,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: text
+field_type: string


### PR DESCRIPTION
Please see https://issues.jboss.org/browse/DEVELOPER-3397 for more
information.

This changes the formats for the `blue card description` field and the
`topic sub title` field. This is a configuration change, and as such
will require a rebuild of the current drupal instances (there may be a
better way to do this, but I'm not sure how, @drupalbee do you know?).