### PR TITLE
Fixes DEVELOPER-3539 error page button text color

### DIFF
--- a/stylesheets/_error-pages.scss
+++ b/stylesheets/_error-pages.scss
@@ -29,5 +29,6 @@
     display: block;
     margin: 15px auto 0 auto;
     max-width: 265px;
+    color: white;
   }
 }


### PR DESCRIPTION
Changes the text in buttons on error page buttons to be white.