### PR TITLE
[DEVELOPER-3465] Switch Dev and PR builds to use staging DCP

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -96,11 +96,14 @@ profiles:
     base_url: http://docker/
     dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     drupal_base_url: http://drupal/
+    push_to_searchisko: false
 
   drupal_pull_request:
     <<: *docker
     base_url: http://stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>/
-    dcp_base_protocol_relative_url: //stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
+    dcp_base_url: http://dcp.stage.jboss.org/
+    dcp_base_protocol_relative_url: //dcp.stage.jboss.org/
+    push_to_searchisko: false
     drupal_base_url: http://drupal/
 
   drupal_staging:

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -83,7 +83,7 @@ profiles:
     push_to_searchisko: true
     broker: https://broker.stage.redhat.com/partner/drc/userMapping?redirect=
 
-  drupal_dev:
+  drupal_dev_local_dcp:
     <<: *docker
     base_url: http://docker/
     dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -90,13 +90,15 @@ profiles:
     base_url: http://docker/
     dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     drupal_base_url: http://drupal/
+    push_to_searchisko: false
+
 
   drupal_dev_local_dcp:
     <<: *docker
     base_url: http://docker/
     dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
     drupal_base_url: http://drupal/
-    push_to_searchisko: false
+    push_to_searchisko: true
 
   drupal_pull_request:
     <<: *docker

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -83,6 +83,14 @@ profiles:
     push_to_searchisko: true
     broker: https://broker.stage.redhat.com/partner/drc/userMapping?redirect=
 
+  drupal_dev:
+    <<: *docker
+    dcp_base_url: http://dcp.stage.jboss.org/
+    dcp_base_protocol_relative_url: //dcp.stage.jboss.org/
+    base_url: http://docker/
+    dcp_base_protocol_relative_url: //docker:<%= ENV['SEARCHISKO_HOST_PORT'] %>/
+    drupal_base_url: http://drupal/
+
   drupal_dev_local_dcp:
     <<: *docker
     base_url: http://docker/

--- a/_docker/environments/drupal-dev-local-dcp/apache/httpd-vhosts.conf
+++ b/_docker/environments/drupal-dev-local-dcp/apache/httpd-vhosts.conf
@@ -1,0 +1,18 @@
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass / http://docker/
+    ProxyPassReverse / http://docker/
+    ServerName docker
+</VirtualHost>
+
+<VirtualHost *:9000>
+    DocumentRoot "/usr/local/apache2/htdocs/docker"
+    DirectoryIndex index.html
+
+    <Directory "/usr/local/apache2/htdocs/docker">
+            Options Indexes FollowSymLinks Includes
+            AllowOverride All
+            Order allow,deny
+            Allow from all
+    </Directory>
+</VirtualHost>

