### PR TITLE
[DEVELOPER-3418] Fix incorrect bind mount for Drupal files directory

### DIFF
--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
-      - /data/drupal/images:/var/www/drupal/web/sites/default/images
+      - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
     environment:

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
-      - /data/drupal/images:/var/www/drupal/web/sites/default/images
+      - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
     environment:


### PR DESCRIPTION
This PR fixes an incorrect bind-mount for the Drupal files directory, which is causing uploaded images to be lost each time we re-build Drupal.