### PR TITLE
Update the .NET Getting Started guide to match the other guides

### DIFF
--- a/products/dotnet/get-started.adoc
+++ b/products/dotnet/get-started.adoc
@@ -11,21 +11,21 @@ Enable .NET Core Repository
 2 minutes
 
 ## Step2 Title
-Setup your development environment
+Set Up Your Development Environment
 
 ## Step3 Duration
 2 minutes
 
 ## Step3 Title
-Hello World and your first application
+Hello World and Your First Application
 
 ## Prerequisites section title
 Introduction and Prerequisites
 
 ## Prerequisites section
-In this tutorial, you will set your system up to install software from the Red Hat .NET repository, which provides the latest versions of .NET Core for Red Hat Enterprise Linux. Then, you will install .NET Core and run a simple "Hello, World" application. The whole tutorial should take less than 10 minutes to complete.
+In this tutorial, you will set up your system to install software from the Red Hat .NET repository, which provides the latest versions of .NET Core for Red Hat Enterprise Linux. You will install .NET Core and run a simple "Hello, World" application. The tutorial should take less than 10 minutes to complete.
 
-Before you begin, you will need a current Red Hat Enterprise Linux 7 server subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite Subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474/[registering and downloading] through link:#{site.base_url}/[developers.redhat.com].
+Before you begin, you will need a current Red Hat Enterprise Linux 7 Server subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite Subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474/[registering and downloading] through link:#{site.base_url}/[developers.redhat.com].
 
 Using VirtualBox? You’ll find instructions #{site.base_url}/products/rhel/get-started/#tab-virtualbox[here]. Hyper-V? Your instructions are #{site.base_url}/products/rhel/get-started/#tab-hyper-v[here]. VMWare? #{site.base_url}/products/rhel/get-started/#tab-vmware[Here] is your link. KVM users, #{site.base_url}/products/rhel/get-started/#tab-kvm[this way], please. Finally, yes, you can install on bare metal if you wish. #{site.base_url}/products/rhel/get-started/#tab-bare-metal[Here] is your page.
 
@@ -33,14 +33,14 @@ If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
 
 ## Step1 Content
 
-In this step you will configure your system to obtain software, including the latest .NET Core from the .NET software repository. Instructions are provided for both the command line (CLI) and graphical user interface (GUI).
+In this step, you will configure your system to obtain software, including the latest .NET Core from the .NET software repository. Instructions are provided for both the command line interface (CLI) and the graphical user interface (GUI).
 
 ### Using the Red Hat Subscription Manager GUI
 
 Start _Red Hat Subscription Manager_ using the _System Tools_ group of the _Applications_ menu. Alternatively, you can start it from the command prompt by typing `subscription-manager-gui`.
 
 . Select _Repositories_ from the _System_ menu of the subscription manager.
-. In the list of repositories, check the _Enabled_ column for _rhel-7-server-dotnet-rpms_. Note: After clicking, it might take several seconds for the check mark to appear in the enabled column.
+. In the list of repositories, check the _Enabled_ column for _rhel-7-server-dotnet-rpms_. Note: After clicking, it might take several seconds for the checkmark to appear in the enabled column.
 
 If you don’t see any .NET Core repositories in the list, your subscription might not include it. See <<troubleshooting,Troubleshooting and FAQ>> for more information. +
 
@@ -59,7 +59,7 @@ If you don’t see any .NET repositories in the list, your subscription might no
 
 [listing,subs="attributes"]
 ----
-# subscription-manager repos --enable rhel-7-server-dotnet-rpms
+# subscription-manager repos --enable=rhel-7-server-dotnet-rpms
 ----
 
 ## Step2 Content
@@ -87,7 +87,7 @@ First, run `dotnet new`. This will create the C# source code for the “Hello wo
 
 Next, run `dotnet restore`. This will fetch all the necessary dependency libraries.
 
-Finally, run `dotnet run`. This will build and run the application. Note that you can run `dotnet build` first if you wish, but it’s not necessary for this simple console application. In the future, you’ll use `dotnet build` with command line options to do things such as build self-contained applications; apps that can be copied and run without any need to first install .NET Core.
+Finally, run `dotnet run`. This will build and run the application. Note that you can run `dotnet build` first if you wish, but it’s not necessary for this simple console application. In the future, you’ll use `dotnet build` with command line options to do things such as build self-contained applications, that is, apps that can be copied and run without any need to first install .NET Core.
 
 ### Working with .NET Core packages
 

