### PR TITLE
[DEVELOPER-3620] Updated acceptance test GitHub status check URL 

### DIFF
--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -101,7 +101,7 @@ services:
      - github_status_api_token
      - github_status_context=Drupal:Acceptance Tests
      - github_status_repo=redhat-developer/developers.redhat.com
-     - github_status_target_url=${BUILD_URL}/artifact/_cucumber/reports/rhd_test_report.html
+     - github_status_target_url=${BUILD_URL}artifact/_cucumber/reports/rhd_test_report.html
      - github_status_sha1=${ghprbActualCommit}
      - PARALLEL_TEST
      - CUCUMBER_TAGS

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -101,7 +101,7 @@ services:
      - github_status_api_token
      - github_status_context=Drupal:Acceptance Tests
      - github_status_repo=redhat-developer/developers.redhat.com
-     - github_status_target_url=${BUILD_URL}
+     - github_status_target_url=${BUILD_URL}/artifact/_cucumber/reports/rhd_test_report.html
      - github_status_sha1=${ghprbActualCommit}
      - PARALLEL_TEST
      - CUCUMBER_TAGS


### PR DESCRIPTION
This PR updates the URL used in the `Drupal: Acceptance Tests` GitHub status URL to point to the test report rather than the build job itself.

**Note:** I have not updated the Awestruct acceptance test URL as this is very shortly going to be removed.