### PR TITLE
FIX: Remove hard-coded referral-alert from product page template

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
@@ -75,21 +75,6 @@
 
 {% set product_machine_name = elements.field_product_machine_name[0]['#context']['value']|lower %}
 {% set active_paragraph = elements.active_paragraph['#paragraph'] %}
-<section id="referral-alert" class="hide">
-    <div class="row content">
-        <div class="large-24 columns">
-            <div class="large-24 columns">
-                <div class="alert-box info radius">
-                    <h4>You have been redirected from JBoss.org to Red Hat Developers.</h4>
-                    <p>It’s true — JBoss Developer and Red Hat Developers are one
-                        and the same, and you can find all the great stuff you were
-                        looking for right here on <a href="http://developers.redhat.com/">developers.redhat.com.</a></p>
-                    <a class="close">x</a>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
 <div class="mobile product-color {{ elements.product_category }}"></div>
 <div class="mobile product-header">
     <div class="row">


### PR DESCRIPTION
Should fix product pages' failing referral alert test as there will not be a hard-coded node on the page.