### PR TITLE
[DEVELOPER-3464] Support HTTPS for site export

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
@@ -103,7 +103,7 @@ function rhd_js_settings_alter(array &$settings, \Drupal\Core\Asset\AttachedAsse
 
     $rhd_settings['downloadManager'] = array();
     $rhd_settings['downloadManager']['baseUrl'] = $env_settings->get('downloadManager')['baseUrl'];
-    $rhd_settings['dcp']['baseProtocolRelativeUrl'] = "http://" . $env_settings->get('searchisko')['host'] . ":"
+    $rhd_settings['dcp']['baseProtocolRelativeUrl'] = $env_settings->get('searchisko')['protocol'] . "://" . $env_settings->get('searchisko')['host'] . ":"
         . $env_settings->get('searchisko')['port'];
 
     $rhd_settings['keycloak'] = array();

--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -10,6 +10,7 @@ drupal:
   host: docker
   port: "80"
 searchisko:
+  protocol: 'http'
   host: docker
   port: "8080"
   baseProtocolRelativeUrl: 'docker:8080'

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -9,6 +9,7 @@ drupal:
   host: stumpjumper.lab4.eng.bos.redhat.com
   port: "<%=ENV['DRUPAL_HOST_PORT']%>"
 searchisko:
+  protocol: 'http'
   host: stumpjumper.lab4.eng.bos.redhat.com
   port: "<%=ENV['SEARCHISKO_HOST_PORT']%>"
   baseProtocolRelativeUrl: 'stumpjumper.lab4.eng.bos.redhat.com:<%=ENV['SEARCHISKO_HOST_PORT']%>'


### PR DESCRIPTION
This PR adds the ability to define the protocol over which the DCP should be accessed. This means that environments that need to support HTTPS, can be configured to use the HTTPS endpoint of the DCP to avoid browser security warnings.