### PR TITLE
DEVELOPER-3666: Run Keycloak/DM tests in staging

### DIFF
--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -92,3 +92,40 @@ services:
       - ../../../:/home/awestruct/developer.redhat.com
     entrypoint: "bundle exec rake test"
 
+  acceptance_tests:
+    build: ../../awestruct
+    volumes:
+      - ../../../:/home/awestruct/developer.redhat.com
+    environment:
+      - PARALLEL_TEST
+      - CUCUMBER_TAGS
+      - SELENIUM_HOST=http://selhub:4444/wd/hub
+      - RHD_JS_DRIVER
+      - RHD_DOCKER_DRIVER
+      - BUILD_URL
+      - RHD_TEST_PROFILE
+
+  docker_chrome:
+    image: selenium/node-chrome-debug:2.53.0
+    volumes:
+      - /dev/shm:/dev/shm
+      - ../../../_cucumber/tmp_downloads:/home/awestruct/developer.redhat.com/_cucumber/tmp_downloads
+    environment:
+      - HUB_PORT_4444_TCP_ADDR=selhub
+      - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    depends_on:
+      - selhub
+    ports:
+      - "5900"
+
+  docker_firefox:
+    image: selenium/node-firefox-debug:2.53.0
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - HUB_PORT_4444_TCP_ADDR=selhub
+      - DBUS_SESSION_BUS_ADDRESS=/dev/null
+    depends_on:
+      - selhub
+    ports:
+      - "5900"


### PR DESCRIPTION
…ging docker-compose file.

corrected typo

acceptance status should match the drupal PR docker-compose file.

removed apache docker from firefox

edited docker firefox task.

reverted changed to drupal dev

removed Service 'docker_firefox' has a link to service 'apache:docker' which is undefined error.

enabling download manager related tests

Ignore download tests