### PR TITLE
[DEVELOPER-3445] Fixes for Drupal pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Red Hat Developers Site!
+# Red Hat Developers Site
 
 Powering the [Red Hat Developers site](http://developers.redhat.com/).
 

--- a/_docker/export/Dockerfile
+++ b/_docker/export/Dockerfile
@@ -18,5 +18,6 @@ RUN mkdir -p mkdir /export && chown jenkins_developer:jenkins_developer /export
 USER jenkins_developer
 ENV GEM_HOME /home/jenkins_developer/gems
 RUN mkdir -p /home/jenkins_developer/gems
-RUN gem install nokogiri -v 1.5.10
+RUN gem install nokogiri:1.5.10 \
+    octokit:4.0
 WORKDIR /home/jenkins_developer/developer.redhat.com

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -35,7 +35,6 @@ class Options
       opts.on('--export [EXPORT_LOCATION]', String, 'Export all content from Drupal within the environment and rsync it to EXPORT_LOCATION') do | export_location |
         tasks[:build] = true
         tasks[:awestruct_command_args] = ['--rm', 'export']
-        tasks[:supporting_services] = []
         if !export_location.nil? && !export_location.empty?
           tasks[:awestruct_command_args] << export_location
         end


### PR DESCRIPTION
Small changes to ensure that Drupal pull requests can work.

1. Needed to install the octokit Gem into the export container as a dependency which running the export with the GitHub status wrapper
2. Ensured that we bind all required environment variables when running the export in the PR environments.