### PR TITLE
Reverted to pushing /register via awestruct

### DIFF
--- a/register.html.slim
+++ b/register.html.slim
@@ -1,7 +1,3 @@
----
-ignore_export: true
----
-
 html
 head
   meta name="description" content="Register for the Red Hat Developer Program.  It's free to join."


### PR DESCRIPTION
The #{site.base_url} needs to be set based on the correct environment. If not, tests will fail as /register on staging will redirect to the production download manager. I'm not aware of a site variable that can be used to parametrise this.