--- a/products/dotnet/get-started.adoc
+++ b/products/dotnet/get-started.adoc
@@ -1,53 +1,207 @@
 :awestruct-layout: product-get-started-dotnet
 :awestruct-interpolate: true
 
+## Step1 Duration
+2 minutes
+
 ## Step1 Title
-Download Red Hat Enterprise Linux (RHEL)
+Enable .NET Core Repository
+
+## Step2 Duration
+2 minutes
 
 ## Step2 Title
-Install RHEL
+Setup your development environment
+
+## Step3 Duration
+2 minutes
 
 ## Step3 Title
-Install .NET Core 1.0 on your RHEL machine or VM
+Hello World and your first application
 
-## Step4 Title
-Build the Hello World app
+## Prerequisites section title
+Introduction and Prerequisites
+
+## Prerequisites section
+In this tutorial, you will set your system up to install software from the Red Hat .NET repository, which provides the latest versions of .NET Core for Red Hat Enterprise Linux. Then, you will install .NET Core and run a simple "Hello, World" application. The whole tutorial should take less than 10 minutes to complete.
+
+Before you begin, you will need a current Red Hat Enterprise Linux 7 server subscription that allows you to download software and get updates from Red Hat. Developers can get a no-cost Red Hat Enterprise Linux Developer Suite Subscription for development purposes by link:#{site.download_manager_base_url}/download-manager/link/1350474/[registering and downloading] through link:#{site.base_url}/[developers.redhat.com].
+
+Using VirtualBox? You’ll find instructions #{site.base_url}/products/rhel/get-started/#tab-virtualbox[here]. Hyper-V? Your instructions are #{site.base_url}/products/rhel/get-started/#tab-hyper-v[here]. VMWare? #{site.base_url}/products/rhel/get-started/#tab-vmware[Here] is your link. KVM users, #{site.base_url}/products/rhel/get-started/#tab-kvm[this way], please. Finally, yes, you can install on bare metal if you wish. #{site.base_url}/products/rhel/get-started/#tab-bare-metal[Here] is your page.
+
+If you need help, see <<troubleshooting,Troubleshooting and FAQ>>.
 
 ## Step1 Content
 
-If you don’t have access to a development machine running RHEL, you can get a no-cost Developer’s Edition. For the download, you will need to register with developers.redhat.com (don’t fret; no credit card information is required). After you register as a developer, you will be given a subscription for Red Hat Enterprise Linux Developer Suite.
+In this step you will configure your system to obtain software, including the latest .NET Core from the .NET software repository. Instructions are provided for both the command line (CLI) and graphical user interface (GUI).
 
-(Keep the username and password you use to register handy; you’ll need it later.)
+### Using the Red Hat Subscription Manager GUI
 
-Download the https://developers.redhat.com/download-manager/file/rhel-server-7.2-x86_64-dvd.iso[Red Hat Enterprise Linux Server DVD] .iso file.
+Start _Red Hat Subscription Manager_ using the _System Tools_ group of the _Applications_ menu. Alternatively, you can start it from the command prompt by typing `subscription-manager-gui`.
+
+. Select _Repositories_ from the _System_ menu of the subscription manager.
+. In the list of repositories, check the _Enabled_ column for _rhel-7-server-dotnet-rpms_. Note: After clicking, it might take several seconds for the check mark to appear in the enabled column.
+
+If you don’t see any .NET Core repositories in the list, your subscription might not include it. See <<troubleshooting,Troubleshooting and FAQ>> for more information. +
+
+
+### Using subscription-manager from the command line
+
+You can add or remove software repositories from the command line using the `subscription-manager` tool as the root user. Use the `--list` option to view the available software repositories and verify that you have access to .NET:
+
+[listing,subs="attributes"]
+----
+$ su -
+# subscription-manager repos --list | egrep dotnet
+----
+
+If you don’t see any .NET repositories in the list, your subscription might not include it. See <<troubleshooting,Troubleshooting and FAQ>> for more information.
+
+[listing,subs="attributes"]
+----
+# subscription-manager repos --enable rhel-7-server-dotnet-rpms
+----
 
 ## Step2 Content
 
-Decide which development environment you wish to use. http://developers.redhat.com/blog/2016/05/17/net-on-linux-which-environment/#more-422109[This blog post] may help.
+Next step, install .NET Core 1.0:
 
