### PR TITLE
Reverted back to having Awestruct push the Homepage

### DIFF
--- a/index.html.slim
+++ b/index.html.slim
@@ -3,7 +3,6 @@ layout: base
 body_class: fullbleed
 title: Red Hat Developers
 description: The simple, modern & productive way to build apps and infrastructure.
-ignore_export: true
 ---
 
  


### PR DESCRIPTION
I spoke to Adela, and we agreed that the homepage is too complex to edit in HTML. It would be better to leave this page in Awestruct until either the Awestruct build is turned off, or the homepage is redesigned.