### PR TITLE
Fixing DEVELOPER-3718 Layout bug on download page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--download.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--download.html.twig
@@ -52,7 +52,7 @@
                 our
                 commitment to providing an exceptional customer experience.
             </p>
-            <a href="{{ content.field_subscription_link['#items']|first.uri }}" class="button">I need a subscription</a></div>
+            <a href="{{ content.field_subscription_link['#items']|first.uri }}" class="button">I need a subscription</a>
         </div>
     {% endif %}
     {% if content.field_upstream_section|render|striptags|trim is not empty %}


### PR DESCRIPTION
Please see https://issues.jboss.org/browse/DEVELOPER-3718 for full information and definition of done.

A `div` tag was closed before it should have been.