### PR TITLE
Small style fixes for Resources page

### DIFF
--- a/resources.html.slim
+++ b/resources.html.slim
@@ -15,48 +15,49 @@ drupal_format: as_is_html
 
 
 div(ng-app="search")
-  #searchpage(ng-controller="SearchController")
+  div(ng-controller="SearchController")
     / pre {{params | json}}
     .large-24.column.type-filters-wrap
       .row
-        .large-24.column
+        .large-24.columns
           p: strong Find by type:
-      .row.type-filters
-        input(type="checkbox" value="blogpost" ng-checked="params.sys_type.indexOf('blogpost') > -1" ng-click="toggleSelection($event)" id="blogposts")
-        label(for="blogposts")
-          i.icon-RHDev_-resources_icons_blogpost
-          h3 Blog Posts
-          p Track the latest topics by following the Red Hat Developer blog
+        .large-24.columns.type-filters
 
-        input(type="checkbox" value="jbossdeveloper_book book" ng-checked="params.sys_type.indexOf('jbossdeveloper_book') > -1" ng-click="toggleSelection($event)" id="book")
-        label(for="book")
-          i.icon-RHDev_-resources_icons_book
-          h3 Book
-          p Catch-up with these comprehensive collections
+          input(type="checkbox" value="blogpost" ng-checked="params.sys_type.indexOf('blogpost') > -1" ng-click="toggleSelection($event)" id="blogposts")
+          label(for="blogposts")
+            i.icon-RHDev_-resources_icons_blogpost
+            h3 Blog Posts
+            p Track the latest topics by following the Red Hat Developer blog
 
-        input(type="checkbox" value="demo quickstart jbossdeveloper_archetype jbossdeveloper_bom quickstart_early_access" ng-checked="params.sys_type.indexOf('demo') > -1" ng-click="toggleSelection($event)" id="code")
-        label(for="code")
-          i.icon-RHDev_-resources_icons_demo
-          h3 Code Artifact
-          p Shorten your time-to-code with these code samples
+          input(type="checkbox" value="jbossdeveloper_book book" ng-checked="params.sys_type.indexOf('jbossdeveloper_book') > -1" ng-click="toggleSelection($event)" id="book")
+          label(for="book")
+            i.icon-RHDev_-resources_icons_book
+            h3 Book
+            p Catch-up with these comprehensive collections
 
-        input(type="checkbox" value="jbossdeveloper_example" ng-checked="params.sys_type.indexOf('jbossdeveloper_example') > -1" ng-click="toggleSelection($event)" id="get-started")
-        label(for="get-started")
-          i.icon-RHDev_-resources_icons_getstarted
-          h3 Get Started
-          p Use your time wisely with effective getting-started documents
+          input(type="checkbox" value="demo quickstart jbossdeveloper_archetype jbossdeveloper_bom quickstart_early_access" ng-checked="params.sys_type.indexOf('demo') > -1" ng-click="toggleSelection($event)" id="code")
+          label(for="code")
+            i.icon-RHDev_-resources_icons_demo
+            h3 Code Artifact
+            p Shorten your time-to-code with these code samples
 
-        input(type="checkbox" value="solution article" ng-checked="params.sys_type.indexOf('solution') > -1" ng-click="toggleSelection($event)" id="knowledge")
-        label(for="knowledge")
-          i.icon-RHDev_-resources_icons_article
-          h3 Knowledgebase Article / Solution
-          p Members only articles and verified solutions for self-service support.
+          input(type="checkbox" value="jbossdeveloper_example" ng-checked="params.sys_type.indexOf('jbossdeveloper_example') > -1" ng-click="toggleSelection($event)" id="get-started")
+          label(for="get-started")
+            i.icon-RHDev_-resources_icons_getstarted
+            h3 Get Started
+            p Use your time wisely with effective getting-started documents
 
-        input(type="checkbox" value="video" ng-checked="params.sys_type.indexOf('video') > -1" ng-click="toggleSelection($event)" id="video")
-        label(for="video")
-          i.icon-RHDev_-resources_icons_video
-          h3 Video
-          p Watch how Red Hatters and contributers utilize development tools
+          input(type="checkbox" value="solution article" ng-checked="params.sys_type.indexOf('solution') > -1" ng-click="toggleSelection($event)" id="knowledge")
+          label(for="knowledge")
+            i.icon-RHDev_-resources_icons_article
+            h3 Knowledgebase Article / Solution
+            p Members only articles and verified solutions for self-service support.
+
+          input(type="checkbox" value="video" ng-checked="params.sys_type.indexOf('video') > -1" ng-click="toggleSelection($event)" id="video")
+          label(for="video")
+            i.icon-RHDev_-resources_icons_video
+            h3 Video
+            p Watch how Red Hatters and contributers utilize development tools
 
     .large-24.columns.searchpage-middle
       .row


### PR DESCRIPTION
Removed white space below page banner and made filters width fit within the page's content section