### PR TITLE
DEVELOPER-3432 Fix broken site/download links

### DIFF
--- a/products/cdk/_includes/get-started-cdk2-next-and-faq.adoc
+++ b/products/cdk/_includes/get-started-cdk2-next-and-faq.adoc
@@ -31,7 +31,7 @@ link:http://developerblog.redhat.com/[]
 
 . *How can I get the Red Hat Container Development Kit?*
 +
-You can download the Red Hat Container Development Kit from link:#{site.base_url}/[developers.redhat.com]. You will need to register, but registering is free.
+You can download the Red Hat Container Development Kit from link:{tthw-site-base-url}/[developers.redhat.com]. You will need to register, but registering is free.
 
 . *Do I need a Red Hat Enterprise Linux subscription to run the Red Hat Container Development Kit?*
 +
@@ -39,7 +39,7 @@ Yes. Since the kit includes a pre-built Red Hat Enterprise Linux virtual machine
 
 . *As a developer, how can I get a no-cost Red Hat Enterprise Linux subscription?*
 +
-When you register and download Red Hat Enterprise Linux Server through link:#{site.base_url}/[developers.redhat.com], a no-cost Red Hat Enterprise Linux Developer Suite subscription will be automatically added to your account.
+When you register and download Red Hat Enterprise Linux Server through link:{tthw-site-base-url}/[developers.redhat.com], a no-cost Red Hat Enterprise Linux Developer Suite subscription will be automatically added to your account.
 
 . *How do I tell if there is a container image available that has a newer version of {tthw-langshort}*?
 +

--- a/products/rhel/_includes/get-started-dcr7-intro-step1.adoc
+++ b/products/rhel/_includes/get-started-dcr7-intro-step1.adoc
@@ -6,7 +6,7 @@ Introduction and Prerequisites
 ## Prerequisites section
 In this tutorial, you will learn how to start building {tthw-langlong} applications in docker containers on Red Hat Enterprise Linux. In order to build and run containers you will first install `docker` on your Red Hat Enterprise Linux {tthw-rhelver} system. You will use the {tthw-langlong} container image from Red Hat Software Collections (RHSCL) 2.2 as the basis for your containerized application.
 
-You will need a system running Red Hat Enterprise Linux {tthw-rhelver} Server with a current Red Hat subscription that allows you to download software and updates from Red Hat. Developers can now get a no-cost Red Hat Enterprise Linux® Developer Suite subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through link:#{site.base_url}/[developers.redhat.com].
+You will need a system running Red Hat Enterprise Linux {tthw-rhelver} Server with a current Red Hat subscription that allows you to download software and updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by {tthw-download-manager}/download-manager/link/1350474[registering and downloading] through link:{tthw-site-base-url}/[developers.redhat.com].
 
 If you encounter difficulties at any point, see <<troubleshooting,Troubleshooting and FAQ>>.
 

--- a/products/rhel/_includes/get-started-dcr7-next-and-faq.adoc
+++ b/products/rhel/_includes/get-started-dcr7-next-and-faq.adoc
@@ -40,7 +40,7 @@ Your system must be registered with Red Hat using `subscription-manager register
 
 . *As a developer, how can I get a no-cost Red Hat Enterprise Linux subscription?*
 +
-When you register and download Red Hat Enterprise Linux Server through link:#{site.base_url}/[developers.redhat.com], a no-cost Red Hat Enterprise Linux Developer Suite subscription will be automatically added to your account. We recommend you follow our link:#{site.base_url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt.
+When you register and download Red Hat Enterprise Linux Server through link:{tthw-site-base-url}/[developers.redhat.com], a no-cost Red Hat Enterprise Linux Developer Suite subscription will be automatically added to your account. We recommend you follow our link:{tthw-site-base-url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt.
 
 . *How do I tell if there is a container image available that has a newer version of {tthw-langshort}?*
 +

--- a/products/softwarecollections/_includes/get-started-rhel7-prereq.adoc
+++ b/products/softwarecollections/_includes/get-started-rhel7-prereq.adoc
@@ -4,7 +4,7 @@ Introduction and Prerequisites
 ## Prerequisites section
 In this tutorial, you will set your system up to install software from Red Hat Software Collections (RHSCL), which provides the latest development technologies for Red Hat Enterprise Linux. Then, you will install {tthw-langlong} and run a simple “Hello, World” application. The whole tutorial should take less than 10 minutes to complete.
 
-Before you begin, you will need a current Red Hat Enterprise Linux {tthw-rhelver} server or workstation subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through link:#{site.base_url}/[developers.redhat.com].
+Before you begin, you will need a current Red Hat Enterprise Linux {tthw-rhelver} server or workstation subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by {tthw-download-manager}/download-manager/link/1350474[registering and downloading] through link:{tthw-site-base-url}/[developers.redhat.com]. 
 
 If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
 

--- a/products/softwarecollections/_includes/get-started-rhscl-faq.adoc
+++ b/products/softwarecollections/_includes/get-started-rhscl-faq.adoc
@@ -5,7 +5,7 @@
 
 . *As a developer, how can I get a Red Hat Enterprise Linux subscription that includes Red Hat Software Collections?*
 +
-Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by {tthw-download-manager}/download-manager/link/1350474[registering and downloading] through developers.redhat.com. We recommend you follow our link:{tthw-site-base-url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt. For more information, see link:{tthw-site-base-url}/articles/no-cost-rhel-faq/[Frequently asked questions: no-cost Red Hat Enterprise Linux Developer Suite].
+Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by {tthw-download-manager}/download-manager/link/1350474[registering and downloading] through link:{tthw-site-base-url}/[developers.redhat.com]. We recommend you follow our link:{tthw-site-base-url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt. For more information, see link:{tthw-site-base-url}/articles/no-cost-rhel-faq/[Frequently asked questions: no-cost Red Hat Enterprise Linux Developer Suite].
 
 . *I can't find the RHSCL repository on my system*.
 +

--- a/products/softwarecollections/_includes/get-started-rhscl-more-resources.adoc
+++ b/products/softwarecollections/_includes/get-started-rhscl-more-resources.adoc
@@ -7,11 +7,11 @@
 link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection 2.2 Documentation]:
 
 * link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Release Notes]
-* link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/html-single/2.2_Release_Notes/index.html[Red Hat Software Collections 2.2 Packaging Guide]
+* link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/html-single/Packaging_Guide/index.html[Red Hat Software Collections 2.2 Packaging Guide]
 
 _Developers should read the packaging guide to get a more complete understanding of how software collections work, and how to deliver software that uses RHSCL._
 
 ### Become a Red Hat developer: developers.redhat.com
 
-Red Hat delivers the resources and ecosystem of experts to help you be more productive and build great solutions.  Register for free at link:#{site.base_url}/[developers.redhat.com].
+Red Hat delivers the resources and ecosystem of experts to help you be more productive and build great solutions.  Register for free at link:{tthw-site-base-url}/[developers.redhat.com].
 


### PR DESCRIPTION
Fixes DEVELOPER-3432, which is also github issue #1366, the awestruct macros for site base and download manager were not being interpreted correctly.