### PR TITLE
Awestruct excludes for pages migrated to Drupal.

### DIFF
--- a/404-error.html.slim
+++ b/404-error.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Page Not Found
+ignore_export: true
 ---
 
 .row#error-page

--- a/about/index.html.slim
+++ b/about/index.html.slim
@@ -5,6 +5,7 @@ primary_nav_hidden: true
 interpolate: true
 title: About Us
 description: Learn about the Red Hat Developer Program and why you should join this free program
+ignore_export: true
 ---
 
 section.about-header

--- a/articles/how-to-post-tag-question-stack-overflow.adoc
+++ b/articles/how-to-post-tag-question-stack-overflow.adoc
@@ -4,6 +4,7 @@
 :author: Red Hat Developers Team
 :title: "How to post and tag a question on Stack Overflow"
 :awestruct-published: June 24, 2016
+:awestruct-ignore_export: true
 
 To post a tagged a question at Stack Overflow so that it can be viewed by Red Hat engineers and visitors to the http://developers.redhat.com/stack-overflow/[Red Hat Developer Stack Overflow help page], follow the steps below.
 

--- a/articles/no-cost-rhel-faq.adoc
+++ b/articles/no-cost-rhel-faq.adoc
@@ -6,6 +6,7 @@
 :awestruct-description: "Answers to Frequently Asked Questions (FAQs) about no-cost Red Hat Enterprise Linux subscriptions for developers."
 :awestruct-published: April 20, 2016
 :awestruct-description: Frequently asked questions about the no-cost RHEL Developer subscription
+:awestruct-ignore_export: true
 
 = FREQUENTLY ASKED QUESTIONS
 = NO-COST RHEL DEVELOPER SUITE SUBSCRIPTION

--- a/articles/rhel-what-you-need-to-know.adoc
+++ b/articles/rhel-what-you-need-to-know.adoc
@@ -5,6 +5,7 @@
 :title: "Getting Red Hat Enterprise Linux Developer Suite: What you need to know"
 :awestruct-published: March 14, 2016
 :awestruct-description: Fundamental tidbits if you are new to developing on Red Hat Enterprise Linux
+:awestruct-ignore_export: true
 
 For developers, getting Red Hat Enterprise Linux is now easier than ever thanks to the  availability of the no-cost Red Hat Enterprise Linux Developer Suite subscription option for developers.
 

--- a/books.html.slim
+++ b/books.html.slim
@@ -2,6 +2,7 @@
 layout: get-involved-base
 title: Books about Red Hat 
 description: All the books about Red Hat products and projects ever written
+ignore_export: true
 ---
 .row
   h2.large-title#books Books

--- a/community/contributor/index.html.slim
+++ b/community/contributor/index.html.slim
@@ -3,6 +3,7 @@ layout: base
 body_class: fullbleed
 title: Red Hat Developers Content Contributors
 description: Contribute community content as part of the Red Hat Developer Program
+ignore_export: true
 ---
 
 section.contributors-main

--- a/community/contributor/signup.html.slim
+++ b/community/contributor/signup.html.slim
@@ -3,6 +3,7 @@ layout: base
 body_class: fullbleed
 title: Red Hat Developers Content Contributors Sign Up
 description: Sign-up to be a content contributor to the Red Hat Developer Program
+ignore_export: true
 ---
 
 section.contributors-main

--- a/confirmation.html.slim
+++ b/confirmation.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Thank you for registering!
+ignore_export: true
 ---
 
 #registration-confirmation

--- a/devnation2015.html.slim
+++ b/devnation2015.html.slim
@@ -2,6 +2,7 @@
 layout: technology-base
 description: DevNation 2015 - a developer conference built for developers, by developers
 title: DevNation 2015
+ignore_export: true
 ---
 .hero.hero-wide.hero-devnation2015
   .row

--- a/events.html.slim
+++ b/events.html.slim
@@ -3,6 +3,7 @@ layout: get-involved-base
 title: Events featuring Red Hat
 description: Discover the events and webinars featuring talks about Red Hat products and upstream projects.
 drupal_format: as_is_html
+ignore_export: true
 ---
 .hero.hero-wide.hero-events
   .row

