### PR TITLE
Ignoring pages migrated to Drupal

### DIFF
--- a/faq.adoc
+++ b/faq.adoc
@@ -4,6 +4,7 @@
 :awestruct-issues: [WAY-46]
 :awestruct-description: Answers common questions about JBoss product and project availability and www.jboss.org.
 :awestruct-interpolate: true
+:awestruct-ignore_export: true
 
 == Overview
 

--- a/terms-and-conditions.adoc
+++ b/terms-and-conditions.adoc
@@ -4,6 +4,7 @@
 :awestruct-title: Developer Program Terms and Conditions
 :awestruct-description: Developer Program Terms and Conditions
 :icons: font
+:awestruct-ignore_export: true
 
 == Developer Program Terms & Conditions
 

--- a/webinars/net-on-rhel-sneak-peek.html.slim
+++ b/webinars/net-on-rhel-sneak-peek.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 drupal_type: rhd_microsite
 description: "Red Hat webinar about .NET on RHEL"
 title: "Red Hat webinar: .NET on RHEL"
+ignore_export: true
 ---
 
 .microsite-header#net-rhel-sneakpeak

--- a/webinars/registration-confirmation.html.slim
+++ b/webinars/registration-confirmation.html.slim
@@ -6,6 +6,7 @@ interpolate: true
 drupal_type: rhd_microsite
 description: Red Hat webinars - your webinar registration is confirmed
 title: Webinar registration confirmation
+ignore_export: true
 ---
 
 .microsite-header


### PR DESCRIPTION
I've added the following pages (for review) in Drupal. This PR ignores the Awestruct versions of the pages:

http://developers.redhat.com/webinars/net-on-rhel-sneak-peek/
http://developer-drupal.web.prod.ext.phx2.redhat.com/articles/faq
http://developer-drupal.web.prod.ext.phx2.redhat.com/articles/developer-program-terms-conditions

