### PR TITLE
[DEVELOPER-3461] Workspace bug workaround into start-up scripts

### DIFF
--- a/_docker/drupal/scripts/drupal_install_checker.rb
+++ b/_docker/drupal/scripts/drupal_install_checker.rb
@@ -59,6 +59,19 @@ class DrupalInstallChecker
     end
   end
 
+  #
+  # This works-around a bug in the workspace module install in staging and production environments. We need to set the
+  # initial id of the row inserted into the workspace table to 1 from 9. In environments where this does not occur e.g
+  # drupal-dev, drupal-pull-request, this method is essentially a null-op
+  #
+  def workaround_workspace_bug
+    process_executor.exec!('mysql', ["--host=#{@opts['database']['host']}",
+                                     "--port=#{@opts['database']['port']}",
+                                     "--user=#{@opts['database']['username']}",
+                                     "--password=#{@opts['database']['password']}",
+                                     '--execute=update workspace set id=1 where id=9', "#{@opts['database']['name']}"])
+  end
+
   def installed?
     settings_exists? && rhd_settings_exists? && mysql_connect? && tables_exists?
   end
@@ -143,5 +156,6 @@ if $0 == __FILE__
     checker.install_module_configuration
     checker.set_cron_key    
     checker.import_config
+    checker.workaround_workspace_bug
   end
 end

--- a/_docker/tests/drupal/drupal_install_checker_test.rb
+++ b/_docker/tests/drupal/drupal_install_checker_test.rb
@@ -33,6 +33,16 @@ class DrupalInstallCheckerTest < Minitest::Test
     assert @install_checker.rhd_settings_exists?
   end
 
+  def test_workaround_workspace_bug
+    @process_exec.expect :exec!, true, ['mysql', ["--host=#{@opts['database']['host']}",
+                                                  "--port=#{@opts['database']['port']}",
+                                                  "--user=#{@opts['database']['username']}",
+                                                  "--password=#{@opts['database']['password']}",
+                                                  '--execute=update workspace set id=1 where id=9', "#{@opts['database']['name']}"]]
+
+    assert @install_checker.workaround_workspace_bug
+  end
+
   def test_rhd_settings_exists_when_false
     refute @install_checker.rhd_settings_exists?
   end


### PR DESCRIPTION
This PR puts the fix for the workspace bug into the Drupal start-up scripts so that if we have to re-build the environment, we don't forget to take that step.