--- a/events/devnation/2016/index.html.slim
+++ b/events/devnation/2016/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: devnation2016
 title: Devnation 2016
 description: Learn more. Code more. Share more. Join the Nation.
+ignore_export: true
 ---
 
 section.wide.wide-hero(class="#{page.hero_class}")

--- a/events/devoxx/2015/index.html.slim
+++ b/events/devoxx/2015/index.html.slim
@@ -5,6 +5,7 @@ primary_nav_hidden: true
 interpolate: true
 description: Red Hat is a Devoxx 2015 sponsor with 14 sessions.  Come find us.
 title: Devoxx 2015
+ignore_export: true
 ---
 
 .wide.wide-hero.devoxxbe(class="#{page.hero_class}")==hero

--- a/events/devoxxfrance/2016/index.html.slim
+++ b/events/devoxxfrance/2016/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: devoxxfrance
 title: DevoxxFrance
 description: Red Hat is a Devoxx France 2016 sponsor.  Come find us, s'il vous plaît
+ignore_export: true
 ---
 
 section.wide.wide-hero(class="#{page.hero_class}")

--- a/events/gids/2016/index.html.slim
+++ b/events/gids/2016/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: gids
 title: GIDS
 description: Red Hat Developers' sessions and speakers at Great Indian Developer Summit 2016
+ignore_export: true
 ---
 
 .wide.wide-hero(class="#{page.hero_class}")

--- a/events/javaone/2015/index.html.slim
+++ b/events/javaone/2015/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: javaone2015
 title: JavaOne
 description: Red Hat Developers' sessions and speakers at JavaOne 2015
+ignore_export: true
 ---
 
 .wide.wide-hero.javaone(class="#{page.hero_class}")==hero

--- a/events/javaone/2016/index.html.slim
+++ b/events/javaone/2016/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: javaone2016
 title: JavaOne
 description: Red Hat Developers' sessions and speakers at JavaOne 2016
+ignore_export: true
 ---
 
 .wide.wide-hero.javaone(class="#{page.hero_class}")==hero

--- a/events/judcon/2016/brno/index.html.slim
+++ b/events/judcon/2016/brno/index.html.slim
@@ -5,6 +5,7 @@ primary_nav_hidden: true
 interpolate: true
 description: Red Hat at JUDCon:Brno 2016.  Come find us.
 title: JUDCon:2016 Brno
+ignore_export: true
 ---
 
 .wide.wide-hero.judcon-brno(class="#{page.hero_class}")==hero

--- a/events/msbuild/2016/index.html.slim
+++ b/events/msbuild/2016/index.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 hero_class: msbuild
 title: MS Build
 description: Red Hat will be a Microsoft Build 2016.  Yes, we really are so come find us.
+ignore_export: true
 ---
 
 .wide.wide-hero(class="#{page.hero_class}")==hero

--- a/faq.adoc
+++ b/faq.adoc
@@ -4,6 +4,7 @@
 :awestruct-issues: [WAY-46]
 :awestruct-description: Answers common questions about JBoss product and project availability and www.jboss.org.
 :awestruct-interpolate: true
+:awestruct-ignore_export: true
 
 == Overview
 

--- a/general-error.html.slim
+++ b/general-error.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Page Does Not Exist
+ignore_export: true
 ---
 
 .row#error-page

--- a/index.html.slim
+++ b/index.html.slim
@@ -3,6 +3,7 @@ layout: base
 body_class: fullbleed
 title: Red Hat Developers
 description: The simple, modern & productive way to build apps and infrastructure.
+ignore_export: true
 ---
 
 

--- a/projects.html.slim
+++ b/projects.html.slim
@@ -3,6 +3,7 @@ layout: technology-base
 status: green
 title: Upstream Communities
 description: Learn more about the upstream projects that Red Hat is involved with.
+ignore_export: true
 ---
 
 .hero.hero-projects

--- a/promotions/devnation-discount-code.html.slim
+++ b/promotions/devnation-discount-code.html.slim
@@ -7,6 +7,7 @@ hero_class: devnation-discount-code
 drupal_type: rhd_microsite
 description: Red Hat Developer Program members get a 30% discount to DevNation 2016
 title: Devnation Discount Code
