### PR TITLE
DEVELOPER-3641 - Site export breaking inline DTM JavaScript

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -61,7 +61,7 @@
 
       function getCategories() {
         var categories = { primaryCategory: "", subCategories: [] },
-          url = window.location.href.split('/');
+          url = window.location.href.split(/\//);
         for(var i=3, l=url.length; i<l; i++) {
           if(i !== 3 && categories.subCategories.length <= 3) { 
             categories.subCategories.push(url[i]);
@@ -75,6 +75,7 @@
       dd.page.category.primaryCategory = categoryObj.primaryCategory;
       dd.page.category.subCategories = categoryObj.subCategories;
       dd.page.pageInfo.breadCrumbs = [categoryObj.primaryCategory, categoryObj.subCategories[0] || ""];
+      dd.page.pageInfo.destinationURL = window.location.href;
 
       if ( d.referrer ) {
         var a = d.createElement( "a" );

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -69,6 +69,7 @@
             } else {
               categories.primaryCategory = url[i];
             }
+          }
         }
         return categories;
       }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -63,11 +63,12 @@
         var categories = { primaryCategory: "", subCategories: [] },
           url = window.location.href.split(/\//);
         for(var i=3, l=url.length; i<l; i++) {
-          if(i !== 3 && categories.subCategories.length <= 3) { 
-            categories.subCategories.push(url[i]);
-          } else {
-            categories.primaryCategory = url[i];
-          }
+          if(categories.subCategories.length <= 3) {
+            if( i !== 3 ) {
+              categories.subCategories.push(url[i]);
+            } else {
+              categories.primaryCategory = url[i];
+            }
         }
         return categories;
       }

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -19,7 +19,7 @@ search.service('searchService',function($http, $q) {
       // fold in params with defaults
       var search = Object.assign(params, {
         query_highlight: true,
-        type: ['jbossdeveloper_book', 'jbossdeveloper_event', 'rht_knowledgebase_article', 'rht_knowledgebase_solution', 'stackoverflow_question', 'jbossorg_sbs_forum','jbossorg_blog', 'rht_website']
+        type: ['rht_website', 'jbossdeveloper_book', 'jbossdeveloper_event', 'rht_knowledgebase_article', 'rht_knowledgebase_solution', 'stackoverflow_question', 'jbossorg_sbs_forum','jbossorg_blog']
 
       });
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3641

This replaces the URL-like string in the HTML with a regex with the hopes that it will not be parsed by the site export. Also sneaking in an additional DTM-related data point because it was there too.