--- a/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
+++ b/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
@@ -1,0 +1,494 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot "/usr/local/apache2"
+
+#
+# Mutex: Allows you to set the mutex mechanism and mutex file directory
+# for individual mutexes, or change the global defaults
+#
+# Uncomment and change the directory if mutexes are file-based and the default
+# mutex file directory is not on a local disk or is not appropriate for some
+# other reason.
+#
+# Mutex default:logs
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, instead of the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses.
+#
+#Listen 12.34.56.78:80
+Listen 80
+Listen 9000
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule authn_file_module modules/mod_authn_file.so
+#LoadModule authn_dbm_module modules/mod_authn_dbm.so
+#LoadModule authn_anon_module modules/mod_authn_anon.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule authn_socache_module modules/mod_authn_socache.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+#LoadModule authz_dbm_module modules/mod_authz_dbm.so
+#LoadModule authz_owner_module modules/mod_authz_owner.so
+#LoadModule authz_dbd_module modules/mod_authz_dbd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+#LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+#LoadModule auth_form_module modules/mod_auth_form.so
+#LoadModule auth_digest_module modules/mod_auth_digest.so
+#LoadModule allowmethods_module modules/mod_allowmethods.so
+#LoadModule file_cache_module modules/mod_file_cache.so
+#LoadModule cache_module modules/mod_cache.so
+#LoadModule cache_disk_module modules/mod_cache_disk.so
+#LoadModule cache_socache_module modules/mod_cache_socache.so
+#LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+#LoadModule socache_dbm_module modules/mod_socache_dbm.so
+#LoadModule socache_memcache_module modules/mod_socache_memcache.so
+#LoadModule macro_module modules/mod_macro.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule buffer_module modules/mod_buffer.so
+#LoadModule ratelimit_module modules/mod_ratelimit.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+#LoadModule ext_filter_module modules/mod_ext_filter.so
+#LoadModule request_module modules/mod_request.so
+#LoadModule include_module modules/mod_include.so
+LoadModule filter_module modules/mod_filter.so
+#LoadModule substitute_module modules/mod_substitute.so
+#LoadModule sed_module modules/mod_sed.so
+#LoadModule deflate_module modules/mod_deflate.so
+LoadModule mime_module modules/mod_mime.so
+#LoadModule ldap_module modules/mod_ldap.so
+LoadModule log_config_module modules/mod_log_config.so
+#LoadModule log_debug_module modules/mod_log_debug.so
+#LoadModule logio_module modules/mod_logio.so
+LoadModule env_module modules/mod_env.so
+#LoadModule expires_module modules/mod_expires.so
+LoadModule headers_module modules/mod_headers.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+#LoadModule remoteip_module modules/mod_remoteip.so
+#LoadModule proxy_module modules/mod_proxy.so
+#LoadModule proxy_connect_module modules/mod_proxy_connect.so
+#LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+#LoadModule proxy_http_module modules/mod_proxy_http.so
+#LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+#LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
+#LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+#LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+#LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+#LoadModule proxy_express_module modules/mod_proxy_express.so
+#LoadModule session_module modules/mod_session.so
+#LoadModule session_cookie_module modules/mod_session_cookie.so
+#LoadModule session_crypto_module modules/mod_session_crypto.so
+#LoadModule session_dbd_module modules/mod_session_dbd.so
+#LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+#LoadModule ssl_module modules/mod_ssl.so
+#LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
+#LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
+#LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
+#LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
+LoadModule unixd_module modules/mod_unixd.so
+#LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+#LoadModule info_module modules/mod_info.so
+#LoadModule cgid_module modules/mod_cgid.so
+#LoadModule dav_fs_module modules/mod_dav_fs.so
+#LoadModule vhost_alias_module modules/mod_vhost_alias.so
+#LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+#LoadModule actions_module modules/mod_actions.so
+#LoadModule speling_module modules/mod_speling.so
+#LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+<IfModule unixd_module>
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User daemon
+Group daemon
+
+</IfModule>
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin you@example.com
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+#ServerName www.example.com:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/usr/local/apache2/htdocs"
+<Directory "/usr/local/apache2/htdocs">
+    #
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+    #
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
+
+    #
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   AllowOverride FileInfo AuthConfig Limit
+    #
+    AllowOverride None
+
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog /proc/self/fd/2
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    CustomLog /proc/self/fd/1 common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    #CustomLog "logs/access_log" combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+#
+# "/usr/local/apache2/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig conf/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    #AddType text/html .shtml
+    #AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+#MIMEMagicFile conf/magic
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# MaxRanges: Maximum number of Ranges in a request before
+# returning the entire resource, or one of the special
+# values 'default', 'none' or 'unlimited'.
+# Default setting is to accept 200 Ranges.
+#MaxRanges unlimited
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+#EnableSendfile on
+
+# Supplemental configuration
+#
+# The configuration files in the conf/extra/ directory can be 
+# included to add extra features or to modify the default configuration of 
+# the server, or you may simply copy their contents here and change as 
+# necessary.
+
+# Server-pool management (MPM specific)
+#Include conf/extra/httpd-mpm.conf
+
+# Multi-language error messages
+#Include conf/extra/httpd-multilang-errordoc.conf
+
+# Fancy directory listings
+#Include conf/extra/httpd-autoindex.conf
+
+# Language settings
+#Include conf/extra/httpd-languages.conf
+
+# User home directories
+#Include conf/extra/httpd-userdir.conf
+
+# Real-time info on requests and configuration
+#Include conf/extra/httpd-info.conf
+
+# Virtual hosts
+Include conf/extra/httpd-vhosts.conf
+
+# Local access to the Apache HTTP Server Manual
+#Include conf/extra/httpd-manual.conf
+
+# Distributed authoring and versioning (WebDAV)
+#Include conf/extra/httpd-dav.conf
+
+# Various default settings
+#Include conf/extra/httpd-default.conf
+
+# Configure mod_proxy_html to understand HTML4/XHTML1
+<IfModule proxy_html_module>
+Include conf/extra/proxy-html.conf
+</IfModule>
+
+# Secure (SSL/TLS) connections
+#Include conf/extra/httpd-ssl.conf
+#
+# Note: The following must must be present to support
+#       starting without SSL on platforms with no /dev/random equivalent
+#       but a statically compiled-in mod_ssl.
+#
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>

