### PR TITLE
[DEVELOPER-3638] Ensure Drupal port is consistent throughout life of PR

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -313,6 +313,13 @@ def start_and_wait_for_supporting_services(environment, supporting_services, sys
 end
 
 #
+# Delegates to the environment for initialisation
+#
+def initialise_environment(environment)
+  environment.initialize_environment
+end
+
+#
 # This guard allows the functions within this script to be unit tested without actually executing the script
 #
 if $0 == __FILE__
@@ -320,6 +327,7 @@ if $0 == __FILE__
   system_exec = SystemCalls.new
   tasks = Options.parse ARGV
   environment = load_environment(tasks)
+  initialise_environment(environment)
 
   #the docker url is taken from DOCKER_HOST env variable otherwise
   Docker.url = tasks[:docker] if tasks[:docker]

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -38,7 +38,7 @@ services:
   drupal:
     build: ../../drupal
     ports:
-      - "80"
+      - "${DRUPAL_HOST_PORT}:80"
     links:
       - drupalmysql
     volumes:

--- a/_docker/lib/rhd_environment.rb
+++ b/_docker/lib/rhd_environment.rb
@@ -19,6 +19,28 @@ class RhdEnvironment
   end
 
   #
+  # This method gives the environment a chance to initialise anything that it might need. Typically this will be
+  # setting/loading properties, but it can be anything
+  #
+  def initialize_environment
+    if @environment_name == 'drupal-pull-request'
+      pull_request_number = ENV['ghprbPullId']
+
+      #
+      # In a drupal PR environment, we take the pull request number and add it to 35000 to provide
+      # a consistent port number for the Drupal instance throughout the life of the pull-request. The
+      # 'DRUPAL_HOST_PORT' env variable is passed to the docker-compose commmand, which is used
+      # as a template variable when setting the Drupal port that is exposed on the local machine.
+      #
+      unless pull_request_number.nil? || pull_request_number.empty?
+        pr_drupal_port = 35000 + pull_request_number.to_i
+        ENV['DRUPAL_HOST_PORT'] = pr_drupal_port.to_s
+        puts "- Drupal port has been bound to '#{pr_drupal_port}'."
+      end
+    end
+  end
+
+  #
   # Get the path to the docker-compose.yml file for this environment
   #
   def get_docker_compose_file

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -20,6 +20,12 @@ class TestControl < Minitest::Test
     ENV['cdn_prefix'] = @previous_cdn_prefix
   end
 
+  def test_should_initialise_environment
+    environment = mock()
+    environment.expects(:initialize_environment)
+    initialise_environment(environment)
+  end
+
   def test_bind_drupal_container_details_into_environment
 
     environment = mock()

--- a/_docker/tests/test_rhd_environment.rb
+++ b/_docker/tests/test_rhd_environment.rb
@@ -19,10 +19,44 @@ class TestRhdEnvironment < MiniTest::Test
     ENV['DRUPAL_HOST_PORT'] = nil
     ENV['SEARCHISKO_HOST_IP'] = nil
     ENV['SEARCHISKO_HOST_PORT'] = nil
+    ENV['ghprbPullId'] = nil
 
     FileUtils.rm("#{@environments_directory}/valid-environment/test.txt", :force => true)
     FileUtils.rm("#{@environments_directory}/drupal-pull-request/rhd.settings.yml", :force => true)
   end
+
+  def test_drupal_pr_environment_preselects_drupal_port
+    ENV['ghprbPullId'] = '1205'
+    @environment.environment_name = 'drupal-pull-request'
+    @environment.initialize_environment
+
+    assert_equal(36205, ENV['DRUPAL_HOST_PORT'].to_i)
+
+  end
+
+  def test_drupal_pr_environment_does_not_preselect_port_if_required_env_variable_empty
+    ENV['ghprbPullId'] = ''
+    @environment.environment_name = 'drupal-pull-request'
+    @environment.initialize_environment
+
+    assert_equal(nil, ENV['DRUPAL_HOST_PORT'])
+  end
+
+  def test_drupal_pr_environment_does_not_preselect_port_if_required_env_variable_missing
+    @environment.environment_name = 'drupal-pull-request'
+    @environment.initialize_environment
+
+    assert_equal(nil, ENV['DRUPAL_HOST_PORT'])
+  end
+
+  def test_non_drupal_pr_environment_does_not_preselect_drupal_port
+    ENV['ghprbPullId'] = '1205'
+    @environment.environment_name = 'drupal-production'
+    @environment.initialize_environment
+
+    assert_equal(nil, ENV['DRUPAL_HOST_PORT'])
+  end
+
 
   def test_get_testing_docker_compose_file
     assert_equal("#{@testing_directory}/docker-compose.yml", @environment.get_testing_docker_compose_file)


### PR DESCRIPTION
This pull request updates our start-up scripts to pre-select the Drupal port in a pull request environment to ensure that it is consistent throughout the life of a pull-request.