### PR TITLE
[DEVELOPER-3570] Fix Wrapper Class Flex Basis

### DIFF
--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -468,6 +468,7 @@ body.fullbleed {
   min-height: 400px;
   padding-bottom: emCalc(100px);
   flex: 1;
+  flex-basis: auto;
 }
 
 


### PR DESCRIPTION
Flex short-hand caused IE to set the flex-basis property of the .wrapper class to 0%, which pulled the footer up into the content.

https://issues.jboss.org/browse/DEVELOPER-3570