+ignore_export: true
 ---
 
 .microsite-header.devnation-discount

--- a/promotions/devnation-pass-giveaway-tnc.adoc
+++ b/promotions/devnation-pass-giveaway-tnc.adoc
@@ -2,6 +2,7 @@
 :awestruct-interpolate: true
 :awestruct-id: microsite-id
 :awestruct-graphic: "http://static.jboss.org/images/rhd/minipage/rhd_minipage_passaday.png"
+:awestruct-ignore_export: true
 
 // Microsite title
 ### Terms and Conditions

--- a/promotions/devnation-pass-giveaway.adoc
+++ b/promotions/devnation-pass-giveaway.adoc
@@ -2,6 +2,7 @@
 :awestruct-interpolate: true
 :awestruct-id: microsite-id
 :awestruct-graphic: "http://static.jboss.org/images/rhd/minipage/rhd_minipage_passaday.png"
+:awestruct-ignore_export: true
 
 // Microsite title
 ### JOIN THE RED HAT DEVELOPER PROGRAM AND AUTOMATICALLY BE ENTERED INTO A DAILY DRAWING FOR A FREE DEVNATION PASS!

--- a/promotions/distributed-javaee-architecture.html.slim
+++ b/promotions/distributed-javaee-architecture.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 drupal_type: rhd_microsite
 description: Get the book, Java EE Design Patterns.  It's free for members.
 title: Download the book - Java EE Design Patterns
+ignore_export: true
 ---
 
 #book-download-promotion.distributed-javaee-architecture

--- a/promotions/openjdk-promo.adoc
+++ b/promotions/openjdk-promo.adoc
@@ -2,6 +2,7 @@
 :awestruct-interpolate: true
 :awestruct-id: microsite-id
 :awestruct-graphic: "http://static.jboss.org/images/rhd/minipage/RHDev_pageimage_openjdk_16jun2016.png"
+:awestruct-ignore_export: true
 
 // Microsite title
 ### Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim...

--- a/register.html.slim
+++ b/register.html.slim
@@ -1,3 +1,7 @@
+---
+ignore_export: true
+---
+
 html
 head
   meta name="description" content="Register for the Red Hat Developer Program.  It's free to join."

--- a/resources.html.slim
+++ b/resources.html.slim
@@ -3,6 +3,7 @@ layout: base
 title: Discover the developer materials Red Hat has to offer
 description: Red Hat has extensive materials to help you get started. On offer are quickstarts, tutorials, videos, articles and more.
 drupal_format: as_is_html
+ignore_export: true
 ---
 
 .hero.hero-wide.hero-resources

--- a/search.html.slim
+++ b/search.html.slim
@@ -2,6 +2,7 @@
 layout: base
 title: Search Results
 drupal_format: as_is_html
+ignore_export: true
 ---
 
 div(ng-app="search")

--- a/solutions/containers/adoption.adoc
+++ b/solutions/containers/adoption.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-adoption
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 [.large-24.columns.panel.callout]
 *New to containers?* +

--- a/solutions/containers/benefits.adoc
+++ b/solutions/containers/benefits.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-benefits
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 === Containers support modern application development trends.
 A recent Forrester Consulting study asked IT decision-makers "For which workloads or application use cases have you used/do you anticipate to use containers?"

--- a/solutions/containers/index.html.slim
+++ b/solutions/containers/index.html.slim
@@ -2,4 +2,5 @@
 layout: topics-base
 interpolate: true
 description: Insightful technical information about docker and Linux containers
+ignore_export: true
 ---

--- a/solutions/containers/overview.adoc
+++ b/solutions/containers/overview.adoc
@@ -3,6 +3,7 @@
 :awestruct-interpolate: true
 :awestruct-description: Introducing Red Hat containers - important technical information and resources
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 == Header
 === So, what are containers??

--- a/solutions/devops/adoption.adoc
+++ b/solutions/devops/adoption.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-adoption
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 [discrete]
 === [[culture]]Culture