--- a/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
+++ b/_docker/environments/drupal-dev-local-dcp/apache/httpd.conf
@@ -115,10 +115,10 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
-#LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-#LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so

--- a/_docker/environments/drupal-dev-local-dcp/docker-compose.yml
+++ b/_docker/environments/drupal-dev-local-dcp/docker-compose.yml
@@ -1,0 +1,158 @@
+version: '2'
+services:
+  awestruct:
+    build: ../../awestruct
+    command:
+      - "rake git_setup clean gen[drupal_dev_local_dcp]"
+    links:
+      - drupal
+      - searchisko
+    volumes:
+      - ../../../:/home/awestruct/developer.redhat.com
+      - ../../awestruct/overlay/ssh-key:/home/awestruct/.ssh
+    environment:
+      - google_api_key
+      - dcp_user
+      - dcp_password
+      - vimeo_client_secret
+      - vimeo_access_token_secret
+      - vimeo_access_token
+      - cache_password
+      - cache_url
+      - site_base_path
+      - site_path_suffix
+      - cdn_prefix
+      - cache_user
+      - github_token
+      - drupal_user
+      - drupal_password
+      - ACCESSIBLE_SLAVE_IP
+      - SEARCHISKO_HOST_PORT
+      - DRUPAL_HOST_PORT
+      - DRUPAL_HOST_IP
+      - ghprbActualCommit
+      - github_status_api_token
+      - BUILD_URL
+
+  drupal:
+    build: ../../drupal
+    ports:
+      - "80:80"
+    links:
+      - drupalmysql
+      - searchisko
+    volumes:
+      - ./rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
+      - ./rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
+      - ../../drupal/drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
+      - ../../../images:/var/www/drupal/web/images:ro
+      - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
+
+  drupalmysql:
+    image: mariadb:10.0.15
+    environment:
+      - MYSQL_USER=drupal
+      - MYSQL_PASSWORD=drupal
+      - MYSQL_DATABASE=drupal
+      - MYSQL_ROOT_PASSWORD=superdupersecret
+    expose:
+      - "3306"
+
+  mysql:
+    build: ../../mysql
+    volumes:
+      - ../../mysql:/etc/mysql/conf.d
+    environment:
+      - MYSQL_DATABASE=searchisko
+      - MYSQL_USER=searchisko
+      - MYSQL_PASSWORD=searchisko
+      - MYSQL_ROOT_PASSWORD=superdupersecret
+    expose:
+      - "3306"
+
+  searchisko:
+    build: ../../searchisko
+    expose:
+     - "8080"
+    ports:
+     - "8080:8080"
+    environment:
+      - DB_NAME=searchisko
+      - DB_USER=searchisko
+      - DB_PASSWORD=searchisko
+    links:
+     - mysql
+
+  apache:
+   image: httpd:2.4.20
+   command: "sh -c 'rm -f /usr/local/apache2/htdocs/index.html && httpd-foreground'"
+   links:
+    - drupal:docker
+   expose:
+    - 80
+    - 9000
+   ports:
+    - "9000:9000"
+   volumes:
+    - export:/usr/local/apache2/htdocs
+    - ./apache/httpd.conf:/usr/local/apache2/conf/httpd.conf
+    - ./apache/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf
+
+  #
+  # Environment actions
+  #
+  export:
+    links:
+     - drupal:docker
+    build: ../../export
+    volumes:
+     - ../../../:/home/jenkins_developer/developer.redhat.com
+     - export:/export
+    entrypoint: "ruby _docker/lib/export/export.rb docker"
+
+  #
+  # Testing
+  #
+  unit_tests:
+   build: ../../awestruct
+   volumes:
+    - ../../../:/home/awestruct/developer.redhat.com
+   entrypoint: "bundle exec rake test"
+
+  acceptance_tests:
+    build: ../../awestruct
+    volumes:
+      - ../../../:/home/awestruct/developer.redhat.com
+    environment:
+      - ghprbActualCommit
+      - github_status_api_token
+      - PARALLEL_TEST
+      - CUCUMBER_TAGS
+      - SELENIUM_HOST=http://selhub:4444/wd/hub
+      - RHD_JS_DRIVER
+      - RHD_DOCKER_DRIVER
+      - BUILD_URL
+      - RHD_TEST_PROFILE
+
+  docker_chrome:
+   image: selenium/node-chrome-debug:2.53.0
+   volumes:
+    - /dev/shm:/dev/shm
+   links:
+    - apache:docker
+   environment:
+    - HUB_PORT_4444_TCP_ADDR=selhub
+    - DBUS_SESSION_BUS_ADDRESS=/dev/null
+   depends_on:
+    - selhub
+   ports:
+    - "5900"
+
+#
+# Volumes
+#
+volumes:
+ export:
+  driver: local
+