-Using VirtualBox? You’ll find instructions #{site.base_url}/products/rhel/get-started/#tab-virtualbox[here].
-Hyper-V? Your instructions are #{site.base_url}/products/rhel/get-started/#tab-hyper-v[here].
-VMWare? #{site.base_url}/products/rhel/get-started/#tab-vmware[Here] is your link.
-KVM users, #{site.base_url}/products/rhel/get-started/#tab-kvm[this way], please.
-Finally, yes, you can install on bare metal if you wish. #{site.base_url}/products/rhel/get-started/#tab-bare-metal[Here] is your page.
+[listing,subs="attributes"]
+----
+$ su -
+# yum install rh-dotnetcore10
+----
 
 ## Step3 Content
 
-To install .NET Core on Red Hat Enterprise Linux, run the following commands:
+Under your normal user ID, start a _Terminal_ window. First, use `scl
+enable` to add .NET Core 1.0 to your environment, then run `dotnet --version` to see the version number:
 
-1. `sudo subscription-manager repos --enable=rhel-7-server-dotnet-rpms`
-2. `sudo yum install -y scl-utils`
-3. `sudo yum install -y rh-dotnetcore10`
-4. `sudo scl enable rh-dotnetcore10 bash`
+[listing,subs="attributes"]
+----
+$ scl enable rh-dotnetcore10 bash
+$ dotnet --version
+----
 
-You can verify your installation by running `dotnet --version` from the command line.
+First, run `dotnet new`. This will create the C# source code for the “Hello world” app. You can look around the source code and all the generated files to get a sense of what’s necessary to support a .NET Core application.
 
-## Step4 Content
-
-You’re only three steps away from creating and running your first app, the “Hello world” app.
-
-First, run `dotnet new`. This will create the source code for the “Hello world” app. You can look around the source code and all the generated files to get a sense of what’s necessary to support a .NET Core application.
-
-Next, run `dotnet restore`. This will fetch all the necessary dependency libraries (DLLs) from NuGet.org.
+Next, run `dotnet restore`. This will fetch all the necessary dependency libraries.
 
 Finally, run `dotnet run`. This will build and run the application. Note that you can run `dotnet build` first if you wish, but it’s not necessary for this simple console application. In the future, you’ll use `dotnet build` with command line options to do things such as build self-contained applications; apps that can be copied and run without any need to first install .NET Core.
