### PR TITLE
Fixes DEVELOPER-3348 - Link to user account information page does not work

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
@@ -108,7 +108,7 @@ function rhd_js_settings_alter(array &$settings, \Drupal\Core\Asset\AttachedAsse
 
     $rhd_settings['keycloak'] = array();
     $rhd_settings['keycloak']['accountUrl'] = $env_settings->get('keycloak')['accountUrl'];
-    $rhd_settings['keycloak']['authUrl'] = $env_settings->get('keycloak')['accountUrl'];
+    $rhd_settings['keycloak']['authUrl'] = $env_settings->get('keycloak')['authUrl'];
 
     $theme_path = drupal_get_path('theme', 'rhd');
 

--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -4,7 +4,7 @@ downloadManager:
   baseUrl: 'https://developers.stage.redhat.com'
   fileBaseUrl: '//developers.stage.redhat.com/download-manager/file/'
 keycloak:
-  accountUrl: 'https://developers.stage.redhat.com/auth/'
+  accountUrl: 'https://developers.stage.redhat.com/auth/realms/rhd/account/'
   authUrl: 'https://developers.stage.redhat.com/auth/'
 drupal:
   host: docker


### PR DESCRIPTION
Please see https://issues.jboss.org/browse/DEVELOPER-3448 for full
information.

I've added the correct location for the account url and also fixed a bug
I had in drupal for which value to use. I've also made the corresponding
changes in prod and staging.