### PR TITLE
[DEVELOPER-3445] Added the --no-kill option to control.rb 

### DIFF
--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -128,6 +128,14 @@ class Options
         tasks[:decrypt] = false
       end
 
+      #
+      # Required during the transition to Drupal PR building. As the Drupal PR job is a downstream of the current
+      # PR job, we don't want to kill any environment that is currently running.
+      #
+      opts.on('--no-kill','Do not attempt to stop the currently running environment (if any)') do
+        tasks[:kill_all] = false
+      end
+
 
       # No argument, shows at tail.  This will print an options summary.
       opts.on_tail('-h', '--help', 'Show this message') do

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -8,6 +8,11 @@ class TestOptions < Minitest::Test
     assert_equal (4+1), 5
   end
 
+  def test_run_the_stack_with_no_kill
+    tasks = Options.parse(['--run-the-stack', '--no-kill'])
+    refute(tasks[:kill_all])
+  end
+
   def test_export_with_no_explicit_destination
     tasks = Options.parse(['--export'])
     assert(tasks[:build])


### PR DESCRIPTION
This PR adds a '--no-kill' option to control.rb that prevents it from killing the currently running environment. This is required during the transition to Drupal PR building so that any environment started by the current PR job is left intact and not destroyed.