### PR TITLE
Google Webmaster Tools authentication file

### DIFF
--- a/_docker/lib/export/static/googlead73883659545ab5.html
+++ b/_docker/lib/export/static/googlead73883659545ab5.html
@@ -1,0 +1,1 @@
+google-site-verification: googlead73883659545ab5.html

--- a/googlead73883659545ab5.html
+++ b/googlead73883659545ab5.html
@@ -1,1 +1,0 @@
-google-site-verification: googlead73883659545ab5.html

--- a/googlead73883659545ab5.html
+++ b/googlead73883659545ab5.html
@@ -1,0 +1,1 @@
+google-site-verification: googlead73883659545ab5.html


### PR DESCRIPTION
This file is needed by Jairus Mitchell in order to convince Google that we have authority to access Google Web master tools for developers.redhat.com.

This works if you see 'google-site-verification: googlead73883659545ab5.html' when browsing to https://developers.redhat.com/googlead73883659545ab5.html (or the equivalent when verifying the PR).