### PR TITLE
Update Getting started Page to A-MQ 6.3

### DIFF
--- a/products/amq/get-started.adoc
+++ b/products/amq/get-started.adoc
@@ -1,81 +1,38 @@
 :awestruct-layout: product-get-started
 :awestruct-interpolate: true
 
+:amq-download-url: https://developers.redhat.com/download-manager/files/jboss-a-mq-6.3.0.redhat-187.zip
+
 == Prerequisites section title
 Prerequisites
 
 == Prerequisites section
-1. Java SE Development Kit (JDK), we recommend OpenJDK or Oracle JDK.
-2. JBoss&#174; Developer Studio 8.1
+1. Java SE Development Kit 8 (JDK), we recommend OpenJDK or Oracle JDK.
+
 
 == Step1 Duration
-10 minutes
+5 minutes
 
 == Step2 Duration
-5 minutes
+1 minutes
 
 == Step3 Duration
-5 minutes
+1 minutes
+
 
 == Step1 Content
-
-1. *Install JBoss Developer Studio*
-a. Download link:#{site.download_manager_file_base_url}/jboss-devstudio-8.1.0.GA-jar_universal.jar?tp=amq[JBoss Developer Studio 8.1.0] and execute its installer.
-* On Mac / Windows development hosts: Right click on `jboss-devstudio-8.1.0.GA-installer-eap.jar`, select _Open With -> Jar Launcher_
-* On Red Hat Enterprise Linux: Use the terminal to go to the folder where you have downloaded JBoss Developer Studio, and execute the installer with the following command:
-+
-`java -jar jboss-devstudio-8.1.0.GA-installer-eap.jar`
-+
-b. The installation wizard will walk through various steps.
-... On Introduction screen Click _N​ext_
-... Accept terms and conditions Click _N​ext_
-... Use default folder Click _N​ext_
-... Target directory being created Click _O​K_
-... In Select Java VM screen use check Default java VM Click _N​ext_
-... In Setup Shortcuts screen check _Create Shortcuts in the Start Menu_ and check _Current User_ Click _N​ext_
-... In Finish screen check Run JBoss Developer Studio after installation. Click _Done_
-2. *Configure maven*
-+
-The hello world example uses maven to download dependent libraries from Red Hat. You will need to add these libraries to your development IDE in order for the example to work.
-+
-a. Open JBoss Developer Studio preferences, expand _J​BossTools_ ​and select _J​Boss Maven Integration_.
-* On Windows, click _Windows -> Preferences_.
-* On Mac, click _JBoss Developer Studio -> Preferences_.
-b. Click _Configure Maven Repostories_ button.
-c. Click _Add Repository_ and select ​`redhat-ga-repository` profile and then click _OK_.
-+
-image:#{cdn(site.base_url + '/images/products/devstudio/maven.png')}[Add Maven Repository]
-+
-d. Repeat the previous step to add the following repositories:
-+
-Add two additional repositories. Make certain to click the checkbox to make these repositories active by default.
-+
-* redhat­-developers-­integration­-repository
-** url: h​ttps://repo.fusesource.com/nexus/content/groups/public/
-** name: redhat­-developers-­integration-­repository
-** id: redhat­-developers-­integration-­repository
-+
-* redhat-­developers-­early-access-­repository
-** url: h​ttp://maven.repository.redhat.com/earlyaccess/all/
-** name: redhat-­developers-­early-access-­repository
-** id: redhat-­developers-­early-access-­repository
-e. Answer _"Yes"_ for the question if you want to update settings.xml
-+
-TIP: You can also copy the settings.xml file to your maven home directory `(USER_HOME/.m2)`.
-
-== Step2 Content
 
 *Download, install and configure JBoss A-MQ:*
 
 1. *Download and extract:*
 +
 a. Download the latest version of Red Hat JBoss A-MQ. The latest
-at the time of this writing is link:#{site.download_manager_file_base_url}/jboss-amq-6.2.1.GA.zip[Red Hat JBoss A-MQ 6.2.1 GA].
-b. Unzip JBoss-AQ to your favorite destination. The document will refer to this directory as AMQ_HOME (We use C:\opt\redhat\jboss-amq on Windows.)
+at the time of this writing is link:{amq-download-url}[Red Hat JBoss A-MQ 6.3.0 GA].
+b. Unzip JBoss A-MQ to any destination. The document will refer to this directory as AMQ_HOME
 * On Windows or Mac, you can extract the contents of the ZIP archive by double clicking on the ZIP file.
 * On Red Hat Enterprise Linux, open a terminal window in the target machine and navigate to where the ZIP file was downloaded. Extract the ZIP file by executing the following command:
 +
-`unzip jboss-a-mq-6.2.1.redhat-084.zip`
+`unzip jboss-a-mq-6.3.0.redhat-187.zip`
 +
 2. *Add users to A-MQ:*
 +