--- a/solutions/devops/buzz.html.slim
+++ b/solutions/devops/buzz.html.slim
@@ -2,4 +2,5 @@
 layout: solution-buzz
 description: Trending content and news about DevOps in Red Hat Developers
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/devops/index.html.slim
+++ b/solutions/devops/index.html.slim
@@ -2,4 +2,5 @@
 layout: topics-base
 interpolate: true
 description: Valued technical and development information for DevOps methodologies
+ignore_export: true
 ---

--- a/solutions/devops/learn.html.slim
+++ b/solutions/devops/learn.html.slim
@@ -2,4 +2,5 @@
 layout: solution-learn
 description: Learn about DevOps and how you can start changing the way you deliver software to production
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/devops/overview.adoc
+++ b/solutions/devops/overview.adoc
@@ -3,6 +3,7 @@
 :awestruct-interpolate: true
 :awestruct-description: "DevOps is about Culture, Processes and Tools: learn how you can engage on Continuous Delivery and Deployment"
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 == Header
 

--- a/solutions/dotnet/index.html.slim
+++ b/solutions/dotnet/index.html.slim
@@ -2,4 +2,5 @@
 layout: topics-dotnet
 interpolate: true
 description: Technical and development information about .NET on Red Hat Enterprise Linux
+ignore_export: true
 ---

--- a/solutions/enterprise-java/adoption.adoc
+++ b/solutions/enterprise-java/adoption.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-adoption
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 === [[accelerate]]Accelerate
 ==== [[accelerate-development]]Accelerate Development

--- a/solutions/enterprise-java/buzz.html.slim
+++ b/solutions/enterprise-java/buzz.html.slim
@@ -2,4 +2,5 @@
 layout: solution-buzz
 description: Read about the latest news on Enterprise Java technologies
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/enterprise-java/index.html.slim
+++ b/solutions/enterprise-java/index.html.slim
@@ -2,4 +2,5 @@
 layout: topics-base
 interpolate: true
 description: Enterprise Java with technologies to address accelerating, integrating, and automating your applications
+ignore_export: true
 ---

--- a/solutions/enterprise-java/learn.html.slim
+++ b/solutions/enterprise-java/learn.html.slim
@@ -2,4 +2,5 @@
 layout: solution-learn
 description: Are you new to Enterprise Java?  Learn about it here
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/enterprise-java/overview.adoc
+++ b/solutions/enterprise-java/overview.adoc
@@ -3,6 +3,7 @@
 :awestruct-interpolate: true
 :awestruct-description: This is an introduction to Enterprise Java technologies
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 == Header
 [.large-16.columns.ov-block]

--- a/solutions/iot/index.html.slim
+++ b/solutions/iot/index.html.slim
@@ -1,4 +1,5 @@
 ---
 layout: topics-iot
 interpolate: true
+ignore_export: true
 ---

--- a/solutions/mobile/adoption.adoc
+++ b/solutions/mobile/adoption.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-adoption
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 [[api-driven_open_tooling]]
 ### API-driven Open Tooling

--- a/solutions/mobile/buzz.html.slim
+++ b/solutions/mobile/buzz.html.slim
@@ -2,4 +2,5 @@
 layout: solution-buzz
 description: Trending content and news about enterprise mobile applications
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/mobile/index.html.slim
+++ b/solutions/mobile/index.html.slim
@@ -2,4 +2,5 @@
 layout: topics-base
 interpolate: true
 description: Valued technical and development information for producing mobile applications
+ignore_export: true
 ---

--- a/solutions/mobile/learn.html.slim
+++ b/solutions/mobile/learn.html.slim
@@ -2,4 +2,5 @@
 layout: solution-learn
 description: Do you need to add mobile devices to your enterprise application?  Begin here.
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/mobile/overview.adoc
+++ b/solutions/mobile/overview.adoc
@@ -3,6 +3,7 @@
 :awestruct-interpolate: true
 :awestruct-description: Introduction to deploying enterprise applications to mobile and handheld devices
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 == Header
 [.large-16.columns.ov-block]

--- a/solutions/web-and-api-development/adoption.adoc
+++ b/solutions/web-and-api-development/adoption.adoc
@@ -1,6 +1,7 @@
 :awestruct-layout: solution-adoption
 :awestruct-interpolate: true
 :page-drupal_type: rhd_solution_overview
