### PR TITLE
[DEVELOPER-3605] Export process should fail if there are pages missing

### DIFF
--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -87,6 +87,8 @@ services:
      - ../../../:/home/jenkins_developer/developer.redhat.com
      - export:/export
     entrypoint: "ruby _docker/lib/export/export.rb docker"
+    environment:
+     - drupal.export.fail_on_missing
 
   #
   # Testing

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       - /data/drupal-export:/export
       - /credentials/rsync:/home/jenkins_developer/.ssh
       - ../../../:/home/jenkins_developer/developer.redhat.com
+    environment:
+     - drupal.export.fail_on_missing
 
   rollback:
     build:

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     - github_status_repo=redhat-developer/developers.redhat.com
     - github_status_target_url=${export_destination}
     - github_status_sha1=${ghprbActualCommit}
+    - drupal.export.fail_on_missing
 
   #
   # Testing

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       - /data/drupal-export:/export
       - /credentials/rsync:/home/jenkins_developer/.ssh
       - ../../../:/home/jenkins_developer/developer.redhat.com
+    environment:
+     - drupal.export.fail_on_missing
+
 
   rollback:
     build:

--- a/_docker/lib/export/README.md
+++ b/_docker/lib/export/README.md
@@ -21,14 +21,17 @@ The following workflow is how content is exported from Drupal:
 * Invoke the Cron service on Drupal to ensure that the sitemap.xml is up-to-date with all of the latest content
 * Parse the sitemap.xml and generate a list of pages that should be fetched from the site
 * Pass the list of links into the httrack process to perform the export from the site
+* Post-process the export to ensure it works as expected
 * Optionally, rsync the export folder to a location of your choice
 
 ### Httrack
 
