### PR TITLE
Updated title to 'OpenJDK'

### DIFF
--- a/products/openjdk/overview.adoc
+++ b/products/openjdk/overview.adoc
@@ -2,10 +2,10 @@
 :awestruct-interpolate: true
 :awestruct-id: microsite-id
 :awestruct-graphic: "http://static.jboss.org/images/rhd/minipage/RHDev_pageimage_openjdk_16jun2016.png"
-:title: Red Hat OpenJDK
+:title: OpenJDK
 
 // Microsite title
-### Red Hat OpenJDK
+### OpenJDK
 
 // Microsite subtitle
 #### A Tried, Tested and Trusted open source implementation of the Java platform


### PR DESCRIPTION
Update the title to say "OpenJDK" instead of "Red Hat OpenJDK"