### PR TITLE
Fixes DEVELOPER-3576 (blue card tags)

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic.field_tags.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic.field_tags.yml
@@ -14,7 +14,7 @@ entity_type: node
 bundle: topic
 label: 'Blue Card Tags'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/topic/node--topic.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/topic/node--topic.html.twig
@@ -97,9 +97,6 @@ other methods (such as node.delete) will result in an exception.
                             <div class="description">
                                 {{ content.field_blue_card_description }}
                             </div>
-                            <div class="promo-tags"><span class="promo-tags-label">Tags:</span>
-                                {{ content.field_tags }}
-                            </div>
                             <div class="row promo-links">
                                 {# TODO: I will need to add a new field override for the links #}
                                 {{ content.field_blue_card_links }}


### PR DESCRIPTION
See https://issues.jboss.org/browse/DEVELOPER-3576 for full information

Blue card tags are no longer required (but should be added for taxonomy purposes) and they are also no longer being displayed on the view.