### PR TITLE
DEVELOPER-3469 - Google Tag Manager script HTTPS always

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -147,10 +147,10 @@
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
               new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-              '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-NJWS5L');
     </script>
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-NJWS5L" height="0" width="0"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NJWS5L" height="0" width="0"></iframe></noscript>
  {% endif %}
  {{ page_top}}
  <div class="site-wrapper">

--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -83,10 +83,10 @@
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NJWS5L');
       noscript
-        iframe src="//www.googletagmanager.com/ns.html?id=GTM-NJWS5L" height="0" width="0"
+        iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NJWS5L" height="0" width="0"
 
     - if site.under_development
       = partial 'under-development.html.slim', parent: page


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3469

Updates the GTM include to be HTTPS-only, to prevent protocol incompatibilities between secure and non-secure access. 