### PR TITLE
DEVELOPER-3752 - Fix double-call of search on resources

### DIFF
--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -752,7 +752,7 @@ function searchCtrlFunc($scope, $window, searchService) {
       window.location = '#!';
     }
     window.setTimeout($scope.filter.restore, 0);
+  } else {
+    $scope.updateSearch();
   }
-
-  $scope.updateSearch();
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3752

Added logic to prevent timeout call in addition to initialization call. If on resources page, just always restore filters as it will call the updateSearch function.

May also resolve - https://issues.jboss.org/browse/DEVELOPER-3691 due to two calls to the search service being made.