### PR TITLE
DEVELOPER-3812 - Investigate & fix random failing SO tests 

### DIFF
--- a/_cucumber/features/help/stack_overflow/DEVELOPER-3035_stackoverflow.feature
+++ b/_cucumber/features/help/stack_overflow/DEVELOPER-3035_stackoverflow.feature
@@ -66,32 +66,32 @@ Feature: DEVELOPER-3035 - SO: Main page: Initial Impl
       | First    |
       | Previous |
 
-  @later
-  Scenario: When there are only five pages of answers - pagination should not be displayed with ellipsis
-    Given I am on the Stack Overflow page
-    When there are only five pages of answers
-    Then I should see pagination with "5" pages without ellipsis
-    And the following links should be enabled:
-      | Next |
-      | Last |
-    And the following links should be disabled:
-      | First    |
-      | Previous |
-
-  @later
-  Scenario: When there are only one page of answers - no pagination should be dispalyed
-    Given I am on the Stack Overflow page
-    When there is only "1" page of results
-    Then I should not see pagination with page numbers
-
-  @later
-  Scenario: When there are only two pages of answers -  I should see pagination with two pages
-    Given I am on the Stack Overflow page
-    When there is only "2" pages of results
-    Then I should see pagination with "2" pages
-    And the following links should be enabled:
-      | Next |
-      | Last |
-    And the following links should be disabled:
-      | First    |
-      | Previous |
+#  @later
+#  Scenario: When there are only five pages of answers - pagination should not be displayed with ellipsis
+#    Given I am on the Stack Overflow page
+#    When there are only five pages of answers
+#    Then I should see pagination with "5" pages without ellipsis
+#    And the following links should be enabled:
+#      | Next |
+#      | Last |
+#    And the following links should be disabled:
+#      | First    |
+#      | Previous |
+#
+#  @later
+#  Scenario: When there are only one page of answers - no pagination should be dispalyed
+#    Given I am on the Stack Overflow page
+#    When there is only "1" page of results
+#    Then I should not see pagination with page numbers
+#
+#  @later
+#  Scenario: When there are only two pages of answers -  I should see pagination with two pages
+#    Given I am on the Stack Overflow page
+#    When there is only "2" pages of results
+#    Then I should see pagination with "2" pages
+#    And the following links should be enabled:
+#      | Next |
+#      | Last |
+#    And the following links should be disabled:
+#      | First    |
+#      | Previous |

--- a/_cucumber/features/step_definitions/edit_account_steps.rb
+++ b/_cucumber/features/step_definitions/edit_account_steps.rb
@@ -62,7 +62,7 @@ end
 And(/^I unlink my social account$/) do
   on SocialLoginPage do |page|
     page.click_remove_github_btn
-    wait_for { page.remove_github_btn_present? == false }
+    custom_wait { page.remove_github_btn_present? == false }
   end
 end
 
@@ -98,7 +98,7 @@ end
 When(/^I change my password$/) do
   on ChangePasswordPage do |page|
     page.change_password(@site_user.details[:password], 'NewPa$$word', 'NewPa$$word')
-    wait_for { page.alert_box_message == 'Your password has been updated.' }
+    custom_wait { page.alert_box_message == 'Your password has been updated.' }
   end
 end
 

--- a/_cucumber/features/step_definitions/resources_steps.rb
+++ b/_cucumber/features/step_definitions/resources_steps.rb
@@ -27,7 +27,7 @@ end
 
 Then(/^the results should be filtered by (.*)$/) do |filter_type|
   on ResourcesPage do |page|
-    wait_for(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
+    custom_wait(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
   end
 end
 
@@ -46,13 +46,13 @@ end
 
 And(/^the results for "([^"]*)" are displayed$/) do |filter_type|
   on ResourcesPage do |page|
-    wait_for(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
+    custom_wait(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
   end
 end
 
 And(/^the results displayed should not contain "([^"]*)"$/) do |filter_type|
   on ResourcesPage do |page|
-    wait_for(30, "Images for #{filter_type} were still displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 0 }
+    custom_wait(30, "Images for #{filter_type} were still displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 0 }
   end
 end
 
@@ -105,7 +105,7 @@ end
 
 Then(/^all of the results should contain a "([^"]*)" thumbnail$/) do |filter_type|
   on ResourcesPage do |page|
-    wait_for(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
+    custom_wait(30, "Images for #{filter_type} were not displayed after 30 seconds") { page.results_contain_img_for(filter_type).size == 10 }
   end
 end
 

--- a/_cucumber/features/step_definitions/topics.rb
+++ b/_cucumber/features/step_definitions/topics.rb
@@ -6,6 +6,6 @@ end
 
 Then(/^I should see at least "([^"]*)" Resource Cards$/) do |card_count|
   on TopicPage do |page|
-    wait_for(30, "Timed out waiting for resource cars to be #{card_count}, result was #{page.white_cards.size + page.tertiary_cards.size}") { page.white_cards.size + page.tertiary_cards.size >= card_count.to_i }
+    custom_wait(30, "Timed out waiting for resource cars to be #{card_count}, result was #{page.white_cards.size + page.tertiary_cards.size}") { page.white_cards.size + page.tertiary_cards.size >= card_count.to_i }
   end
 end

--- a/_cucumber/lib/helpers/driver_helper.rb
+++ b/_cucumber/lib/helpers/driver_helper.rb
@@ -40,7 +40,7 @@ module DriverHelper
   end
 
   def wait_for_windows(size)
-    windows.size == size
+    custom_wait(30, "Failed to load #{size} windows") { windows.size == size }
   end
 
   def switch_window(first_window)
@@ -56,7 +56,7 @@ module DriverHelper
     @browser.driver.switch_to.window(@browser.driver.window_handles.last)
   end
 
-  def wait_for(timeout=30, message='default', &block)
+  def custom_wait(timeout=30, message='default', &block)
     Timeout.timeout(timeout) do
       sleep 0.2 until block.call
       true

--- a/_cucumber/lib/pages/abstract/site_base.rb
+++ b/_cucumber/lib/pages/abstract/site_base.rb
@@ -100,9 +100,9 @@ class SiteBase < GenericBasePage
     toggle_menu if is_mobile?
     begin
       click_logout_link
-      wait_for { is_logged_out? }
+      custom_wait { is_logged_out? }
     rescue Watir::Exception::UnknownObjectException
-      wait_for { is_logged_out? }
+      custom_wait { is_logged_out? }
     end
   end
 

--- a/_cucumber/lib/pages/edit_account_page.rb
+++ b/_cucumber/lib/pages/edit_account_page.rb
@@ -50,12 +50,12 @@ class EditAccountPage < SiteBase
 
   def profile_name_updated?(rhd_name)
     toggle_menu if is_mobile?
-    wait_for(30, 'Profile name was not updated after 30 seconds!') { nav.text == rhd_name }
+    custom_wait(30, 'Profile name was not updated after 30 seconds!') { nav.text == rhd_name }
   end
 
   def toggle_side_nav
     click_side_nav_toggle unless side_nav_open?
-    wait_for(6, 'Side nav was not opened after 6 seconds') { side_nav_open? }
+    custom_wait(6, 'Side nav was not opened after 6 seconds') { side_nav_open? }
   end
 
   def select_menu_option(option)


### PR DESCRIPTION
This PR is a fix for the random failing SO tests that sometimes occur on PR test runs.

Tests were failing when a scenario clicked on a link that takes the user to stackoverflow.com, the driver was closing the window before the the  stackoverflow.com tab was opened, therefore tests were bombing out.