-The export process relies on [httrack](https://www.httrack.com/) to perform the dump to HTML. The default configuration of httrack is as follows:
+The export process relies on [httrack](https://www.httrack.com/) to perform the dump to HTML. We use a custom patched version of httrack to allow us to specify a particular structure for saving the HTML files of the site.
+
+The default configuration of httrack is as follows:
 
 ```
---list /export/url-list.txt -O /export --disable-security-limits -c50 --max-rate 0 -v +"http://#{drupal_host}*" -"*/node*" -"*/devel*"
+--list /export/url-list.txt -O /export --disable-security-limits -c50 --max-rate 0 -v +"http://#{drupal_host}*" -"*/node*" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t
 ```
 
 The options specified are:
@@ -41,7 +44,9 @@ The options specified are:
 * -v -> Gives verbose output
 * +"http://drupal_host -> Instructs httrack to fetch all content from the Drupal host
 * -"*/node* -> Instructs httrack to ignore any pages or content beginning with `/node` (these are Drupal related pages)
-* -"*/devel* -> Instructs httrack to ignore any pages or content beginning with '/devel' (these are Drupal related pages)
+* -o0 -> Instructs httrack not to generate a 404 page for any content that is missing
+* -N ?html? -> Configures httrack to save any HTML page in the format `host/path/name/index.html` e.g. `docker/containers/overview/index.html`
+* -N -> Configures httrack to save any non-HTML asset using the path that it exists at on the original site
 
 
 The full range of httrack configuration options are available [here](https://www.httrack.com/html/fcguide.html).
@@ -50,6 +55,24 @@ The full range of httrack configuration options are available [here](https://www
 
 httrack has built-in caching that should make subsequent exports of the site quicker than the first run. The export process has been designed to make use of this cache. To make sure you get a cache hit when running an export
 you need to ensure that httrack is always exporting into the same directory. In you are running the export process in a Docker container, then using a volume mounted at `/export` is recommended to facilitate the cache hit.
+
+### Httrack post-processing
+
+We perform a number of post-processing steps on the httrack export to make it suitable for use with the main developers.redhat.com site. These changes mostly relate to re-writing links
+and slightly altering the export structure.
+
+Additionally we also run checks to ensure that all pages that are in the sitemap.xml in Drupal are present where we expect them to be in the export directory. The default behaviour of this checking process is to error
+if there are pages that are not present in the site export. This will cause the export process to fail before any rsync of content takes place therefore preventing bad HTML or missing pages from being pushed into production.
+
+#### Overriding default failure behaviour of export when pages are missing
+
+It is possible to override the default failure behaviour of the export process if there are missing pages. This may be desirable in the situations where there are significant issues with Drupal or you simply need to run an export
+to resolve a broken site.
+
+To override the failure behaviour, you can set the `drupal.export.fail_on_missing` environment variable to `false`. This variable is set within the `docker-compose.yml` for the environment in which you are working. Therefore you can
+set the value of this to `false` in the Jenkins export job configuration to override the value, giving you the ability to force an export even if there is content missing.
+
+
 
 ### Rsync
 

--- a/_docker/lib/export/drupal_page_url_list_generator.rb
+++ b/_docker/lib/export/drupal_page_url_list_generator.rb
@@ -44,8 +44,7 @@ class DrupalPageUrlListGenerator
     end
 
     links.uniq!
-    # Ensure that we also grab robots.txt which will not appear in the sitemap.xml
-    links << "http://#{@drupal_host}/robots.txt"
+    links
   end
 
   #

--- a/_docker/lib/export/export_inspector.rb
+++ b/_docker/lib/export/export_inspector.rb
@@ -2,6 +2,11 @@ require 'uri/http'
 
 #
 # The purpose of this class is to inspect an export directory to ensure that all pages that should be there, are in fact there.
+# If a page is missing from the export, then an exception is raised causing the export process to fail.
+#
+# The raising of an exception can be overridden if the 'drupal.export.fail_on_missing' system property is set to 'false'. This
+# should only be used in situations where you want the export to continue even if there is content missing e.g. you're having a very
+# bad time of things with Drupal.
 #
 # @author rblake@redhat.com
 #
@@ -18,6 +23,21 @@ class ExportInspector
     else
       "#{page_path}/index.html"
     end
+  end
+
+  #
+  # Determines if the process should fail if content is missing from the export
+  #
+  def should_fail_on_missing_content
+    fail_on_missing = ENV['drupal.export.fail_on_missing']
+    fail = true
+
+    if !fail_on_missing.nil? && !fail_on_missing.empty?
+      if fail_on_missing.to_s == 'false'
+        fail = false
+      end
+    end
+    fail
   end
 
   #
@@ -58,11 +78,16 @@ class ExportInspector
 
     if missing_pages > 0
       puts "WARNING: Of '#{total_pages}' pages, '#{missing_pages}' are not found in the export."
+
+      if should_fail_on_missing_content
+        raise StandardError.new("There are '#{missing_pages}' pages missing from the site export (see warnings for missing content). Failing export process.")
+      end
+
     end
 
   end
 
-  private :determine_expected_filesystem_path, :check_if_path_exists
+  private :determine_expected_filesystem_path, :check_if_path_exists, :should_fail_on_missing_content
 
 
 end

--- a/_docker/lib/export/export_inspector.rb
+++ b/_docker/lib/export/export_inspector.rb
@@ -32,10 +32,8 @@ class ExportInspector
     fail_on_missing = ENV['drupal.export.fail_on_missing']
     fail = true
 
-    if !fail_on_missing.nil? && !fail_on_missing.empty?
-      if fail_on_missing.to_s == 'false'
-        fail = false
-      end
+    unless fail_on_missing.nil? || fail_on_missing.empty?
+      fail = false if fail_on_missing =~ /false/
     end
     fail
   end

--- a/_docker/tests/export/test_drupal_page_url_list_generator.rb
+++ b/_docker/tests/export/test_drupal_page_url_list_generator.rb
@@ -31,12 +31,11 @@ class TestDrupalPageUrlListGenerator < Minitest::Test
     @drupal_page_list_url_generator.generate_page_url_list!
 
     lines = File.readlines("#{@export_directory}/url-list.txt")
-    assert_equal(8, lines.length)
+    assert_equal(7, lines.length)
     lines.each do | line |
       assert(line.start_with?('http://192.168.99.100:32769/'))
     end
 
-    assert_equal(lines.last, "http://192.168.99.100:32769/robots.txt\n")
   end
 
   def test_should_download_parse_and_generate_links_file
@@ -52,12 +51,11 @@ class TestDrupalPageUrlListGenerator < Minitest::Test
     @drupal_page_list_url_generator.generate_page_url_list!
 
     lines = File.readlines("#{@export_directory}/url-list.txt")
-    assert_equal(8, lines.length)
+    assert_equal(7, lines.length)
     lines.each do | line |
       assert(line.start_with?('http://192.168.99.100:32769/'))
     end
 
-    assert_equal(lines.last, "http://192.168.99.100:32769/robots.txt\n")
   end
 
   def test_should_raise_error_if_fails_to_download


### PR DESCRIPTION
This PR updates the export process to fail if there are missing pages. Previously the behaviour was to simply emit a warning if there were pages missing from the export, however these were going un-noticed and the site was being published with pages missing.

I have also included a mechanism to override this default failure behaviour if you absolutely need to. By setting the `drupal.export.fail_on_missing` environment variable to `false`, you can disable the failure behaviour. This allows you to push an export in times when bad things are happening and you just need to get something up. 

I've added the `drupal.export.fail_on_missing` variable to the `export` container definitions in docker-compose.yml for each environment. The variable is currently set to nothing meaning that the failure behaviour is enabled by default. Should we ever need to disable the failure behaviour, then we can simply set the value of the `drupal.export.fail_on_missing` variable in the Jenkins job configuration for the export.


