### PR TITLE
DEVELOPER-3429 - Event dates not displaying correctly

### DIFF
--- a/javascripts/events.js
+++ b/javascripts/events.js
@@ -140,6 +140,6 @@ dcp.controller('eventsController', function($scope, searchService, helpers) {
 
 dcp.filter('moment',function() {
   return function(dateString, format){
-    return moment(dateString).format(format);
+    return moment.utc(dateString).format(format);
   };
 });


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3429

This fix pre-supposes that all dates coming into the event moment filter are UTC times and that the day, month, and year are the only relevant data points coming back from the service. If dates are encoded to a specific timezone this may skew the displayed dates.