--- a/_docker/environments/drupal-dev-local-dcp/rhd.settings.php
+++ b/_docker/environments/drupal-dev-local-dcp/rhd.settings.php
@@ -1,0 +1,23 @@
+<?php
+use Symfony\Component\Yaml\Yaml;
+
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+$config['automated_cron.settings']['interval'] = 0;
+
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+$settings['extension_discovery_scan_tests'] = TRUE;
+
+if (file_exists(__DIR__ . '/rhd.settings.yml')) {
+  $yml_settings = Yaml::parse(file_get_contents(__DIR__ . "/rhd.settings.yml"));
+  $config['redhat_developers'] = $yml_settings;
+}
+
+$settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
+$settings['install_profile'] = 'standard';
+$config_directories['sync'] = 'sites/default/files/config_BbPlfGDu86LJqlRwhA9RbCf38VZMDijNF-owvfhuzVL73hk7BtWwy3kfIlqKLXeiSgTA-MHeVw/sync';
+

--- a/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
+++ b/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
@@ -1,0 +1,22 @@
+environment: dev
+broker: https://broker.staging.redhat.com/partner/drc/userMapping?redirect=
+downloadManager:
+  baseUrl: 'https://developers.stage.redhat.com'
+  fileBaseUrl: '//developers.stage.redhat.com/download-manager/file/'
+keycloak:
+  accountUrl: 'https://developers.stage.redhat.com/auth/'
+  authUrl: 'https://developers.stage.redhat.com/auth/'
+drupal:
+  host: docker
+  port: "80"
+searchisko:
+  host: docker
+  port: "8080"
+  baseProtocolRelativeUrl: 'docker:8080'
+database:
+  host:  drupalmysql
+  port: '3306'
+  username: 'drupal'
+  password: 'drupal'
+  name: 'drupal'
+

