### PR TITLE
Fixes DEVELOPER-3688 Get Started -> Hello World

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.paragraph.get_started.field_overview_url.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.paragraph.get_started.field_overview_url.yml
@@ -15,7 +15,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: 'Get Started'
+    value: 'Hello World'
 default_value_callback: ''
 settings: {  }
 field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.get_started.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.get_started.yml
@@ -3,4 +3,4 @@ langcode: en
 status: true
 dependencies: {  }
 id: get_started
-label: 'Get Started'
+label: 'Hello World'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.getting_started_section.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.getting_started_section.yml
@@ -3,4 +3,4 @@ langcode: en
 status: true
 dependencies: {  }
 id: getting_started_section
-label: 'Getting Started Blue Section'
+label: 'Hello World Blue Section'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.getting_started_tab_section.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/paragraphs.paragraphs_type.getting_started_tab_section.yml
@@ -3,4 +3,4 @@ langcode: en
 status: true
 dependencies: {  }
 id: getting_started_tab_section
-label: 'Getting Started Tab Section'
+label: 'Hello World Tab Section'

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.install
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.install
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Update module to update the URL entry of the get started to 'Hello World'.
+ */
+function rhd_common_update_8200() {
+    $query = \Drupal::entityQuery('node');
+    $query->condition('type', 'product');
+    $entity_ids = $query->execute();
+    \Drupal::logger('rhd_common')->debug("Found entities: @entity_ids", ['@entity_ids' => $entity_ids]);
+    $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($entity_ids);
+    array_walk($nodes, 'walkProducts');
+}
+
+/**
+ * Iteration method to walk over all products and update the 'field_overview_url' field.
+ * @param Drupal\node\Entity\Node $product
+ * @param string $key unused
+ */
+function walkProducts(&$product, $key) {
+    $sub_pages = $product->field_product_pages->referencedEntities();
+    /** @var \Drupal\paragraphs\Entity\Paragraph $get_started_paragraph */
+    $get_started_paragraph = &current(array_filter($sub_pages, 'findGetStartedPage'));
+    if ($get_started_paragraph instanceof \Drupal\paragraphs\Entity\Paragraph) {
+        \Drupal::logger('rhd_common')->debug("Found paragraph: @get_started_paragraph", ['@get_started_paragraph' => $get_started_paragraph->id()]);
+        \Drupal::logger('rhd_common')->debug("Found paragraph url: @get_started_paragraph", ['@get_started_paragraph' => $get_started_paragraph->field_overview_url->value]);
+        $get_started_paragraph->field_overview_url = 'Hello World';
+        $get_started_paragraph->save();
+        $product->setNewRevision(TRUE);
+        $product->setRevisionAuthorId(1); // Admin
+        $product->setRevisionLogMessage('Updating the url to "Hello World"');
+        $product->save();
+    }
+}
+
+/**
+ * @param \Drupal\paragraphs\Entity\Paragraph $paragraph
+ * @return boolean
+ */
+function findGetStartedPage(&$paragraph) {
+    return strtolower($paragraph->field_overview_url->value) === 'get started';
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
@@ -11,7 +11,7 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     {{ title_suffix }}
 
     <div{{ content_attributes }}>
-        <h2 id="get-started">Get Started</h2>
+        <h2 id="get-started">Hello World</h2>
         {% if content.field_overview_main_content|render|striptags|trim is not empty %}
             {{ content.field_overview_main_content }}
         {% else %}

--- a/_docker/lib/export/static_export_rsync.rb
+++ b/_docker/lib/export/static_export_rsync.rb
@@ -50,7 +50,7 @@ class StaticExportRsync
   #
   def rsync(local_folder, remote_destination, delete)
     @log.info("rsyncing folder '#{local_folder}' to '#{remote_destination}'...")
-    @process_runner.execute!("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet#{' --delete' if delete} --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{local_folder}/ #{remote_destination}")
+    @process_runner.execute!("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet#{' --delete' if delete} --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{local_folder}/ #{remote_destination}")
   end
 
   def replace_create_path(path)

--- a/_docker/tests/export/test_static_export_rsync.rb
+++ b/_docker/tests/export/test_static_export_rsync.rb
@@ -31,7 +31,7 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:/my/target/directory'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host_directory}")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host_directory}")
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, false)
   end
 
@@ -40,7 +40,7 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:/my/target/directory'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host_directory}")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host_directory}")
     @export_archiver.expects(:archive_site_export).with(export_dir)
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, true)
   end
@@ -82,10 +82,10 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:/it-rhd-stg/stg_main[/my/target/directory]'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
     @export_archiver.expects(:archive_site_export).with(export_dir)
 
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, true)
@@ -97,10 +97,10 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:/it-rhd-stg/stg_main[/my/target/directory]'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/it-rhd-stg/stg_main/my/target/directory")
 
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, false)
 
@@ -111,10 +111,10 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:[/my/target/directory]'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target/directory")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/my/target/directory")
     @export_archiver.expects(:archive_site_export).with(export_dir)
 
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, true)
@@ -126,10 +126,10 @@ class TestStaticExportRsync < MiniTest::Test
     target_host = 'rhd@filemgnt.jboss.org'
     target_host_directory = 'rhd@filemgnt.jboss.org:[/my/target/directory]'
 
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target/directory")
-    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{@empty_directory}/ #{target_host}:/my/target/directory")
+    @process_runner.expects(:execute!).with("rsync --filter='P *.css' --filter='P apidocs' --filter='P cdn' --filter='P get-started' --partial --archive --checksum --compress --omit-dir-times --quiet --delete --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --exclude='.snapshot' #{export_dir}/ #{target_host}:/my/target/directory")
 
     @static_export_rsync.rsync_static_export(export_dir, target_host_directory, false)
 


### PR DESCRIPTION
Please see https://issues.jboss.org/browse/DEVELOPER-3688 for full information.

We want to move the "Get Started" pages to be called "Hello World". We should also be able to keep the "Get Started" pages for now so we can do the redirects, then remove the old pages.