+
+### Working with .NET Core packages
+
+The .NET Core software packages are designed to allow multiple versions of software to be installed concurrently. To accomplish this, the desired package is added to your runtime environment as needed with the `scl enable` command. When `scl enable` runs, it modifies environment variables and then runs the specified command. The environmental changes only affect the command that is run by `scl` and any processes that are run from that command. The steps in this tutorial run the command `bash` to start a new interactive shell to work in the updated environment. The changes aren’t permanent. Typing `exit` will return to the original shell with the original environment. Each time you login, or start a new terminal session, `scl enable` needs to be run again.
+
+While it is possible to change the system profile to make .NET Core packages part of the system’s global environment, this is not recommended. Doing this can cause conflicts and unexpected problems with other applications because the system version of the package is obscured by having the other version in the path first.
+
+
+#### Permanently enable .NET Core in your development environment
+
+To make the .NET Core packages a permanent part of your development environment, you can add it to the login script for your specific user ID. this is the recommend approach for development as only processes run under your user ID will be affected.
+
+Using your preferred text editor, add the following line to your `~/.bashrc`:
+
+.~/.bashrc
+[listing,subs="attributes"]
+----
+# Add .NET Core 1.0 to my login environment
+source scl_source enable rh-dotnetcore10
+----
+
+After making the change, you should log out and log back in again.
+
+When you deliver an application that uses .NET Core packages, a best practice is to have your startup script handle the `scl enable` step for your application. You should not ask your users to change their environment as this is likely to create conflicts with other applications.
+
+### Where to go next?
+
+
+*.NET Core Documentation at docs.microsoft.com* +
+link:https://docs.microsoft.com/en-us/dotnet/articles/core/index[]
+
+*Find additional .NET Core packages* +
+[listing,subs="attributes"]
+----
+$ yum list available rh-dotnetcore10\*
+----
+
+*View the full list of packages* +
+[listing,subs="attributes"]
+----
+$ yum --disablerepo="*" --enablerepo="rhel-7-server-dotnet-rpms" list available
+----
+
+// This content goes inside the box: "Want to know more?"
+
+## More Resources
+[[dotnetdocs]]
+
+link:https://access.redhat.com/documentation/en/net-core/[Red Hat .NET Core 1.0 Documentation]:
+
+* link:https://access.redhat.com/documentation/en/net-core/1.0/getting-started-guide/getting-started-guide[Red Hat .NET Core 1.0 Getting Started Guide]
+* link:https://access.redhat.com/documentation/en/net-core/1.0/release-notes/release-notes[Red Hat .NET Core 1.0 Release Notes]
+
+### Become a Red Hat developer: developers.redhat.com
+
+Red Hat delivers the resources and ecosystem of experts to help you be more productive and build great solutions.  Register for free at link:#{site.base_url}/[developers.redhat.com].
+
+
+## Faq section title
+[[troubleshooting]]Troubleshooting and FAQ
+
+## Faq section
+
+. *As a developer, how can I get a Red Hat Enterprise Linux subscription that includes .NET Core?*
++
+Developers can get a no-cost Red Hat Enterprise Linux Developer Suite subscription for development purposes by #{site.download_manager_base_url}/download-manager/link/1350474[registering and downloading] through developers.redhat.com. We recommend you follow our link:#{site.base_url}/products/rhel/get-started/[Getting Started Guide] which covers downloading and installing Red Hat Enterprise Linux on a physical system or virtual machine (VM) using your choice of VirtualBox, VMware, Microsoft Hyper-V, or Linux KVM/Libvirt. For more information, see link:#{site.base_url}/articles/no-cost-rhel-faq/[Frequently asked questions: no-cost Red Hat Enterprise Linux Developer Suite].
+
+. *I can't find the .NET Core repository on my system*.
++
+Some Red Hat Enterprise Linux subscriptions do not include access to .NET Core.
++
+The name of the repository depends on whether you have a server or workstation version of Red Hat Enterprise Linux installed. You can use `subscription-manager` to view the available software repositories and verify that you have access to .NET Core for Red Hat Enterprise Linux:
++
+[listing,subs="attributes"]
+----
+$ su -
+# subscription-manager repos --list | egrep dotnet
+----
+
+. *Can I use .NET Core in containers?*
++
+Yes, .NET Core is available as a docker-formatted container image from the Red Hat Container Registry. Get started guides for building your first container are available on link:#{site.base_url}/[developers.redhat.com].
+
+. *Is there an open-source community for .NET Core?*
++
+*How can I contribute or get involved with .NET Core?*
++
+The open source community that is the upstream for .NET Core can be found at link:https://github.com/dotnet/core[github.com/dotnet/core].
+
+. *I’ve installed rh-dotnetcore10 but `dotnet` is not in my path.*
++
+*I can’t find the `dotnet` command.*
++
+.NET Core for Red Hat Enterprise Linux does not alter the system path. You need to use `scl enable` to change the environment for your session:
++
+[listing,subs="attributes"]
+----
+$ scl enable rh-dotnetcore10 bash
+----
++
+For more information see the link:https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/2/index.html[Red Hat Software Collection documentation].
+
+. *When I try to run `dotnet`, I get an error about a missing shared library.*
++
+This is due to not having run `scl enable` first. When `scl enable` runs, in addition to setting up the command search PATH, it also sets up the search path for shared libraries, LD_LIBRARY_PATH.
+
+. *How do I uninstall .NET Core and any dependencies?*
++
+Uninstalling the `rh-dotnetcore10-runtime` package will cause the dependent packages that are no longer needed to be removed.
++
+[listing,subs="attributes"]
+----
+# yum uninstall rh-dotnetcore10-runtime
+----
+. *Some .NET/C# code/examples I’ve tried don’t work with .NET Core.*
++
+.NET Core 1.0 is a new version of the .NET framework that is incompatible with the previous .NET 2.x, 3.x and 4.x series frameworks. There is a large amount of code written for .NET that will not run without modification on .NET Core.


### PR DESCRIPTION
This updates the .NET Getting Started guide to match the style, language and steps used in other guides.

Specifically:
- Let the users use either the GUI or CLI from Subcription Manager
- Don't use sudo (which doesn't work out of the box in all versions of RHEL)
- Mention how `scl` work and how to enable the collection generally
- Add links to upstream repositories and documentation