### PR TITLE
[DEVELOPER-3621] Ensure that test reports are generated 

### DIFF
--- a/_cucumber/cucumber.rake
+++ b/_cucumber/cucumber.rake
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'parallel'
 require 'fileutils'
 require_relative '../_lib/github'
+require 'report_builder'
 
 task :features do
   cleanup
@@ -78,8 +79,26 @@ def run(profile, tag)
       system("parallel_cucumber _cucumber/features/ -o \"-p #{profile} #{tag_string}\" -n 10")
     end
   end
-  rerun
-  $?.exitstatus
+
+  test_exit_code = $?.exitstatus
+  if test_exit_code != 0
+    test_exit_code = rerun
+  end
+  generate_reports
+  test_exit_code
+end
+
+def generate_reports
+
+  ReportBuilder.configure do |config|
+    config.json_path = '_cucumber/reports/'
+    config.report_path = '_cucumber/reports/rhd_test_report'
+    config.report_types = [:json, :html]
+    config.report_tabs = [:overview, :features, :errors]
+    config.report_title = 'RHD Test Results'
+    config.compress_images = true
+    end
+  ReportBuilder.build_report
 end
 
 def rerun


### PR DESCRIPTION
It would appear that we are no longer having the test reports being generated as a result of #1545. As well as being inconvenient that we no longer have the reports, it also causes the build to fail each time as the archive of artefacts build step fails. This attempts to resolve that issue.

Before merging this, please click through to the actual acceptance test job and make sure you can browse to the report!