### PR TITLE
[DEVELOPER-3667] Added --no-pull option to control.rb to bypass Docker Hub

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -315,9 +315,9 @@ end
 #
 # Delegates to the environment for initialisation
 #
-def initialise_environment(environment, system_exec)
+def initialise_environment(environment, pull_drupal_data_image, system_exec)
   environment.initialize_environment
-  if environment.pull_drupal_data_image?
+  if pull_drupal_data_image
     puts '- Pulling drupal_data image from Docker Hub...'
     system_exec.execute_docker_compose(environment, :pull, %w(drupal_data));
     puts '- Completed pull of drupal_data image from Docker Hub.'
@@ -332,7 +332,7 @@ if $0 == __FILE__
   system_exec = SystemCalls.new
   tasks = Options.parse ARGV
   environment = load_environment(tasks)
-  initialise_environment(environment, system_exec)
+  initialise_environment(environment, tasks[:docker_pull], system_exec)
 
   #the docker url is taken from DOCKER_HOST env variable otherwise
   Docker.url = tasks[:docker] if tasks[:docker]

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -151,6 +151,11 @@ class Options
         tasks[:decrypt] = false
       end
 
+      opts.on('--no-pull','Do not attempt to pull the :latest version of the drupal-data image from Docker Hub') do
+        tasks[:docker_pull] = false
+      end
+
+
       #
       # Required during the transition to Drupal PR building. As the Drupal PR job is a downstream of the current
       # PR job, we don't want to kill any environment that is currently running.
@@ -176,6 +181,14 @@ class Options
     testing_directory = File.expand_path('../environments/testing',File.dirname(__FILE__))
     environment = RhdEnvironments.new(File.expand_path('../environments',File.dirname(__FILE__)), testing_directory).load_environment(tasks[:environment_name])
     tasks[:environment] = environment
+
+    #
+    # Unless specified explicitly by the --no-pull option, we determine if we should pull the drupal-data image based upon
+    # the defaults set by the environment in which we are running.
+    #
+    if tasks[:docker_pull].nil?
+      tasks[:docker_pull] = environment.pull_drupal_data_image?
+    end
 
     #
     # Set the list of supporting services to be started from the environment, unless the options above explicitly set it first

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -25,17 +25,15 @@ class TestControl < Minitest::Test
     system_exec = mock()
     environment = mock()
     environment.expects(:initialize_environment)
-    environment.expects(:pull_drupal_data_image?).returns(false)
-    initialise_environment(environment, system_exec)
+    initialise_environment(environment, false, system_exec)
   end
 
   def test_should_initialise_environment_and_pull_latest_image_if_required
     system_exec = mock()
     environment = mock()
     environment.expects(:initialize_environment)
-    environment.expects(:pull_drupal_data_image?).returns(true)
     system_exec.expects(:execute_docker_compose).with(environment, :pull, %w(drupal_data))
-    initialise_environment(environment, system_exec)
+    initialise_environment(environment, true, system_exec)
   end
 
 

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -32,6 +32,23 @@ class TestOptions < Minitest::Test
     assert_equal([], tasks[:supporting_services])
   end
 
+  def test_no_pull_option
+    tasks = Options.parse(['--no-pull'])
+    refute(tasks[:docker_pull])
+  end
+
+  def test_no_pull_defaults_to_environment_if_not_specified
+    tasks = Options.parse(['-e', 'drupal-dev'])
+    assert(tasks[:docker_pull])
+  end
+
+
+  def test_no_pull_overrides_environment_default
+    tasks = Options.parse(['-e', 'drupal-dev', '--no-pull'])
+    refute(tasks[:docker_pull])
+  end
+
+
 
   def test_loads_awestruct_pull_request_environment_by_default
     tasks = Options.parse(['-t'])


### PR DESCRIPTION
This PR adds support for a `--no-pull` option on control.rb. Using this you can bypass the pull of the `redhatdeveloper/drupal-data` image from DockerHub if it already exists on your machine.

For example:

```
bundle exec _docker/control.rb -e drupal-dev --run-the-stack --no-pull
```

This will use the pre-existing `redhatdeveloper/drupal-data` Docker image on your machine. 

Note: If the `redhatdeveloper/drupal-data` image does not exist locally, then the `--no-pull` option has no effect. You must pull the image in this scenario.

