### PR TITLE
[DEVELOPER-3480] Copy static resources into export directory

### DIFF
--- a/_docker/lib/export/export.rb
+++ b/_docker/lib/export/export.rb
@@ -50,6 +50,7 @@ class Export
 
 end
 
+@DEFAULT_STATIC_RESOURCES = File.expand_path('static',File.dirname(__FILE__))
 @DEFAULT_EXPORT_LOCATION = "/export"
 @DEFAULT_EXPORT_ARCHIVE_LOCATION = "/export/export-archives"
 
@@ -65,7 +66,7 @@ if $0 == __FILE__
   process_runner = ProcessRunner.new
   cron_invoker = CronInvoker.new(drupal_host)
   page_url_list_generator = DrupalPageUrlListGenerator.new(drupal_host, @DEFAULT_EXPORT_LOCATION)
-  export_strategy = HttrackExportStrategy.new(process_runner, ExportInspector.new, ExportHtmlPostProcessor.new(process_runner))
+  export_strategy = HttrackExportStrategy.new(process_runner, ExportInspector.new, ExportHtmlPostProcessor.new(process_runner, @DEFAULT_STATIC_RESOURCES))
   rsync_handler = StaticExportRsync.new(process_runner, ExportArchiver.new(@DEFAULT_EXPORT_ARCHIVE_LOCATION, ExportArchivePruner.new(@DEFAULT_EXPORT_ARCHIVE_LOCATION)))
   log = DefaultLogger.logger
 

--- a/_docker/lib/export/static/.htaccess
+++ b/_docker/lib/export/static/.htaccess
@@ -1,0 +1,22 @@
+<IfModule mod_deflate.c>
+  ############################################
+  ## GZIP text content
+  ## http://developer.yahoo.com/performance/rules.html#gzip
+  AddOutputFilterByType DEFLATE text/text text/html text/plain text/xml text/css application/x-javascript application/javascript text/javascript
+</IfModule>
+
+<IfModule mod_headers.c>
+  ############################################
+  ## Force the keep-alive header to be sent
+  ## PageSpeed tells us this isn't been sent correctly by jboss.org
+  Header set Connection keep-alive 
+</IfModule>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ############################################
+  ## Add default Expires header
+  ## http://developer.yahoo.com/performance/rules.html#expires
+  ExpiresDefault "access plus 30 minutes"
+</IfModule>
+

--- a/_docker/lib/export/static/robots.txt
+++ b/_docker/lib/export/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /auth/
+Disallow: /download-manager/

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -11,10 +11,12 @@ require_relative '../test_helper'
 class TestExportHtmlPostProcessor < MiniTest::Test
 
   def setup
-    @export_post_processor = ExportHtmlPostProcessor.new(ProcessRunner.new)
     @export_directory = Dir.mktmpdir
     test_export = Dir.open(File.expand_path('test_export_form_rewrite',File.dirname(__FILE__)))
     FileUtils.cp_r("#{test_export.path}/.", @export_directory)
+
+    test_static_resources = File.expand_path('test_static_resources',File.dirname(__FILE__))
+    @export_post_processor = ExportHtmlPostProcessor.new(ProcessRunner.new, test_static_resources)
   end
 
   def teardown
@@ -33,6 +35,13 @@ class TestExportHtmlPostProcessor < MiniTest::Test
 
   def get_form_action_url_from_html_doc(html_document, form_id)
     html_document.css("##{form_id}").first.attributes['action'].value
+  end
+
+  def test_should_copy_static_resources
+    @export_post_processor.post_process_html_export('docker', @export_directory)
+    assert(File.exist?("#{@export_directory}/robots.txt"))
+    assert(File.exist?("#{@export_directory}/.htaccess"))
+    assert(File.exist?("#{@export_directory}/nested/nested-file.txt"))
   end
 
   def test_should_rewrite_index_html_link

--- a/_docker/tests/export/test_static_resources/.htaccess
+++ b/_docker/tests/export/test_static_resources/.htaccess
@@ -1,0 +1,22 @@
+<IfModule mod_deflate.c>
+  ############################################
+  ## GZIP text content
+  ## http://developer.yahoo.com/performance/rules.html#gzip
+  AddOutputFilterByType DEFLATE text/text text/html text/plain text/xml text/css application/x-javascript application/javascript text/javascript
+</IfModule>
+
+<IfModule mod_headers.c>
+  ############################################
+  ## Force the keep-alive header to be sent
+  ## PageSpeed tells us this isn't been sent correctly by jboss.org
+  Header set Connection keep-alive 
+</IfModule>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ############################################
+  ## Add default Expires header
+  ## http://developer.yahoo.com/performance/rules.html#expires
+  ExpiresDefault "access plus 30 minutes"
+</IfModule>
+

--- a/_docker/tests/export/test_static_resources/nested/nested-file.txt
+++ b/_docker/tests/export/test_static_resources/nested/nested-file.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /auth/
+Disallow: /download-manager/

--- a/_docker/tests/export/test_static_resources/robots.txt
+++ b/_docker/tests/export/test_static_resources/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /auth/
+Disallow: /download-manager/


### PR DESCRIPTION
This PR introduces the `static` directory concept in the export process. You can place any files you want into the `static` directory, and they will be copied into the root of the export.

This process is perfect for copying in things like a `robots.txt` file or a `.htaccess` file (basically anything that would not be fetched by httrack.