### PR TITLE
Fixed "contact Us" email in site chrome

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -281,7 +281,7 @@
                     <div class="large-12 columns">
                         <ul class="inline-list">
                             <li><a href="/about">About us</a></li>
-                            <li><a href="mailto:developer@redhat.com">Contact us</a></li>
+                            <li><a href="mailto:developers@redhat.com">Contact us</a></li>
                         </ul>
                     </div>
                     <div class="large-12 columns">


### PR DESCRIPTION
@MikGue has asked that we point people to use developers@redhat.com rather than developer@redhat.com. 

We made the change earlier, here: https://github.com/redhat-developer/developers.redhat.com/blob/master/_layouts/base.html.slim#L267. But it was not done in the twig version of the file.