### PR TITLE
[DEVELOPER-3607] Removed Blinkr GitHub statuses from build pipeline

### DIFF
--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     - github_status_repo=redhat-developer/developers.redhat.com
     - github_status_target_url=${BUILD_URL}
     - github_status_sha1=${ghprbActualCommit}
-    - github_status_initialise=Drupal:Unit Tests,Drupal:Acceptance Tests,Drupal:Exported Site Preview,Drupal:Blinkr,Drupal:Drupal Site
+    - github_status_initialise=Drupal:Unit Tests,Drupal:Acceptance Tests,Drupal:Exported Site Preview,Drupal:Drupal Site
 
   acceptance_tests:
    build: ../../awestruct

--- a/_lib/github.rb
+++ b/_lib/github.rb
@@ -6,7 +6,7 @@ end
 
 class GitHub
 
-  @@valid_contexts = ['Unit Tests', 'Site Preview', 'Acceptance Tests', 'Blinkr']
+  @@valid_contexts = ['Unit Tests', 'Site Preview', 'Acceptance Tests']
 
   Octokit.configure do |c|
     c.access_token = ENV['github_status_api_token']

--- a/_tests/test_github.rb
+++ b/_tests/test_github.rb
@@ -80,10 +80,6 @@ class TestGitHub < Minitest::Test
     Octokit.expects(:create_status).with('foo/bar', sha, state, options)
     GitHub.update_status('foo', 'bar', sha, state, options)
 
-    options = {:context => "Blinkr", :target_url => "www.example.com", :description => "Short Desc"}
-    Octokit.expects(:create_status).with('foo/bar', sha, state, options)
-    GitHub.update_status('foo', 'bar', sha, state, options)
-
     options = {:context => "Acceptance Tests", :target_url => "www.example.com", :description => "Short Desc"}
     Octokit.expects(:create_status).with('foo/bar', sha, state, options)
     GitHub.update_status('foo', 'bar', sha, state, options)
@@ -103,12 +99,10 @@ class TestGitHub < Minitest::Test
     target_url = "www.example.com"
     options1 = {:context => "Unit Tests", :target_url => "www.example.com", :description => "Pending"}
     options2 = {:context => "Acceptance Tests", :target_url => "www.example.com", :description => "Pending"}
-    options3 = {:context => "Blinkr", :target_url => "www.example.com", :description => "Pending"}
-    options4 = {:context => "Site Preview", :target_url => "www.example.com", :description => "Pending"}
+    options3 = {:context => "Site Preview", :target_url => "www.example.com", :description => "Pending"}
     Octokit.expects(:create_status).with('foo/bar', sha, state, options1)
     Octokit.expects(:create_status).with('foo/bar', sha, state, options2)
     Octokit.expects(:create_status).with('foo/bar', sha, state, options3)
-    Octokit.expects(:create_status).with('foo/bar', sha, state, options4)
     GitHub.all_status_to_pending('foo', 'bar', sha, target_url)
   end
 end


### PR DESCRIPTION
This PR removes the Blinkr statues from GitHub for each pull request. This will mean you can actually tell if all checks for a PR failed or succeeded without having to browse through them.