### PR TITLE
Removed version number text from WildFly link

### DIFF
--- a/products/eap/download.adoc
+++ b/products/eap/download.adoc
@@ -3,6 +3,6 @@
 
 == Upstream
 
-http://www.wildfly.org[WildFly 8.1.0, role="download-link"] +
+http://www.wildfly.org[WildFly, role="download-link"] +
 Visit the http://wildfly.org/downloads/[project download] page for more options and all versions.
 


### PR DESCRIPTION
This link is unlikely to get updated as new versions are released. It also adds little value, so I've simplified the text.