### PR TITLE
Fixing false positive test results. Having the report generated using…

### DIFF
--- a/_cucumber/cucumber.rake
+++ b/_cucumber/cucumber.rake
@@ -2,20 +2,11 @@ require 'rubygems'
 require 'parallel'
 require 'fileutils'
 require_relative '../_lib/github'
-require 'report_builder'
 
-task :cleanup do
-  puts('. . . . Deleting old reports and screenshots  . . . .')
-  File.delete('cucumber_failures.log') if File.exist?('cucumber_failures.log')
-  File.delete('cucumber_failures1.log') if File.exist?('cucumber_failures1.log')
-  FileUtils.rm_rf('_cucumber/reports')
-  Dir.mkdir('_cucumber/reports')
-  FileUtils.rm_rf('_cucumber/screenshots')
-  Dir.mkdir('_cucumber/screenshots')
-end
+task :features do
+  cleanup
+  p ". . . . HOST TO TEST = #{ENV['HOST_TO_TEST']} . . . ."
 
-
-task :parallel_run do
   if ENV['RHD_TEST_PROFILE']
     profile = ENV['RHD_TEST_PROFILE']
   else
@@ -40,23 +31,40 @@ task :parallel_run do
   if ENV['ghprbActualCommit'].to_s.empty?
     status_code = run(profile, tags)
   else
-    options = {:context => 'Acceptance Tests', :description => "Acceptance Tests pending", :target_url => ENV['BUILD_URL']}
-    GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], 'pending', options)
+    p 'Sending progress to Github . . . '
+    options = {:context => 'Acceptance Tests', :description => 'Acceptance Tests pending', :target_url => ENV['BUILD_URL']}
+    GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], "pending", options)
     status_code = run(profile, tags)
     if status_code == 0
-      options[:description] = "Acceptance Tests finished ok!"
-      GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], 'success', options)
+      options[:description] = 'Acceptance Tests finished ok!'
+      GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], "success", options)
     else
-      options[:description] = "Acceptance Tests failed"
-      puts GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], 'failure', options)
+      options[:description] = 'Acceptance Tests failed'
+      puts GitHub.update_status($github_org, $github_repo, ENV['ghprbActualCommit'], "failure", options)
     end
   end
-  generate_report
-  status_code
+  puts "Acceptance tests resulted with status code of #{status_code}"
+  exit(status_code)
+end
+
+task :wip do
+  cleanup
+  system('cucumber _cucumber -r _cucumber/features/ --tags @wip')
+end
+
+task :debugger do
+  cleanup
+  system('cucumber _cucumber -r _cucumber/features/ --tags @debug')
+end
+
+task :debug, :times do |task, args|
+  puts "Executing scenario tagged with @debug #{args[:times]} times"
+  args[:times].to_i.times { Rake::Task[:debugger].execute }
 end
 
 def run(profile, tag)
   tag_string = tag unless tag.eql?(nil)
+
   if profile.eql?('slow')
     if tag.eql?(nil)
       system("cucumber _cucumber -r _cucumber/features/ -p #{profile}")
@@ -70,22 +78,11 @@ def run(profile, tag)
       system("parallel_cucumber _cucumber/features/ -o \"-p #{profile} #{tag_string}\" -n 10")
     end
   end
+  rerun
   $?.exitstatus
 end
 
-def generate_report
-  ReportBuilder.configure do |config|
-    config.json_path = '_cucumber/reports/'
-    config.report_path = '_cucumber/reports/rhd_test_report'
-    config.report_types = [:json, :html]
-    config.report_tabs = [:overview, :features, :errors]
-    config.report_title = 'RHD Test Results'
-    config.compress_images = true
-  end
-  ReportBuilder.build_report
-end
-
-task :rerun do
+def rerun
   # rerun attempt one
   if File.exist?('cucumber_failures.log') && File.size('cucumber_failures.log') > 0
     puts ('. . . . . There were failures during the test run! Attempt one of rerunning failed scenarios . . . . .')
@@ -99,23 +96,11 @@ task :rerun do
   $?.exitstatus
 end
 
-task :features => [:cleanup, :parallel_run, :rerun]
-
-task :wip do
-  if ENV['RHD_TEST_PROFILE'].to_s.empty?
-    profile = 'default'
-  else
-    profile = ENV['RHD_TEST_PROFILE']
-  end
-  system("cucumber _cucumber -r _cucumber/features/ --tags @wip --profile #{profile}")
+def cleanup
+  p '. . . . Deleting old reports and screenshots  . . . .'
+  File.delete('cucumber_failures.log') if File.exist?('cucumber_failures.log')
+  FileUtils.rm_rf('_cucumber/reports')
+  Dir.mkdir('_cucumber/reports')
+  FileUtils.rm_rf('_cucumber/screenshots')
+  Dir.mkdir('_cucumber/screenshots')
 end
-
-task :debugger do
-  system('cucumber _cucumber -r _cucumber/features/ --tags @debug')
-end
-
-task :debug, :times do |task, args|
-  puts "Executing scenario tagged with @debug #{args[:times]} times"
-  args[:times].to_i.times { Rake::Task[:debugger].execute }
-end
-


### PR DESCRIPTION
Fixing false positive test results. Having the report generated using the new rake task - after the rerun has occurred produces a status code of 0, therefore jenkins sees that as pass. So it passing the build, even though there may be failures.
