### PR TITLE
[DEVELOPER-3518] Removed the use of the endsWith() JS function in IE

### DIFF
--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -125,8 +125,7 @@ app.ssoConfig.account_url = drupalSettings.rhd.keycloak.accountUrl;
 app.ssoConfig.auth_url = drupalSettings.rhd.keycloak.authUrl;
 
 var homeLink = document.getElementById('home-link')
-var confirmationPage = homeLink != null && homeLink.attributes['href'].value.endsWith('.html') ? 'confirmation.html' : 'confirmation'
-app.ssoConfig.confirmation = confirmationPage == 'confirmation.html' ? homeLink.href.replace('index.html',confirmationPage) : homeLink.href + confirmationPage
+app.ssoConfig.confirmation = homeLink.href + '/confirmation'
 app.ssoConfig.logout_url = homeLink.href
 app.projects = {};
 app.projects.defaultImage = "/images/design/projects/default_200x150.png";


### PR DESCRIPTION
The `endsWith()` JS function is not supported by IE, therefore we need to use something else to work out where to send the user after they have successfully registered.