### PR TITLE
Fixes DEVELOPER-3405 (tags on promo cards)

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.promotion_card.field_container_external_link
-    - field.field.node.promotion_card.field_container_tags
     - field.field.node.promotion_card.field_containers_short_summary
     - node.type.promotion_card
   module:
@@ -29,13 +28,6 @@ content:
       target: ''
     third_party_settings: {  }
     type: link
-  field_container_tags:
-    weight: 102
-    label: visually_hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
   field_containers_short_summary:
     weight: 104
     label: visually_hidden

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.teaser.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.promotion_card.field_container_external_link
-    - field.field.node.promotion_card.field_container_tags
     - field.field.node.promotion_card.field_containers_short_summary
     - node.type.promotion_card
   module:
@@ -29,14 +28,6 @@ content:
       url_only: false
       url_plain: false
       rel: '0'
-    third_party_settings: {  }
-  field_container_tags:
-    type: entity_reference_entity_view
-    weight: 2
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
     third_party_settings: {  }
   field_containers_short_summary:
     type: text_default


### PR DESCRIPTION
See https://issues.jboss.org/browse/DEVELOPER-3405 for full information.

It was decided we'd remove the tags on the promotion page display.