### PR TITLE
[DEVELOPER-3500] Remove references to Drupal host from site export

### DIFF
--- a/_docker/lib/export/README.md
+++ b/_docker/lib/export/README.md
@@ -31,7 +31,7 @@ The export process relies on [httrack](https://www.httrack.com/) to perform the 
 The default configuration of httrack is as follows:
 
 ```
---list /export/url-list.txt -O /export --disable-security-limits -c50 --max-rate 0 -v +"http://#{drupal_host}*" -"*/node*" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t
+--list /export/url-list.txt -O /export --disable-security-limits -c50 --max-rate 0 -v +"http://#{drupal_host}*" -"*/node*" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer "<!-- -->"
 ```
 
 The options specified are:
@@ -47,6 +47,7 @@ The options specified are:
 * -o0 -> Instructs httrack not to generate a 404 page for any content that is missing
 * -N ?html? -> Configures httrack to save any HTML page in the format `host/path/name/index.html` e.g. `docker/containers/overview/index.html`
 * -N -> Configures httrack to save any non-HTML asset using the path that it exists at on the original site
+* --footer -> This is the message that httrack will write to the HTML to say where it mirrored from. We override this to hide details of the Drupal host. Ideally this should be set to `(none)`, but a bug in httrack prevents it from working when updating a cache, so instead we add an empty HTML comment
 
 
 The full range of httrack configuration options are available [here](https://www.httrack.com/html/fcguide.html).

--- a/_docker/lib/export/httrack_export_strategy.rb
+++ b/_docker/lib/export/httrack_export_strategy.rb
@@ -32,7 +32,7 @@ class HttrackExportStrategy
   def run_new_export(links_file, drupal_host, export_directory)
 
     @log.info("Running first time export of content from '#{drupal_host}'. Be patient, this will take time...")
-    @process_runner.execute!("httrack --list #{links_file.to_path} -O #{export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t")
+    @process_runner.execute!("httrack --list #{links_file.to_path} -O #{export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
     @log.info("Completed export of content from '#{drupal_host}'")
 
   end

--- a/_docker/tests/export/test_export_form_rewrite/remove-drupal-url/index.html
+++ b/_docker/tests/export/test_export_form_rewrite/remove-drupal-url/index.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="ie8 lt-ie9" lang="en"><![endif]--><!--[if IE 9]><html class="ie9" lang="en"><![endif]--><!--[if (gte IE 9)|!(IE)]<!--><html lang="en">
+<!--<![endif]--><!-- Added by HTTrack --><head>
+    <meta http-equiv="content-type" content="text/html;charset=UTF-8">
+    <!-- /Added by HTTrack --><!--[if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/ie8/0.4.1/ie8.js" ></script><![endif]--><script>
+    var digitalData = {"page":{"attributes":{"queryParameters":""},"category":{"contentType":"","contentSubType":"","keyPage":false,"keyPageType":"","pageType":"","primaryCategory":"","subCategories":[]},"pageInfo":{"breadCrumbs":[],"cms":"RHD CMS 8","destinationURL":"","errorMessage":"","errorType":"","language":"en","pageID":"1745","contentID":"1745","pageName":"","referringDomain":"","referringURL":"","syndicationIds":[],"sysEnv":"","title":"Red Hat Developers"},"listing":{"browseFilter":"","query":"","queryMethod":"","refinementType":"","refinementValue":"","resultCount":"","searchType":""}},"user":[{"profile":[{"profileInfo":{"accountID":"","daysSinceLastPurchase":"","daysSinceRegistration":"","eloquaGUID":"POPULATE ELOQUA ID","keyCloakID":"","loggedIn":false,"profileID":"","registered":false,"socialAccountsLinked":[],"subscriptionFrequency":"","subscriptionLevel":"","userAgent":""}}]}],"event":[]},
+        relURL = window.location.href.replace(/https?:\/\//,'').replace('developer-drupal.web.prod.ext.phx2.redhat.com','').replace('developers.redhat.com','').replace(/\/$/,'');
+
+    /**
+     * Creates and dispatches an event trigger
+     * @param {String} evt - The name of the event
+     */
+    function sendCustomEvent(evt){
+        if(document.createEvent && document.body.dispatchEvent){
+            var event = document.createEvent('Event');
+            event.initEvent(evt, true, true); //can bubble, and is cancellable
+            document.body.dispatchEvent(event);
+        } else if(window.CustomEvent && document.body.dispatchEvent) {
+            var event = new CustomEvent(evt, {bubbles: true, cancelable: true});
+            document.body.dispatchEvent(event);
+        }
+    }
+
+    ( function( w, d, dd, undefined ) {
+        var categoryObj = getCategories();
+
+        function getCookie( name ) {
+            var value = "; " + document.cookie;
+            var parts = value.split( "; " + name + "=" );
+            if ( parts.length == 2 ) {
+                return parts.pop().split( ";" ).shift();
+            }
+        }
+
+        function getQueryParams() {
+            return relURL.split('?')[1] ? relURL.split('?')[1].replace(/=/g,':').split('&') : "";
+        }
+
+        function getCategories() {
+            var categories = { primaryCategory: "", subCategories: [] },
+                url = relURL.split('?')[0].split('#')[0].split(/\//);
+            for(var i=1, l=url.length; i<l; i++) {
+                if (i !== 1 && i <= 3) {
+                    categories.subCategories.push(url[i]);
+                }
+
+                if (i === 1) {
+                    categories.primaryCategory = url[i].length > 0 ? url[i] : "home page";
+                }
+            }
+            return categories;
+        }
+
+        function getPageName() {
+            var splitURL = relURL.split('?')[0].split('#')[0].split(/\//),
+                page = splitURL.pop();
+            return page.length > 0 ? page : 'home page';
+        }
+
+        dd.page.attributes.queryParameters = getQueryParams();
+        dd.page.category.primaryCategory = categoryObj.primaryCategory;
+        dd.page.category.subCategories = categoryObj.subCategories;
+        dd.page.pageInfo.destinationURL = window.location.href;
+        dd.page.pageInfo.pageName = getPageName();
+        dd.page.pageInfo.breadCrumbs = [categoryObj.primaryCategory, categoryObj.subCategories[0] || ""];
+
+        if ( d.referrer ) {
+            var a = d.createElement( "a" );
+            a.href = d.referrer;
+
+            dd.page.pageInfo.referringDomain = a.hostname;
+            dd.page.pageInfo.referringURL = a.href;
+        }
+
+        dd.page.pageInfo.sysEnv = ( w.innerWidth <= 768 ) ? "tablet" : "desktop";
+
+        var elqGUID = getCookie( "rh_elqCustomerGUID" );
+        if ( elqGUID ) {
+            dd.user[ 0 ].profile[ 0 ].profileInfo.eloquaGUID = elqGUID;
+        }
+
+    } )( window, document, digitalData );
+</script><script id="adobe_dtm" src="https://assets.adobedtm.com/2b327a0a54b320bf1bcdb5fa39a2b896027067d9/satelliteLib-9ec3c34e9d660fa2fcb85ced512c3a48dc09c0c5.js"></script><!--TODO: metrics here--><!--TODO: include Adobe A/B testing inline--><meta charset="utf-8">
+    <meta name="referrer" content="no-referrer">
+    <meta name="title" content="Red Hat Developers | Red Hat Developers">
+    <meta property="og:type" content="page">
+    <meta name="twitter:card" content="summary">
+    <meta name="description" content="The simple, modern &amp; productive way to build apps and infrastructure.">
+    <meta name="Generator" content="Drupal 8 (https://www.drupal.org)">
+    <meta name="MobileOptimized" content="width">
+    <meta name="HandheldFriendly" content="true">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" href="themes/custom/rhd/favicon.ico" type="image/vnd.microsoft.icon">
+    <link rel="canonical" href="./">
+    <link rel="shortlink" href="http://developer-drupal.web.prod.ext.phx2.redhat.com/node/1745">
+    <link rel="revision" href="./">
+    <meta charset="utf-8">
+    <meta content="bxtQxPXTaA2g5bXw_buofCT53_Uwp1fGAu9uHSA0UWc" name="google-site-verification">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>Red Hat Developers | Red Hat Developers</title>
+    <link rel="stylesheet" href="sites/default/files/css/css_fJSGC_69MLA2PukKR_x1DKCH0YRzHwSq0z6AwbLz4BQ.css?ok1nij" media="all">
+    <link rel="stylesheet" href="sites/default/files/css/css_4d3TAe2yEhXA8e_qXbm7liT_319IDyK9PeDMHY92_EM.css?ok1nij" media="all">
+    <!--[if lt IE 9]>
+    <script src="//html5shim.googlecode.com/svn/trunk/html5.js" type="text/javascript"></script>
+    <![endif]--><script src="https://cdn.ravenjs.com/3.8.0/raven.min.js"></script><script>Raven.config('https://cc00364690f241ffb2fcb39254d7f23f@sentry.io/115436').install()</script><!--[if lte IE 8]>
+    <script src="/sites/default/files/js/js_VtafjXmRvoUgAzqzYTA3Wrjkx9wcWhjP0G4ZnnqRamA.js"></script>
+    <![endif]-->
+</head>
+<body class="fullbleed home">
+<script type="text/javascript">
+    dataLayer = [{'channel' : 'developer'}];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NJWS5L');
+</script><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NJWS5L" height="0" width="0"></iframe></noscript>
+
+<div class="site-wrapper">
+    <header class="main clearfix"><div class="row header-wrap">
+        <nav class="accounts"><ul>
+            <li class="login"><a>Log In</a></li>
+            <li class="register"><a>Register</a></li>
+            <li class="logged-in"><a class="logged-in-name" href="#"></a></li>
+            <li class="logged-in"><a class="logout" href="#">Log Out</a></li>
+        </ul>
+            <div class="search-wrapper">
+                <form class="search-bar" accept-charset="utf-8" action="./search/" method="get" role="search" type="submit">
+                    <input class="user-search" type="text" placeholder="Enter your search term" id="search_list_text" name="q" maxlength="128" required><button type="submit" id="search-button">
+                    <i class="fa fa-search"></i>
+                </button>
+                </form>
+            </div>
+        </nav><div class="logo-wrap">
+        <h1 class="logo">
+            <!-- Do not remove the 'home-link' id from this 'a' tag -->
+            <a id="home-link" href="./" title="Red Hat Developers"><img alt="Red Hat Developers" src="images/design/RHD-logo.svg"></a>
+        </h1>
+        <a class="nav-toggle" href="#">Menu<i class="fa fa-angle-down"></i></a>
+    </div>
+        <nav class="mega-menu"><ul>
+            <li class="has-sub-nav">
+                <a href="#">Topics<i class="fa fa-angle-down"></i></a>
+                <div class="sub-nav" id="sub-nav-topics">
+                    <a href="containers/">Containers</a>
+                    <a href="devops/">DevOps</a>
+                    <a href="enterprise-java/">Enterprise Java</a>
+                    <a href="iot/">Internet of Things</a>
+                    <a href="microservices/">Microservices</a>
+                    <a href="mobile/">Mobile</a>
+                    <a href="web-and-api-development/">Web and API Development</a>
+                    <a href="dotnet/">.NET</a>
+                </div>
+            </li>
+            <li class="has-sub-nav">
+                <a href="#">Technologies<i class="fa fa-angle-down"></i></a>
+                <div class="sub-nav" id="sub-nav-technologies">
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#development_and_management">Accelerated Development and Management</a>
+                        <a class="hide-on-mobile" href="products/datagrid/overview/">Red Hat JBoss Data Grid</a>
+                        <a class="hide-on-mobile" href="products/eap/overview/">Red Hat JBoss Enterprise Application Platform</a>
+                        <a class="hide-on-mobile" href="products/webserver/overview/">Red Hat JBoss Web Server</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#developer_tools">Developer Tools</a>
+                        <a class="hide-on-mobile" href="products/cdk/overview/">Red Hat Container Development Kit</a>
+                        <a class="hide-on-mobile" href="products/devsuite/overview/">Red Hat Development Suite</a>
+                        <a class="hide-on-mobile" href="products/developertoolset/overview/">Red Hat Developer Toolset</a>
+                        <a class="hide-on-mobile" href="products/devstudio/overview/">Red Hat JBoss Developer Studio</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#infrastructure_management">Infrastructure</a>
+                        <a class="hide-on-mobile" href="products/rhel/overview/">Red Hat Enterprise Linux</a>
+                        <a class="hide-on-mobile" href="products/softwarecollections/overview/">Red Hat Software Collections</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#integration_and_automation">Integration and Automation</a>
+                        <a class="hide-on-mobile" href="products/amq/overview/">Red Hat JBoss A-MQ</a>
+                        <a class="hide-on-mobile" href="products/datavirt/overview/">Red Hat JBoss Data Virtualization</a>
+                        <a class="hide-on-mobile" href="products/fuse/overview/">Red Hat JBoss Fuse</a>
+                        <a class="hide-on-mobile" href="products/bpmsuite/overview/">Red Hat JBoss BPM Suite</a>
+                        <a class="hide-on-mobile" href="products/brms/overview/">Red Hat JBoss BRMS</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#mobile">Mobile</a>
+                        <a class="hide-on-mobile" href="products/mobileplatform/overview/">Red Hat Mobile Application Platform</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#cloud">Cloud</a>
+                        <a class="hide-on-mobile" href="products/openshift/overview/">Red Hat OpenShift Container Platform</a>
+                    </div>
+                    <div class="sub-nav-group">
+                        <a class="heading" href="products/#runtimes">Runtimes</a>
+                        <a class="hide-on-mobile" href="products/openjdk/overview/">OpenJDK</a>
+                        <a class="hide-on-mobile" href="products/dotnet/overview/">.NET Runtime for Red Hat Linux</a>
+                    </div>
+                </div>
+            </li>
+            <li class="has-sub-nav">
+                <a href="#">Community<i class="fa fa-angle-down"></i></a>
+                <div class="sub-nav pull-right" id="sub-nav-community">
+                    <a href="https://developers.redhat.com/blog">Developers Blog<span class="page-description">Insights &amp; news on Red Hat developer tools, platforms and more</span></a>
+                    <a href="events/">Events<span class="page-description">Find the latest conferences, meetups, and virtual seminars</span></a>
+                    <div class="sub-nav-group">
+                        <a href="projects/">Open Source Communities<span class="page-description">Community Projects that Red Hat participates in</span></a>
+                    </div>
+                    <a href="community/contributor/">Content Contributors<span class="page-description">Share your knowledge. Contribute content to Red Hat Developers.</span></a>
+                </div>
+            </li>
+            <li class="has-sub-nav">
+                <a href="#">Help<i class="fa fa-angle-down"></i></a>
+                <div class="sub-nav pull-right" id="sub-nav-help">
+                    <a href="resources/">Resources<span class="page-description">Important technical resources for you in all shapes and sizes:  blogs, books, code, videos and more.</span></a>
+                    <a href="forums/">Forums<span class="page-description">We've extended our popular JBoss.org forums to cover our entire Red Hat portfolio for you.</span></a>
+                    <a href="stack-overflow/">Stack Overflow Q&amp;A<span class="page-description">You already use Stack Overflow, so we'll help you use it to find your best answers.</span></a>
+                </div>
+            </li>
+            <li><a href="downloads/">Downloads </a></li>
+        </ul></nav>
+    </div>
+    </header><div class="wrapper clearfix">
+    <div class="content-wrapper">
+
+        <div id="page-wrapper">
+            <div id="page">
+                <div id="main-wrapper">
+                    <div class="region region-content">
+                        <div id="block-rhd-content" class="block block-system block-system-main-block">
+
+
+
+                            <article data-history-node-id="1745" role="article" about="/" typeof="schema:WebPage" class="node node--type-page node--view-mode-full"><span property="schema:name" content="Red Hat Developers" class="rdf-meta hidden"></span>
+
+
+
+                                <div class="node__content">
+
+                                    <div property="schema:text" class="clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item">
+                                        <section class="homepage-main"><div class="row">
+                                            <div class="medium-14 small-24 columns homepage-cta">
+                                                <h2>Experience .NET Core on Red Hat Enterprise Linux</h2>
+                                                <h3>Get the new O'Reilly book</h3>
+                                                <img class="mobile" src="images/promotions/dot-net-core.png" alt=".NET Core Book"><a class="button" href="promotions/dot-net-core/">Download Now</a>
+                                            </div>
+                                            <div class="medium-9 small-24 columns"><img class="desktop" src="images/promotions/dot-net-core.png" alt=".NET Core Book"></div>
+                                        </div></section><div class="spotlights-wrap"><div class="row"><div class="large-24"><div class="spotlights-container">
+                                        <a class="spotlight-item" href="events/javaone/2016/"><img src="https://static.jboss.org/images/rhd/promo/RHDev_homepromo_javaonerecap_17jan2017.jpg" alt="Java One recap."><span>Watch JavaOne session recordings</span></a><a class="spotlight-item" href="promotions/microservices-for-java-developers/"><img src="https://static.jboss.org/images/rhd/promo/RHDev_homepromo_microservicesforjava_17jan2017.png" alt="Microservices for Java developers ebook available for free."><span>Hands-on intro to frameworks and containers</span></a><a class="spotlight-item" href="products/devstudio/overview/"><img src="https://static.jboss.org/images/rhd/promo/RHDev_homepromo_devstudio10_17jan2017.png" alt="Red Hat JBoss Developer Studio 10 is here."><span>DevStudio 10 now with OpenShift integration</span></a><a class="spotlight-item" href="products/openjdk/overview/"><img src="https://static.jboss.org/images/rhd/promo/RHDev_homepromo_openjdk_17jan2017.png" alt="OpenJDK is now available for Windows. Join RHD now to download."><span>Join Red Hat Developers and try OpenJDK</span></a><a class="spotlight-item" href="products/eap/download/"><img src="https://static.jboss.org/_root/images/rhd/promo/RHDev_homepromo_eap7launch_17jan2017.png" alt="Ready. Set. Code! JBoss Enterprise Application Platform 7 is here."><span>Download it now and get started</span></a>
+                                    </div></div></div></div>
+                                        <div class="row featured-and-latest">
+                                            <div class="large-24 columns"><h3 class="caps">Cool Stuff You Should Know...</h3></div>
+                                            <div class="medium-12 columns">
+                                                <p>Knowledge should be shared, and with so much to learn, do and accomplish having a starting point is key. With suggested content — our favorite pieces — and easy access to the latest content on the site, you can jump in quickly and easily.</p>
+                                                <h4 class="caps">Featured Content</h4>
+                                                <ul class="homepage-resources">
+                                                    <li>
+                                                        <img class="resource-thumbnail" src="https://static.jboss.org/images/rhd/feature/rhdev_homefeature_springcloudvskubernetes_17jan2017.png"><span><a class="title" href="https://developers.redhat.com/blog/2016/06/27/microprofile-collaborating-to-bring-microservices-to-enterprise-java">Spring Cloud for Microservices Compared to Kubernetes</a><p class="date author">Dec 09, 2016 | By Bilgin Ibryam</p>
+<p class="description">Learn how they help deliver Microservice based architectures and how to get the best of each.</p></span>
+                                                    </li>
+                                                    <li>
+                                                        <img class="resource-thumbnail" src="https://static.jboss.org/images/rhd/feature/rhdev_homefeature_iot_gateway_17jan2017.png"><span><a class="title" href="https://developers.redhat.com/blog/2016/11/02/how-to-build-an-intelligent-iot-gateway-in-a-few-easy-steps">How to Build an Intelligent IoT Gateway in 7 Easy Steps</a><p class="date author">Nov 02, 2016 | By ishuverma</p>
+<p class="description">Get the components to set up your gateway and learn how to automate gateway provisioning in these simple steps.</p></span>
+                                                    </li>
+                                                    <li>
+                                                        <img class="resource-thumbnail" src="https://static.jboss.org/images/rhd/feature/rhdev_homefeature_eclipsevertx_17jan2017.png"><span><a class="title" href="https://developers.redhat.com/blog/2016/12/30/eclipse-vert-x-core-cheat-sheet">Eclipse Vert.x Core Cheat Sheet</a><p class="date author">Dec 30, 2016 | By Clement Escoffier</p>
+<p class="description">Learn how to create apps your way with Eclipse Vert.x.</p></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="medium-12 columns">
+                                                <h4 class="caps">Latest Content</h4>
+                                                <ul class="homepage-resources homepage-resources-latest"></ul>
+                                            </div>
+                                        </div>
+                                        <section class="register-banner inverse"><div class="row"><div class="large-24 columns home-join-img">
+                                            <img class="desktop" src="https://static.jboss.org/rhd/fonts/images_design_RHDev_homepage_jointext_desktop-2.svg" alt="Join RHD"><img class="mobile" src="https://static.jboss.org/rhd/fonts/images_design_RHDev_homepage_jointext_mobile-2.svg" alt="Join RHD">
+                                        </div></div>
+                                            <div class="row home-jointext">
+                                                <div class="large-10 columns"><a class="button" href="register/">Join Today - It's Free!</a></div>
+                                                <div class="large-14 columns">
+                                                    <p>Red Hat delivers the resources and ecosystem of experts to help professional programmers to be more productive and get ahead of the curve as they build great applications.<a class="dark-background" href="register/"> Join now for free!</a></p>
+                                                    <p><img class="inline-icon" src="https://static.jboss.org/rhd/fonts/images_design_RHDev_homepage_download-3.svg" alt="Download icon"> Get immediate access to<b> download</b> Red Hat® products</p>
+                                                    <p><img class="inline-icon" src="https://static.jboss.org/rhd/fonts/images_design_RHDev_homepage_cloud-3.svg" alt="Download icon"> Launch your new apps in the<b> cloud</b> on Red Hat® OpenShift</p>
+                                                    <p><img class="inline-icon" src="https://static.jboss.org/rhd/fonts/images_design_RHDev_homepage_lowercost-3.svg" alt="Download icon"> Offers and<b> discounts</b> on products, services, training, &amp; events</p>
+                                                </div>
+                                            </div></section><section class="contributors-banner inverse"><div class="row"><div class="large-24 column">
+                                        <h2>Become a content contributor and get swag.</h2>
+                                        <h4>Learn more. Code more. Share more.</h4>
+                                        <div class="row">
+                                            <div class="large-14 columns">
+                                                <p>Our content is only as good as its contributors and we'd like to feature yours. Anything from blogs, videos, demos, photos, screenshots, and more that can help enterprise developers do their jobs faster.</p>
+                                                <p>It's easy to get started with three ways to contribute.</p>
+                                            </div>
+                                            <div class="large-10 columns"><a class="button" href="community/contributor/">Learn More</a></div>
+                                        </div>
+                                        <div class="row banner-icons">
+                                            <div class="large-8 small-24 columns">
+                                                <img src="https://static.jboss.org/rhd/images/images_content-contributors_wc_icon-3.png"><h3>General Contributor</h3>
+                                            </div>
+                                            <div class="large-8 small-24 columns">
+                                                <img src="https://static.jboss.org/rhd/images/images_content-contributors_mvc_icon-3.png"><h3>Most Valuable Contributor</h3>
+                                            </div>
+                                            <div class="large-8 small-24 columns">
+                                                <img src="https://static.jboss.org/rhd/images/images_content-contributors_dots_icon-3.png"><h3>Developer on the Street</h3>
+                                            </div>
+                                        </div>
+                                    </div></div></section>
+                                    </div>
+
+                                </div>
+
+                            </article>
+                        </div>
+
+                    </div>
+
+                </div> <!-- /#main, /#main-wrapper -->
+
+            </div>
+        </div> <!-- /#page, /#page-wrapper -->
+
+    </div>
+</div>
+
+    <footer class="bottom"><div class="row">
+        <div class="large-5 columns">
+            <a href="https://www.redhat.com/" target="_blank" rel="noopener noreferrer"><img alt="Red Hat" class="rh-logo" src="images/branding/RHLogo_white.svg"></a>
+        </div>
+        <div class="large-5 columns">
+            <h3>Helpful Links</h3>
+            <ul class="quick-links">
+                <li><a href="https://access.redhat.com/security/team/contact/" target="_blank" rel="noopener noreferrer">Report a security
+                    problem<i class="fa fa-external-link"></i></a></li>
+                <li><a href="http://www.redhat.com/en/services/consulting" target="_blank" rel="noopener noreferrer">Consulting solutions<i class="fa fa-external-link"></i></a></li>
+                <li><a href="http://www.redhat.com/en/services/training" target="_blank" rel="noopener noreferrer">Training<i class="fa fa-external-link"></i></a></li>
+            </ul>
+        </div>
+        <div class="large-5 columns">
+            <h3>Related Sites</h3>
+            <ul class="quick-links">
+                <li><a href="https://www.redhat.com/" target="_blank" rel="noopener noreferrer">Red Hat Corporate<i class="fa fa-external-link"></i></a></li>
+                <li><a href="https://access.redhat.com/" target="_blank" rel="noopener noreferrer">Customer Portal<i class="fa fa-external-link"></i></a></li>
+                <li><a href="https://www.openshift.com/" target="_blank" rel="noopener noreferrer">OpenShift<i class="fa fa-external-link"></i></a></li>
+            </ul>
+        </div>
+        <div class="large-9 columns">
+            <h3>Red Hat Developers</h3>
+            <p>We provide a complete experience to enable enterprise developers and software builders to envision,
+                create and maintain high-value enterprise software.</p>
+            <div class="row">
+                <div class="large-12 columns">
+                    <ul class="inline-list">
+                        <li><a href="about/">About us</a></li>
+                        <li><a href="mailto:developers@redhat.com">Contact us</a></li>
+                    </ul>
+                </div>
+                <div class="large-12 columns">
+                    <ul class="social-nav">
+                        <li><a href="https://plus.google.com/103877536668756379905/posts" target="_blank" rel="noopener noreferrer"><i class="fa fa-google-plus"></i></a></li>
+                        <li><a href="https://www.youtube.com/channel/UC7noUdfWp-ukXUlAsJnSm-Q" target="_blank" rel="noopener noreferrer"><i class="fa fa-youtube"></i></a></li>
+                        <li><a href="https://www.facebook.com/RedHatDeveloperProgram" target="_blank" rel="noopener noreferrer"><i class="fa fa-facebook"></i></a></li>
+                        <li>
+                            <a href="https://twitter.com/rhdevelopers" target="_blank" rel="noopener noreferrer"><i class="fa fa-twitter"></i></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+        <div class="row legal">
+            <div class="large-5 medium-24 right columns">
+                <a class="devnation-logo" href="http://www.devnation.org/" target="_blank" rel="noopener noreferrer"><img src="images/design/logo_devnation_footer.png" alt="Red Hat Summit"></a><a class="summit-logo" href="http://www.redhat.com/summit/" target="_blank" rel="noopener noreferrer"><img src="images/design/logo-summit.png" alt="Red Hat Summit"></a>
+            </div>
+            <div class="large-19 columns">
+                <ul class="inline-list">
+                    <li><a class="copyright">Copyright © 2016 Red Hat Inc.</a></li>
+                    <li><a href="http://www.redhat.com/en/about/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy statement
+                        |</a></li>
+                    <li><a href="http://www.redhat.com/en/about/terms-use" target="_blank" rel="noopener noreferrer">Terms of use   |</a></li>
+                    <li><a href="http://www.redhat.com/en/about/all-policies-guidelines" target="_blank" rel="noopener noreferrer">All policies
+                        and guidelines</a></li>
+                </ul>
+            </div>
+        </div>
+    </footer>
+</div>
+<div class="overlay">
+    <div class="overlay-wrap">
+        <div class="overlay-inner">
+            <a class="overlay-close">×</a>
+            <div class="overlay-content row"> </div>
+        </div>
+    </div>
+</div>
+<div id="fb-root"></div>
+<script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"node\/1745","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en"},"pluralDelimiter":"\u0003","user":{"uid":0,"permissionsHash":"7f6b3fb70a64a2cb547a035f9540ff595cb3080da50831c0f8a26f51bd18304a"},"rhd":{"urls":{"base_url":"developer-drupal.web.prod.ext.phx2.redhat.com","final_base_url":"developers.redhat.com"},"downloadManager":{"baseUrl":"https:\/\/developers.redhat.com"},"dcp":{"baseProtocolRelativeUrl":"https:\/\/dcp2.jboss.org:443"},"keycloak":{"accountUrl":"https:\/\/developers.redhat.com\/auth\/realms\/rhd\/account\/","authUrl":"https:\/\/developers.redhat.com\/auth\/"},"templates":{"book":"\u003Cli class=\u0022book columns large-6\u0022 data-isbn=\u0022\u003C!=isbn!\u003E\u0022\u003E\n    \u003Ca href=\u0022\u003C!=preview_link!\u003E\u0022 class=\u0022book-preview\u0022 target=\u0022_blank\u0022 rel=\u0022noopener noreferrer\u0022\u003EPreview\u003C\/a\u003E\n    \u003Cimg src=\u0022\u003C!=thumbnail!\u003E\u0022 alt=\u0022Cover Image\u0022\u003E\n    \u003Ch4\u003E\u003C!=sys_title!\u003E\u003C\/h4\u003E\n    \u003Cp\u003E\u003C!=authors!\u003E\u003C\/p\u003E\n    \u003Cp\u003E\u003C!=published!\u003E\u003C\/p\u003E\n    \u003Cdiv class=\u0022rating\u0022\u003E\u003C!=average_rating!\u003E\u003C\/div\u003E\n    \u003Cp class=\u0022desc\u0022\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\n    \u003Ca href=\u0022\u003C!=sys_url_view!\u003E\u0022 class=\u0022button\u0022\u003EPurchase\u003Ci class=\u0022fa fa-external-link\u0022\u003E\u003C\/i\u003E\u003C\/a\u003E\u003C\/li\u003E\n","miniBuzz":"\u003Cdiv class=\u0022large-12 column\u0022\u003E\n    \u003Cdiv class=\u0022update updatemobile\u0022\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\n            \u003Ch5\u003E\u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022external-link\u0022\u003E\u003C!=sys_title!\u003E\u003C\/a\u003E\u003C\/h5\u003E\n            \u003Cdiv class=\u0022row\u0022\u003E\n                \u003Cdiv class=\u0022small-12 medium-14 column\u0022\u003E\n                    \u003Cdiv class=\u0022update-source\u0022\u003E\u003C!=authorName!\u003E\u003C\/div\u003E\n                \u003C\/div\u003E\n                \u003Cdiv class=\u0022small-12 medium-10 column\u0022\u003E\n                    \u003Cdiv class=\u0022update-timestamp\u0022\u003E\u003C!=updatedDate!\u003E\u003C\/div\u003E\n                \u003C\/div\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n        \u003Cdiv class=\u0022update-body\u0022\u003E\n            \u003Cp\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\n        \u003C\/div\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\n            \u003Cdiv class=\u0022share-this\u0022\u003E\n                \u003Cp\u003E\u003Ci class=\u0022fa fa-share\u0022\u003EShare This\u003C\/i\u003E\u003C\/p\u003E\n                \u003Cul class=\u0022share-this-buttons social-buttons cf\u0022\u003E\n                    \u003Cli\u003E\u003Ca href=\u0022https:\/\/twitter.com\/share\u0022 class=\u0022socialite twitter-share\u0022 data-text=\u0022\u003C!=sys_title!\u003E\u0022\n                           data-url=\u0022\u003C!=sys_url_view!\u003E\u0022 rel=\u0022noopener noreferrer nofollow\u0022 target=\u0022_blank\u0022\u003E\u003Cspan\n                                    class=\u0022vhidden\u0022\u003ETweet\u003C\/span\u003E\u003C\/a\u003E\u003C\/li\u003E\n                    \u003Cli\u003E\u003Ca href=\u0022http:\/\/www.facebook.com\/sharer.php?u=\u003C!=sys_url_view!\u003E\u0026t=\u003C!=sys_title!\u003E\u0022\n                           class=\u0022socialite facebook-share\u0022 data-href=\u0022\u003C!=sys_url_view!\u003E\u0022 data-send=\u0022false\u0022\n                           data-type=\u0022button_count\u0022\n                           data-width=\u002260\u0022 data-show-faces=\u0022false\u0022 rel=\u0022noopener noreferrer nofollow\u0022 target=\u0022_blank\u0022\u003E\u003Cspan class=\u0022vhidden\u0022\u003EShare on Facebook\u003C\/span\u003E\u003C\/a\u003E\n                    \u003C\/li\u003E\n                    \u003Cli\u003E\u003Ca href=\u0022https:\/\/plus.google.com\/share?url=\u003C!=sys_url_view!\u003E\u0022 class=\u0022socialite googleplus-one\u0022\n                           data-size=\u0022tall\u0022\n                           data-annotation=\u0022inline\u0022 data-width=\u002260\u0022 data-href=\u0022\u003C!=sys_url_view!\u003E\u0022 rel=\u0022noopener noreferrer nofollow\u0022\n                           target=\u0022_blank\u0022\u003E\u003Cspan\n                                    class=\u0022vhidden\u0022\u003EShare on Google+\u003C\/span\u003E\u003C\/a\u003E\u003C\/li\u003E\n                    \u003Cli\u003E\n                        \u003Ca href=\u0022http:\/\/www.linkedin.com\/shareArticle?mini=true\u0026url=\u003C!=sys_url_view!\u003E\u0026title=\u003C!=sys_title!\u003E\u0022\n                           class=\u0022socialite linkedin-share\u0022 data-url=\u0022\u003C!=sys_url_view!\u003E\u0022 data-counter=\u0022right\u0022\n                           rel=\u0022noopener noreferrer nofollow\u0022\n                           target=\u0022_blank\u0022\u003E\u003Cspan class=\u0022vhidden\u0022\u003EShare on LinkedIn\u003C\/span\u003E\u003C\/a\u003E\u003C\/li\u003E\n                \u003C\/ul\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/div\u003E\n","productBuzz":"    \u003Cdiv class=\u0022buzz-product-update\u0022\u003E\n        \u003Cdiv class=\u0022update\u0022\u003E\n            \u003Cdiv class=\u0022update-meta\u0022\u003E\n                \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-source\u0022\u003E\u003Ch5\u003E\u003C!=sys_title!\u003E\u003C\/h5\u003E\u003C\/a\u003E\n                \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-source\u0022\u003E\u003C!=authorName!\u003E\u003C\/a\u003E\n                \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-timestamp\u0022\u003E\u003C!=updatedDate!\u003E\u003C\/a\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n        \u003Cdiv class=\u0022update-body\u0022\u003E\n            \u003Cp\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n","buzz":"\u003Cdiv class=\u0022buzz-product-update\u0022\u003E\n    \u003Cdiv class=\u0022update\u0022\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\n            \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-source\u0022\u003E\u003Ch5\u003E\u003C!=sys_title!\u003E\u003C\/h5\u003E\u003C\/a\u003E\n            \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-source\u0022\u003E\u003C!=authorName!\u003E\u003C\/a\u003E\n            \u003Ca href=\u0022\u003C!=permanentLink!\u003E\u0022 class=\u0022update-timestamp\u0022\u003E\u003C!=updatedDate!\u003E\u003C\/a\u003E\n        \u003C\/div\u003E\n        \u003Cdiv class=\u0022update-body\u0022\u003E\n            \u003Cp\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/div\u003E\n","termsConditions":"\u003Cdiv class=\u0022downloadthankyou\u0022 id=\u0022tacBanner\u0022\u003E\n    You joined the Red Hat Developer Program on\n    \u003Cspan id=\u0022tcWhenSigned\u0022\u003E\u003C!=acceptanceTimestamp!\u003E\u003C\/span\u003E.\n    Your subscription to the Red Hat Developer Program ends in\n    \u003Cspan id=\u0022tcEndsIn\u0022\u003E\u003C!=daysRemaining!\u003E\u003C\/span\u003E days.\n\u003C\/div\u003E\n","connector":"\u003Cli class=\u0022connector\u0022\u003E\n    \u003Ca href=\u0022#\u0022 class=\u0022fn-open-connector\u0022\u003E\u003Cimg src=\u0022\u003C!=img_path_thumb!\u003E\u0022 alt=\u0022logo\u0022 class=\u0022connector-logo\u0022\u003E\u003C\/a\u003E\n    \u003Ch3\u003E\u003Ca href=\u0022#\u0022 class=\u0022fn-open-connector\u0022\u003E\u003C!=sys_title!\u003E\u003C\/a\u003E\u003C\/h3\u003E\n    \u003Cp\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\n    \u003Cdiv class=\u0022connector-overlay-content\u0022\u003E\n        \u003Cdiv class=\u0022row\u0022\u003E\n            \u003Cdiv class=\u0022large-7 columns\u0022\u003E\n                \u003Cimg src=\u0022\u003C!=img_path_thumb!\u003E\u0022 alt=\u0022Logo\u0022 class=\u0022connector-logo\u0022 onerror=\u0022\u003C!=fallback_img!\u003E\u0022\u003E\n            \u003C\/div\u003E\n            \u003Cdiv class=\u0022large-17 columns\u0022\u003E\n                \u003Cp\u003E\u003C!=sys_content!\u003E\u003C\/p\u003E\n                \u003Cdiv class=\u0022connector-a\u0022\u003E\n                    \u003Ch4\u003EConnector A\n                        \u003Cdiv class=\u0022copy-to-clipboard\u0022\u003E\n                            \u003Cobject data=\u0022\u0022 type=\u0022\u0022 classid=\u0022clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\u0022 width=\u0022110\u0022\n                                    height=\u002214\u0022 id=\u0022clippy\u0022\u003E\n                                \u003Cparam name=\u0022movie\u0022 value=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\u003E\n                                \u003Cparam name=\u0022allowScriptAccess\u0022 value=\u0022always\u0022\u003E\n                                \u003Cparam name=\u0022quality\u0022 value=\u0022high\u0022\u003E\n                                \u003Cparam name=\u0022scale\u0022 value=\u0022noscale\u0022\u003E\n                                \u003Cparam name=\u0022\u0022 value=\u0022text=\u003C!=code_snippet_1!\u003E\u0022\u003E\n                                \u003Cparam name=\u0022bgcolor\u0022 value=\u0022#FFFFFF\u0022\u003E\n                                \u003Cembed src=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\n                                       type=\u0022application\/x-shockwave-flash\u0022\n                                       width=\u0022110\u0022 height=\u002214\u0022 name=\u0022clippy\u0022 quality=\u0022high\u0022 allowScriptAccess=\u0022always\u0022\n                                       pluginspage=\u0022http:\/\/www.macromedia.com\/go\/getflashplayer\u0022\n                                       FlashVars=\u0022text=#{page.text}\u0022\n                                       bgcolor=\u0022#FFFFFF\u0022\u003E\n                            \u003C\/object\u003E\n                        \u003C\/div\u003E\n                    \u003C\/h4\u003E\n                    \u003Cinput type=\u0022text\u0022 class=\u0022snippet-value\u0022 value=\u0022\u003C!=code_snippet_1!\u003E\u0022\u003E\n                \u003C\/div\u003E\n                \u003Cdiv class=\u0022connector-b\u0022\u003E\n                    \u003Ch4\u003EConnector B\u003C\/h4\u003E\n                    \u003Cdiv class=\u0022copy-to-clipboard\u0022\u003E\n                        \u003Cobject data=\u0022\u0022 type=\u0022\u0022 classid=\u0022clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\u0022 width=\u0022110\u0022\n                                height=\u002214\u0022 id=\u0022clippy\u0022\u003E\n                            \u003Cparam name=\u0022movie\u0022 value=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\u003E\n                            \u003Cparam name=\u0022allowScriptAccess\u0022 value=\u0022always\u0022\u003E\n                            \u003Cparam name=\u0022quality\u0022 value=\u0022high\u0022\u003E\n                            \u003Cparam name=\u0022scale\u0022 value=\u0022noscale\u0022\u003E\n                            \u003Cparam name=\u0022FlashVars\u0022 value=\u0022text=\u003C!=code_snippet_2!\u003E\u0022\u003E\n                            \u003Cparam name=\u0022bgcolor\u0022 value=\u0022#FFFFFF\u0022\u003E\n                            \u003Cembed src=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\n                                   type=\u0022application\/x-shockwave-flash\u0022 width=\u0022110\u0022 height=\u002214\u0022 name=\u0022clippy\u0022\n                                   quality=\u0022high\u0022 allowScriptAccess=\u0022always\u0022\n                                   pluginspage=\u0022http:\/\/www.macromedia.com\/go\/getflashplayer\u0022\n                                   FlashVars=\u0022text=#{page.text}\u0022 bgcolor=\u0022#FFFFFF\u0022\u003E\n                        \u003C\/object\u003E\n                    \u003C\/div\u003E\n                    \u003Cdiv class=\u0022copy-to-clipboard\u0022\u003E\n                        \u003Cobject data=\u0022\u0022 type=\u0022\u0022 classid=\u0022clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\u0022 width=\u0022110\u0022\n                                height=\u002214\u0022 id=\u0022clippy\u0022\u003E\n                            \u003Cparam name=\u0022movie\u0022 value=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\u003E\n                            \u003Cparam name=\u0022allowScriptAccess\u0022 value=\u0022always\u0022\u003E\n                            \u003Cparam name=\u0022quality\u0022 value=\u0022high\u0022\u003E\n                            \u003Cparam name=\u0022scale\u0022 value=\u0022noscale\u0022\u003E\n                            \u003Cparam name=\u0022\u0022 value=\u0022text=\u003C!=code_snippet_2!\u003E\u0022\u003E\n                            \u003Cparam name=\u0022bgcolor\u0022 value=\u0022#FFFFFF\u0022\u003E\n                            \u003Cembed src=\u0022\/\/static.jboss.org\/ffe\/0\/www\/vendor\/clippy\/clippy.swf\u0022\n                                   type=\u0022application\/x-shockwave-flash\u0022\n                                   width=\u0022110\u0022 height=\u002214\u0022 name=\u0022clippy\u0022 quality=\u0022high\u0022 allowScriptAccess=\u0022always\u0022\n                                   pluginspage=\u0022http:\/\/www.macromedia.com\/go\/getflashplayer\u0022\n                                   FlashVars=\u0022text=#{page.text}\u0022\n                                   bgcolor=\u0022#FFFFFF\u0022\u003E\n                        \u003C\/object\u003E\n                    \u003C\/div\u003E\n\n                    \u003Cinput type=\u0022text\u0022 class=\u0022snippet-value\u0022 value=\u0022\u003C!=code_snippet_2!\u003E\u0022\u003E\n                \u003C\/div\u003E\n                \u003Cp class=\u0022link_1_text\u0022\u003E\n                    \u003Ca href=\u0022\u003C!=link_1_url!\u003E\u0022 class=\u0022link_1\u0022\u003E\u003C!=link_1_text!\u003E\u003C\/a\u003E\n                    \u003Cbr\u003E\n                    \u003Ca href=\u0022\u003C!=link_2_url!\u003E\u0022 class=\u0022link_2\u0022\u003E\u003C!=link_2_text!\u003E\u003C\/a\u003E\n                \u003C\/p\u003E\n                \u003Cp class=\u0022docs-link-text\u0022\u003EFor more details, view the \u003Ca href=\u0022\u003C!=more_details_url!\u003E\u0022 class=\u0022docs-link\u0022\u003EProduct\n                        Documentation\u003C\/a\u003E\u003C\/p\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/li\u003E\n","productStackoverflowTemplate":"\u003Cdiv class=\u0022stackoverflow-product-update\u0022\u003E\n    \u003Cdiv class=\u0022update\u0022\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\n            \u003Cdiv class=\u0022row\u0022\u003E\n                \u003Cdiv class=\u0022large-24 columns\u0022\u003E\u003Ca class=\u0022update-source\u0022 href=\u0022\u003C!=sys_url_view!\u003E\u0022 target=\u0022_blank\u0022 rel=\u0022noopener noreferrer\u0022\u003E\n                        \u003Ch5 class=\u0022qtn-title\u0022\u003EQ: \u003C!=sys_title!\u003E\u003C\/h5\u003E\u003C\/a\u003E\u003C\/div\u003E\n                \u003Cdiv class=\u0022large-12 columns\u0022\u003E\u003Cp\u003E\u003C!=up_vote_count!\u003E votes | \u003C!=answer_count!\u003E answers | \u003C!=view_count!\u003E\n                        views\u003C\/p\u003E\u003C\/div\u003E\n                \u003Cdiv class=\u0022large-12 columns\u0022\u003E\u003Cspan class=\u0022right\u0022\u003E\u003Cp\u003E\u003C!=dateCreated!\u003E\u003C\/p\u003E\u003C\/span\u003E\u003C\/div\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/div\u003E\n","searchPageTemplate":"\u003Cdiv class=\u0022searchpage-update\u0022\u003E\n    \u003Cdiv class=\u0022update\u0022\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\u003Ca class=\u0022update-source\u0022 href=\u0022\u003C!=searchLink!\u003E\u0022\u003E\u003Ch5\u003E\u003C!=sys_title!\u003E\u003C\/h5\u003E\u003C\/a\u003E\u003Ca\n                    class=\u0022update-source\u0022 href=\u0022\u003C!=searchLink!\u003E\u0022\u003E\u003C!=sys_type!\u003E\u003C\/a\u003E\u003C\/div\u003E\n        \u003Cdiv class=\u0022update-body\u0022\u003E\u003Cp\u003E\u003C!=sys_description!\u003E\u003C\/p\u003E\u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/div\u003E\n","stackoverflowTemplate":"\u003Cdiv class=\u0022stackoverflow-update\u0022\u003E\n    \u003Cdiv class=\u0022update\u0022\u003E\n        \u003Cdiv class=\u0022update-meta\u0022\u003E\n            \u003Cdiv class=\u0022row\u0022\u003E\n                \u003Cdiv class=\u0022large-6 columns qtn-stats\u0022\u003E\u003Cspan class=\u0022votes-count\u0022\u003E\u003Ch4\u003E\u003C!=up_vote_count!\u003E\u003C\/h4\u003E\u003Cp\u003EVotes\u003C\/p\u003E\u003C\/span\u003E\u003Cspan\n                            class=\u0022answer-count \u003C!=qtnAccepted!\u003E\u0022\u003E\u003Ch4\u003E\u003C!=answer_count!\u003E\u003C\/h4\u003E\u003Cp\u003E\n                            Answers\u003C\/p\u003E\u003C\/span\u003E\u003Cspan class=\u0022views-count\u0022\u003E\u003Ch4\u003E\u003C!=view_count!\u003E\u003C\/h4\u003E\u003Cp\u003EViews\u003C\/p\u003E\u003C\/span\u003E\n                \u003C\/div\u003E\n                \u003Cdiv class=\u0022large-18 columns\u0022\u003E\u003Ca class=\u0022update-source\u0022 href=\u0022\u003C!=sys_url_view!\u003E\u0022 target=\u0022_blank\u0022 rel=\u0022noopener noreferrer\u0022\u003E\n                        \u003Ch5 class=\u0022qtn-title\u0022\u003E\u003C!=sys_title!\u003E\u003C\/h5\u003E\u003C\/a\u003E\n                    \u003Cp class=\u0022qtn-content\u0022\u003E\u003C!=qtnContent!\u003E\u003C\/p\u003E\n                    \u003Cdiv class=\u0022callout qtn-answer \u0026lt;!=displayAnswr!\u0026gt;\u0022\u003E\u003Cp\u003E\u003C!=answer!\u003E\u003C\/p\u003E\u003Ca\n                                href=\u0022\u003C!=sys_url_view!\u003E\u0022 target=\u0022_blank\u0022 rel=\u0022noopener noreferrer\u0022\u003ERead full question at Stack Overflow\u0026nbsp;\u003Ci\n                                    class=\u0022fa fa-angle-right\u0022\u003E\u003C\/i\u003E\u003C\/a\u003E\u003C\/div\u003E\n                    \u003Cp\u003E\u003Cspan class=\u0022so-tags\u0022\u003E\u003Cstrong\u003ETags:\u0026nbsp;\u003C\/strong\u003E\u003C!=tags!\u003E\u003C\/span\u003E\u003Cspan class=\u0022so-author\u0022\u003E\u003C!=dateCreated!\u003E | \u003C!=authorName!\u003E\u003C\/span\u003E\n                    \u003C\/p\u003E\u003C\/div\u003E\n            \u003C\/div\u003E\n        \u003C\/div\u003E\n    \u003C\/div\u003E\n\u003C\/div\u003E\n"}}}</script><script src="sites/default/files/js/js_FydPQe2-evD8Lv2n8i3KdPnzoId5TnWcTLKU7k-dAhk.js"></script><script type="text/javascript">
+    if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {
+        _satellite.pageBottom();
+    }
+</script>
+</body>
+</html>

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -106,4 +106,18 @@ class TestExportHtmlPostProcessor < MiniTest::Test
 
   end
 
+  def test_should_remove_drupal_host_identifying_markup
+
+    page_with_drupal_markup = get_html_document("#{@export_directory}/remove-drupal-url/index.html")
+    drupal_elements = page_with_drupal_markup.css('link[rel="shortlink"],link[rel="revision"],meta[name="Generator"]')
+    assert(drupal_elements.size > 0)
+
+    @export_post_processor.post_process_html_export('docker', @export_directory)
+
+    page_with_drupal_markup = get_html_document("#{@export_directory}/remove-drupal-url/index.html")
+    drupal_elements = page_with_drupal_markup.css('link[rel="shortlink"],link[rel="revision"],meta[name="Generator"]')
+    assert_equal(0, drupal_elements.size)
+  end
+
+
 end

--- a/_docker/tests/export/test_httrack_export_strategy.rb
+++ b/_docker/tests/export/test_httrack_export_strategy.rb
@@ -26,7 +26,7 @@ class TestHttrackExportStrategy < MiniTest::Test
 
   def test_should_run_first_time_export
 
-    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t")
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
     @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
 
@@ -49,7 +49,7 @@ class TestHttrackExportStrategy < MiniTest::Test
   end
 
   def test_should_run_first_time_export_with_no_host_port
-    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://developer-drupal.web.stage.ext.phx2.redhat.com*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t")
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://developer-drupal.web.stage.ext.phx2.redhat.com*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
     @export_post_processor.expects(:post_process_html_export).with('developer-drupal.web.stage.ext.phx2.redhat.com', "#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
     @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
 


### PR DESCRIPTION
This PR tries as much as possible to remove all references to the Drupal host from the export of the site.

I've updated the export process to do a few more things:

1. Prevent httrack from adding the "Mirrored from..." to the source of every HTML file. Ideally I wanted to make it add nothing to the file, but this doesn't work when updating a cache of an existing export. So I've configured it to add an empty HTML comment instead

2. It will remove any of the following HTML elements from the DOM of each HTML file in the export:

- `<link rel="shortcut">`
- `<link rel="revision">`
- `<meta name="Generator">`

I've ensured that we only re-write each HTML file once, so the export process needed slightly more tweaking than I originally hoped.

Please note that currently I cannot remove the reference to the Drupal host from the Javascript on the page. It just makes our life difficult to do this.

**How to verify:**

- Visit the exported version of the site associated with this PR
- Pick a few pages at random
- View the source for the page and note that the only reference to the Drupal host is now within JS on the page

Additionally please make sure that the search function still works on each page you visit as I had to slightly re-work the code that modifies the form target for search.