+:awestruct-ignore_export: true
 
 Your web applications are not just Java - at a minimum they also have HTML, CSS, and JavaScript.  And for some ideas, Ruby, Python, or Node may be a better approach.  How do you allow the right tool for the right problem while still maintaining application and environment integrity along with an environment that is supportable?
 

--- a/solutions/web-and-api-development/buzz.html.slim
+++ b/solutions/web-and-api-development/buzz.html.slim
@@ -2,4 +2,5 @@
 layout: solution-buzz
 description: The latest, trending news about building web applications and APIs
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/web-and-api-development/index.html.slim
+++ b/solutions/web-and-api-development/index.html.slim
@@ -1,5 +1,6 @@
 ---
 layout: topics-base
 interpolate: true
-description: Numerous ways and technologies to build web applications 
+description: Numerous ways and technologies to build web applications
+ignore_export: true
 ---

--- a/solutions/web-and-api-development/learn.html.slim
+++ b/solutions/web-and-api-development/learn.html.slim
@@ -2,4 +2,5 @@
 layout: solution-learn
 description: Learn how to build web applications and APIs using Red Hat technologies
 drupal_type: rhd_solution_overview
+ignore_export: true
 ---

--- a/solutions/web-and-api-development/overview.adoc
+++ b/solutions/web-and-api-development/overview.adoc
@@ -3,6 +3,7 @@
 :page-drupal_type: rhd_solution_overview
 :awestruct-interpolate: true
 :awestruct-description: "Red Hat topic on Web Applications and APIs - an overview"
+:awestruct-ignore_export: true
 
 == Header
 [.large-16.columns.ov-block]

--- a/stack-overflow.html.slim
+++ b/stack-overflow.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: technology-base
 title: Stack Overflow
+ignore_export: true
 ---
 
 .hero.hero-wide.stackoverflow-main

--- a/terms-and-conditions.adoc
+++ b/terms-and-conditions.adoc
@@ -4,6 +4,7 @@
 :awestruct-title: Developer Program Terms and Conditions
 :awestruct-description: Developer Program Terms and Conditions
 :icons: font
+:awestruct-ignore_export: true
 
 == Developer Program Terms & Conditions
 

--- a/ticket-monster.adoc
+++ b/ticket-monster.adoc
@@ -2,6 +2,7 @@
 :awestruct-layout: ticket-monster
 :awestruct-description: Ticket Monster is a moderately complex application that demonstrates how to build modern applications using JBoss web technologies.
 :awestruct-interpolate: true
+:awestruct-ignore_export: true
 
 == Intro
 

--- a/vjbug/index.html.slim
+++ b/vjbug/index.html.slim
@@ -5,6 +5,7 @@ primary_nav_hidden: true
 interpolate: true
 title: vJBug
 description: The virtual user group for JBoss developers accross the globe
+ignore_export: true
 ---
 
 .wide.wide-hero.vjbug(class="#{page.hero_class}")==hero

--- a/webinars/net-on-rhel-sneak-peek.html.slim
+++ b/webinars/net-on-rhel-sneak-peek.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 drupal_type: rhd_microsite
 description: "Red Hat webinar about .NET on RHEL"
 title: "Red Hat webinar: .NET on RHEL"
+ignore_export: true
 ---
 
 .microsite-header#net-rhel-sneakpeak

--- a/webinars/registration-confirmation.html.slim
+++ b/webinars/registration-confirmation.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 drupal_type: rhd_microsite
 description: Red Hat webinars - your webinar registration is confirmed
 title: Webinar registration confirmation
+ignore_export: true
 ---
 
 .microsite-header


### PR DESCRIPTION
This PR prevents Awestruct from pushing a bunch of pages to Drupal. It comprises:

1) A lot of misc pages that edited infrequently (0a52853)
2) Pages recently created in Drupal (ceb5eb0)
3) All Articles (b844823)
4) All SOLPs (3537fbc)
5) All Topics (54fc7ef)

Some of these have Drupal versions of the pages ready to replace them. Others will just stay as HTML in Drupal until they get migrated to a richer content-type.