### PR TITLE
[DEVELOPER-3356] Fix incorrect bind-mount location for Drupal config 

### DIFF
--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
-      - /data/drupal/config:/var/www/drupal/config/active
+      - /data/drupal/config:/var/www/drupal/web/config/active
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
     environment:

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
-      - /data/drupal/config:/var/www/drupal/config/active
+      - /data/drupal/config:/var/www/drupal/web/config/active
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
     environment:


### PR DESCRIPTION
This PR fixes the bind-mount location for the active configuration directory in Drupal in both staging and production environments.