### PR TITLE
DEVELOPER-3680 - Stop event when messageCallback is not a string

### DIFF
--- a/javascripts/vendor/keycloak.js
+++ b/javascripts/vendor/keycloak.js
@@ -791,7 +791,7 @@
                 if (typeof event.data == "string") {
                     data = JSON.parse(event.data);
                 } else {
-                    data = event.data;
+                    return;
                 }
                 
                 var promise = loginIframe.callbackMap[data.callbackId];


### PR DESCRIPTION
The data being sent to this function is set up to be a specific string. The object being sent in is unrelated to the processing being done here.