--- a/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
+++ b/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
@@ -11,6 +11,7 @@ drupal:
   port: "80"
 searchisko:
   host: docker
+  protocol: "http"
   port: "8080"
   baseProtocolRelativeUrl: 'docker:8080'
 database:
@@ -19,4 +20,3 @@ database:
   username: 'drupal'
   password: 'drupal'
   name: 'drupal'
-

--- a/_docker/environments/drupal-dev/apache/httpd.conf
+++ b/_docker/environments/drupal-dev/apache/httpd.conf
@@ -115,10 +115,10 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
-#LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-#LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so

--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -11,9 +11,9 @@ drupal:
   port: "80"
 searchisko:
   protocol: 'http'
-  host: docker
-  port: "8080"
-  baseProtocolRelativeUrl: 'docker:8080'
+  host: dcp.stage.jboss.org
+  port: "80"
+  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:80'
 database:
   host:  drupalmysql
   port: '3306'

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -10,9 +10,9 @@ drupal:
   port: "<%=ENV['DRUPAL_HOST_PORT']%>"
 searchisko:
   protocol: 'http'
-  host: stumpjumper.lab4.eng.bos.redhat.com
-  port: "<%=ENV['SEARCHISKO_HOST_PORT']%>"
-  baseProtocolRelativeUrl: 'stumpjumper.lab4.eng.bos.redhat.com:<%=ENV['SEARCHISKO_HOST_PORT']%>'
+  host: dcp.stage.jboss.org
+  port: "80"
+  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:80'
 database:
   host: drupalmysql
   port: '3306'

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -9,10 +9,10 @@ drupal:
   host: stumpjumper.lab4.eng.bos.redhat.com
   port: "<%=ENV['DRUPAL_HOST_PORT']%>"
 searchisko:
-  protocol: 'http'
+  protocol: 'https'
   host: dcp.stage.jboss.org
-  port: "80"
-  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:80'
+  port: "443"
+  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:443'
 database:
   host: drupalmysql
   port: '3306'

--- a/_docker/lib/rhd_environment.rb
+++ b/_docker/lib/rhd_environment.rb
@@ -121,7 +121,7 @@ class RhdEnvironment
     case @environment_name
       when 'awestruct-dev', 'awestruct-pull-request'
          supporting_services += %w(mysql searchisko)
-      when 'drupal-dev'
+      when 'drupal-dev', 'drupal-dev-local-dcp'
         supporting_services+= %w(apache mysql searchisko drupalmysql drupal)
       when 'drupal-pull-request'
          supporting_services+= %w(mysql searchisko drupalmysql drupal)

--- a/_docker/tests/test_rhd_environment.rb
+++ b/_docker/tests/test_rhd_environment.rb
@@ -125,6 +125,11 @@ class TestRhdEnvironment < MiniTest::Test
     assert_equal(%w(mysql searchisko), @environment.get_supporting_services)
   end
 
+  def test_supporting_services_drupal_dev_local_dcp
+    @environment.environment_name = 'drupal-dev-local-dcp'
+    assert_equal(%w(apache mysql searchisko drupalmysql drupal), @environment.get_supporting_services)
+  end
+
   def test_supporting_services_drupal_dev
     @environment.environment_name = 'drupal-dev'
     assert_equal(%w(apache mysql searchisko drupalmysql drupal), @environment.get_supporting_services)


### PR DESCRIPTION
Updates to environments:

drupal-dev-local-dcp: Uses local dockerized DCP, and pushes content to it.
drupal-pull-request: Uses dcp.stage.jboss.org, and does not push content to it.
drupal-dev: Uses dcp.stage.jboss.org, and does not push content to it.

This ensures the DCP content is available by default in development mode and in PR builds. In the case where local standalone DCP is required, the 'drupal-dev-local-dcp' environment can be used.