### PR TITLE
DEVELOPER-3771 Changing the url for the "Get Started" Button

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
@@ -110,7 +110,7 @@
                             </div>
                             <div class="small-24 large-6 columns"><p>Let's walk through everything you need to build your
                                     first application.</p></div>
-                            <div class="small-24 large-6 columns"><a class="button" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'get-started'}) }}">Get Started</a>
+                            <div class="small-24 large-6 columns"><a class="button" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'hello-world'}) }}">Get Started</a>
                             </div>
                             <div class="small-24 large-6 columns outside-links">
                                 <a class="large-24 medium-12 columns"
@@ -141,7 +141,7 @@
                 <h4 class="caps">Build Something Today</h4>
                 <p>Let's walk through everything you need to build your first application.</p>
                 <a class="button" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'download'}) }}">Download</a>
-                <a class="button inverse" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'get-started'}) }}">Get Started</a>
+                <a class="button inverse" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'hello-world'}) }}">Get Started</a>
                 <div class="outside-links">
                     <a class="large-24 medium-12 columns" href="http://www.redhat.com/en/about/contact/sales"><strong>Buy It</strong>
                         <p>

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/templates/product-pages.html.twig
@@ -82,7 +82,7 @@
             <h3>{{ elements.title }}</h3>
             <a class="button"
                href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'downloads'}) }}">Download</a><a
-                    class="button inverse" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'get-started'}) }}">Get
+                    class="button inverse" href="{{ url('rhd_common.main_page_controller', {'product_code': elements.url_product_name, 'sub_page': 'hello-world'}) }}">Get
                 Started</a>
         </div>
     </div>


### PR DESCRIPTION
Fixing the URL of the "Get Started" button to point to the Hello World pages instead of Get Started pages.