### PR TITLE
DEVELOPER-3776 - Fix styles for code within pre tag

### DIFF
--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -137,6 +137,10 @@ $include-html-global-classes: false; // fix for our version of ruby - https://gi
   }
 }
 
+pre code {
+  border: none;
+}
+
 .content {
   padding:1em 0;
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3776

Removes the border from code tags when they are within a pre tag.