@@ -84,52 +41,63 @@ Edit the file `AMQ_HOME/etc/user.properties`. Uncomment the last line so that sy
 `admin=admin,admin,manager,viewer,Operator,Maintainer,Deployer, Auditor,Administrator,SuperUser`
 +
 3. *Start the A-MQ broker:* Scripts to start and stop the A-MQ broker are found within the `AMQ_HOME/bin` directory.
-* For Windows: Double-click on the `AMQ/bin/start.bat` file and accept security pop-ups as they appear.
+* For Windows: Double-click on the `AMQ_HOME/bin/start.bat` file and accept security pop-ups as they appear.
 * For Red Hat Enterprise Linux and Mac: Execute the following command:
 +
 `AMQ_HOME/bin/start`
 +
 TIP: To check the status of the A-MQ broker you can execute the status script found in the same directory as the start script. To learn more about the various scripts see the link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_A-MQ/6.2/html/Console_Reference/index.html[customer portal].​
 +
+video::184305594[vimeo]
+
++
 * *Next Steps:* Congratulate yourself. You have just installed and started the JBoss A-MQ Broker. Next up, Install the developer environment...
 
+== Step2 Content
+*Connecting to A-MQ:*
+
+
+a. You may execute following command to check thes messages have been enqueue/dequeued
+
+* For Linux/MAC:
++
+`AMQ_HOME/bin/client activemq:dstat`
+
+* For Windows:
++
+`AMQ_HOME\bin\client.bat activemq:dstat`
+    
+b. Or simply go to the adminstration console and login with *ID:admin* and *PASSWORD:admin*
++
+`http://localhost:8181`
+
 == Step3 Content
+*Produce and consume messages:*
 
-Try it out! Download and configure the source within the Red Hat JBoss Developer Studio.
 
-1. Download the example: ​Download or clone the example from GitHub.
-* via download: there is a download available of the link:#[source].
-* via git: type the following command to wherever you care to place the helloworld project.
+a. Sending messages to broker
+
+* For Linux/MAC:
 +
-`git clone https://github.com/rayploski/amq-quickstarts.git`
+`AMQ_HOME/bin/client "activemq:producer --user <Username> --password <Password>"`
+
+* For Windows:
 +
-Unzip the folder to your favorite destination (will be referred to as `FOLDER_HOME`).
-2. Import the “HelloWorld” to JBoss Developer Studio:
-a. Click on _File -> Import_
-b. Expand the Maven folder and choose _"Existing Maven Project"_
+`AMQ_HOME\bin\client.bat "activemq:producer --user <Username> --password <Password>"`
+
+b. Consume messages from broker:
+
+* For Linux/MAC:
 +
-image:#{cdn(site.base_url + '/images/products/amq/import-project-maven.png')}[Import Existing Maven Repository]
+`AMQ_HOME/bin/client "activemq:consumer --user <Username> --password <Password>"`
+
+* For Windows:
 +
-c. Click the _Next_ button.
-d. Navigate to your ​`FOLDER_HOME/​amq-helloworld-jms​` directory.
+`AMQ_HOME\bin\client.bat "activemq:consumer --user <Username> --password <Password>"`
 +
-[.content-img-sm]
-image:#{cdn(site.base_url + '/images/products/amq/navigate-amq-jms.png')}[Navigate to the AMQ JMS HelloWorld directory]
+video::184305760[vimeo]
+
+
 +
-e. Click the _O​K_ ​button. A final dialog will confirm your choices.
-+
-image:#{cdn(site.base_url + '/images/products/amq/import-amq-jms.png')}[Confirm the amq-helloworld-jms project]
-+
-f. Click the _Finish_ button. JBoss Developer Studio will import the project and download dependencies from the repositories you configured in the “Install JBoss Developer Studio” section. This may take a few minutes depending on your internet connection.
-3. Run Hello World: Navigate, explore, and run the hello world example.
-a. Click on the folder icons within the Project Explorer section to discover App.java. Double click on App.java
-+
-image:#{cdn(site.base_url + '/images/products/amq/amq-helloworld.png')}[Navigate to App.java]
-+
-b. When you are ready to try the example out, select from the main menu, _R​u​n ​→ Run As​→ J​ava Application_
-+
-[.content-img-sm]
-image:#{cdn(site.base_url + '/images/products/amq/run-run-as.png')}[Run As Java Application]
-+
-The application will launch, connect to the message broker, send messages, receive them and output to the console within JBoss Developer Studio.
-4. Next Steps: Congratulate yourself! You’ve just sent and received messages via Red Hat JBoss A­MQ. Visit frequently to view more tutorials on connecting via MQTT, STOMP and other topics around A­MQ.
+
+Congratulate yourself! You’ve just sent and received messages via Red Hat JBoss A­MQ. Visit frequently to view more tutorials on connecting via MQTT, STOMP and other topics around A­MQ.


### PR DESCRIPTION
The current developers.redhat.com 's A-MQ getting started page is still on 6.2.1 instead of 6.3. Please update!
JIRA: https://issues.jboss.org/browse/DEVELOPER-3548