### PR TITLE
FUSEDOC-1661 Refactored EAP tab in Fuse Get Started

### DIFF
--- a/products/fuse/get-started.adoc
+++ b/products/fuse/get-started.adoc
@@ -3,7 +3,8 @@
 
 :jbdsis-standalone-installer-download-url: https://developers.redhat.com/download-manager/file/devstudio-integration-stack-9.0.2.GA-standalone-installer.jar
 :fuse-on-karaf-download-url: https://developers.redhat.com/download-manager/file/jboss-fuse-karaf-6.3.0.redhat-187.zip
-:installation-on-eap-link: https://access.redhat.com/documentation/en/red-hat-jboss-fuse/6.3/paged/installation-on-jboss-eap
+:eap-download-url: https://developers.redhat.com/download-manager/file/jboss-eap-6.4.0.GA-installer.jar
+:fuse-on-eap-download-url: https://developers.redhat.com/download-manager/content/origin/files/sha256/84/847cd3a03bc3ae41b1b997b2bae34dadaa8a8fee4b45dd70de8b53bb32f953dd/fuse-eap-installer-6.3.0.redhat-187.jar
 
 ## Fuse Runtime
 
@@ -45,8 +46,6 @@ video::183852576[vimeo]
 ----
 java -jar devstudio-integration-stack-9.0.2.GA-standalone-installer.jar
 ----
-+
-Note: This will execute the installation wizard.
 .	During installation:
 .. Accept the terms and conditions
 .. Choose your preferred installation path
@@ -172,44 +171,48 @@ Before you start, make sure you have installed the following software:
 
 * Java SE Development Kit (JDK) version 1.8.x (Java 8) - we recommend Oracle JDK or OpenJDK
 * https://maven.apache.org/download.cgi[Apache Maven]
-* JBoss Fuse on EAP runtime - see {installation-on-eap-link}/[Installation on JBoss EAP]
+
+[[fuse-eap-install-runtime]]
+=== Install and configure the JBoss Fuse on JBoss EAP runtime
+
+. Download the {eap-download-url}[JBoss EAP] runtime package.
+. Run the JBoss EAP installer, as follows:
++
+----
+java -jar jboss-eap-6.4.0-installer.jar
+----
+. During installation:
+.. Accept the terms and conditions
+.. Choose your preferred installation path, `_EAPInstall_`, for the JBoss EAP runtime
+.. Create an administrative user and make a careful note of these administrative user credentials for later
+.. You can accept the default settings on the remaining screens
+. Download the {fuse-on-eap-download-url}[Fuse on EAP] runtime package.
+. Open a command prompt and change directory to `_EAPInstall_`.
+. From the `_EAPInstall_` directory, run the Fuse on EAP installer, as follows:
++
+----
+java -jar <TEMP_LOCATION>/fuse-eap-installer-6.3.0.redhat-187.jar
+----
 
 === Set up your development environment
 
 The following steps will install a local version of JBoss Developer Studio 9.1.0 (the Eclipse Mars edition) along with the Fuse tooling.
 
 . Download the {jbdsis-standalone-installer-download-url}[Red Hat JBoss Developer Studio Integration Stack 9.0.2.GA Stand-Alone Installer].
-. Run the installer
-.. For Mac / Windows Development Hosts:
-... Go to the folder you have downloaded the installer and either:
-.... Right-click on the installer jar
-.... Select *Open With->Jar Launcher*
-... Or double-click on the jar to start the installer (on Windows).
-.. For Linux Development Hosts:
-... Go to the folder where you have downloaded the installer and execute it with
+. Go to the folder where you have downloaded the installer and execute it with
 +
 ----
 java -jar devstudio-integration-stack-9.0.2.GA-standalone-installer.jar
 ----
-+
-Note: This will execute the installation wizard.
-. In the wizard, ensure that you select your JDK, not the JRE chosen by default.
-. Also in the wizard, on the *Select Additional Features to Install* page, ensure you select *JBoss Fuse Development*
-. Start Developer Studio.
-
-=== Define a JBoss EAP Server
-Now that you have Developer Studio and Fuse Tools installed, you can install a reference to your installed Fuse on EAP runtime to explore via the tooling.
-
-. Start Developer Studio.
-. Find the *Servers* view in the JBoss (default) perspective.
-. Click the *No servers are available. Click this link to create a new server* link.
-. In the *New Server* wizard, choose *Red Hat JBoss Middleware->Red Hat JBoss Enterprise Application Platform 6.1+*. Click *Next*.
-. On the *Create a new Server Adapter* page, accept the default settings. Click *Next*.
-. On the *JBoss Runtime* page, type the directory where your JBoss Fuse on EAP server was installed or click *Browse* and find the directory in the *File* dialog.
-. Click *Next*.
-. Update the user name and password you set up during the server installation process.
-. Click *Finish*.
-. On the *Servers* tab, select your new server and click on the green start button to start the EAP Server.
+.	During installation:
+.. Accept the terms and conditions
+.. Choose your preferred installation path
+.. Select the Java 8 JVM
+.. At the *Select Platforms and Servers* step, configure the runtime server by clicking *Add* and browsing to the location of the `_EAPInstall_` directory (see <<fuse-eap-install-runtime>>)
+.. Select *JBoss Fuse Development* as additional features
+. Developer environment will start up.
+When the *Searching for runtimes* dialog appears, click *OK* to create the JBoss EAP runtime.
+. Accept any additional dependencies and license agreements.
 
 === Build your first Fuse on EAP application
 With your tooling and runtime installed, you're ready to start your first project. We'll get you started with a Spring-based Camel route on EAP.
@@ -219,15 +222,15 @@ First, we need to create a new Fuse Project.
 
 . Select *File->New->Fuse Integration Project*.
 . Call it `eap-camel`. Click *Next*.
-. Select your Fuse on EAP server as the *Target Runtime*. Click *Next*.
+. Select your `Red Hat JBoss EAP 6.4 Runtime` server as the *Target Runtime*. Click *Next*.
 . Select *Use a predefined template*.
 . Select the *Fuse on EAP->Medium->Spring on EAP* template.
 . Click *Finish*.
 
 ==== Deploy the Project to the Server
 
-. In the *Servers* view, if your server isn’t already started - select your runtime server and click the green arrow to start it.
-. Right-click on the server after it is started and select *Add and Remove* from the context menu.
+. In the *Servers* view (bottom left corner of the Fuse Integration perspective), if your server isn’t already started - select your runtime server and click the green arrow to start it.
+. After the server has started, switch back to the *Servers* view, right-click on the server and select *Add and Remove* from the context menu.
 . In the *Add and Remove* dialog, select your `eap-camel` project and click the *Add >* button.
 . Click *Finish*.
 


### PR DESCRIPTION
This pull requests implements [FUSEDOC-1661](https://issues.jboss.org/browse/FUSEDOC-1661), which is an enhancement request to document the steps for installing the Fuse on EAP runtime explicitly in the Get Started doc, instead of referencing the JBoss Fuse product docs on the customer portal.