### PR TITLE
[DEVELOPER-3460] Updated rollback locations for staging and production

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -277,7 +277,7 @@
   {#{% if (rhd_dtm_code) %}#}
     {#<script src="{{rhd_dtm_code}}"></script>#}
   {#{% endif %}#}
-  {#{# I REALLY think this should be at the bottom of the page #}#}
+  {#{# I REALLY think this should be at the bottom of the page #}
   {#{% if (rhd_dtm_code) %}#}
     {#<script type="text/javascript">_satellite.pageBottom();</script>#}
   {#{% endif %}#}

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -88,7 +88,7 @@ services:
      args:
       http_proxy: proxy01.util.phx2.redhat.com:8080
       https_proxy: proxy01.util.phx2.redhat.com:8080
-    entrypoint: "ruby _docker/lib/rollback/rollback.rb rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/drupal/production"
+    entrypoint: "ruby _docker/lib/rollback/rollback.rb rhd@filemgmt.jboss.org:/www_htdocs/it-rhd-drupal"
     volumes:
      - /data/drupal-export:/export
      - /credentials/rsync:/home/awestruct/.ssh

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -70,7 +70,7 @@ services:
      args:
       http_proxy: proxy01.util.phx2.redhat.com:8080
       https_proxy: proxy01.util.phx2.redhat.com:8080
-    entrypoint: "ruby _docker/lib/rollback/rollback.rb rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/drupal/staging"
+    entrypoint: "ruby _docker/lib/rollback/rollback.rb rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg-main-drupal"
     volumes:
      - /data/drupal-export:/export
      - /credentials/rsync:/home/awestruct/.ssh


### PR DESCRIPTION
This PR updates the rollback rsync locations for the staging and production environments to their correct long-term locations.

It also removes the erroneous `#}` at the bottom of each Drupal page as I just noticed it hadn't been fixed.