### PR TITLE
DEVELOPER-3728 - Adobe DTM User Auth Events Double-counting

### DIFF
--- a/javascripts/sso.js
+++ b/javascripts/sso.js
@@ -33,8 +33,6 @@ app.sso = function () {
                     }
                 }
 
-                updateAnalytics(usr);
-
             }).error(clearTokens);
         } else {
             $('li.login, section.register-banner, .devnation-hidden-code').show();
@@ -49,6 +47,8 @@ app.sso = function () {
                 keycloak.login({ action : 'register', redirectUri : app.ssoConfig.confirmation });
             });
         }
+
+        updateAnalytics(usr);
     }
 
     function daysDiff(dt1, dt2) {


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3728

Moves the user auth event outside of the authentication to push whether the user is authenticated or not. May change at some point to a different event name based on Search Discovery's input after the New Year.
