### PR TITLE
Fixes DEVELOPER-3480 (robots.txt missing)

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/robots.txt
+++ b/_docker/drupal/drupal-filesystem/web/robots.txt
@@ -57,3 +57,7 @@ Disallow: /index.php/user/password/
 Disallow: /index.php/user/register/
 Disallow: /index.php/user/login/
 Disallow: /index.php/user/logout/
+# auth and download-manager URLs do not need to be retrieved
+Disallow: /auth/
+Disallow: /download-manager/
+

--- a/_docker/lib/export/export.rb
+++ b/_docker/lib/export/export.rb
@@ -40,6 +40,9 @@ class Export
     @page_url_list_generator.save_sitemap(@page_url_list_generator.fetch_sitemap_contents,
                                           File.join(export_directory, 'sitemap.xml'))
 
+    @page_url_list_generator.save_robots(@page_url_list_generator.fetch_robots,
+                                         File.join(export_directory, 'robots.txt'))
+
     if !@rsync_destination.nil? and !@rsync_destination.empty?
       @rsync_handler.rsync_static_export(export_directory, @rsync_destination, true)
     else

--- a/_docker/tests/export/test_drupal_page_url_list_generator.rb
+++ b/_docker/tests/export/test_drupal_page_url_list_generator.rb
@@ -113,4 +113,23 @@ class TestDrupalPageUrlListGenerator < Minitest::Test
       assert_match %r{http://www\.sitemaps\.org/schemas/sitemap/0\.9}, urlset.namespace.href
     end
   end
+
+  def test_save_robots
+    # Mock setup
+    robots_contents = mock()
+    robots_contents.expects(:code).returns(200)
+    robots_contents.expects(:body).returns('')
+
+    Net::HTTP.expects(:get_response).with do | url |
+      assert_equal('http://192.168.99.100:32769/robots.txt', url.to_s)
+    end.returns(robots_contents)
+
+    # Execution
+    robots_contents = @drupal_page_list_url_generator.fetch_robots
+    robot_location = File.join(@export_directory, 'test', 'robots.txt')
+
+    @drupal_page_list_url_generator.save_robots(robots_contents, robot_location)
+
+    assert(File.exists?(robot_location))
+  end
 end

--- a/_docker/tests/export/test_export.rb
+++ b/_docker/tests/export/test_export.rb
@@ -25,6 +25,8 @@ class TestExport < MiniTest::Test
     @page_url_list_generator.expects(:generate_page_url_list!).returns(url_list_file)
     @page_url_list_generator.expects(:fetch_sitemap_contents)
     @page_url_list_generator.expects(:save_sitemap).with(nil, '/export/foo/sitemap.xml')
+    @page_url_list_generator.expects(:fetch_robots)
+    @page_url_list_generator.expects(:save_robots).with(nil, '/export/foo/robots.txt')
     @export_strategy.expects(:export!).with(url_list_file, @drupal_host, @export_directory).returns('/export/foo')
     @rsync_handler.expects(:rsync_static_export).with('/export/foo', @rsync_destination, true)
 
@@ -40,6 +42,8 @@ class TestExport < MiniTest::Test
     @page_url_list_generator.expects(:generate_page_url_list!).returns(url_list_file)
     @page_url_list_generator.expects(:fetch_sitemap_contents)
     @page_url_list_generator.expects(:save_sitemap).with(nil, '/export/foo/sitemap.xml')
+    @page_url_list_generator.expects(:fetch_robots)
+    @page_url_list_generator.expects(:save_robots).with(nil, '/export/foo/robots.txt')
     @export_strategy.expects(:export!).with(url_list_file, @drupal_host, @export_directory).returns('/export/foo')
     @rsync_handler.expects(:rsync_static_export).with('/export/foo', @rsync_destination).never
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DEVELOPER-3480 for full information.

Added a few methods to fetch the robots.txt from the Drupal instance and
save that as part of the export. Also fixed tests that changed / were
added.