### PR TITLE
[DEVELOPER-3758] Prevent backup from using all disk space on production VM

### DIFF
--- a/_docker/lib/backup/reset/backup_reset.rb
+++ b/_docker/lib/backup/reset/backup_reset.rb
@@ -1,0 +1,48 @@
+require_relative '../../default_logger'
+require_relative '../../../lib/process_runner'
+
+#
+# This simple class performs a simple reset of the Git repository that we use to store backups in order to
+# reclaim disk space.
+#
+# @author rblake@redhat.com
+#
+class BackupReset
+
+  def initialize(backup_directory, git_backup_repository, process_runner)
+    @backup_directory = backup_directory
+    @git_backup_repository = git_backup_repository
+    @process_runner = process_runner
+    @log = DefaultLogger.logger
+  end
+
+  #
+  # Cleans the backup repository by firstly deleting it and then cloning again using git lfs
+  #
+  def reset_backup_repository
+    clean_existing_repository
+    clone_backup_repository
+  end
+
+  private
+
+  #
+  # Clones the backup repository using Git LFS. Assumes that credentials have been configured on the container in which this
+  # code is executing
+  #
+  def clone_backup_repository
+    @process_runner.execute!("git lfs clone #{@git_backup_repository} #{@backup_directory}")
+  end
+
+  #
+  # Deletes any content within the currently checked out repository, thus reclaiming disk space
+  #
+  def clean_existing_repository
+    @process_runner.execute!("rm -rf #{@backup_directory}/* #{@backup_directory}/.git #{@backup_directory}/.gitattributes")
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  backup_reset = BackupReset.new('/backups','https://github.com/redhat-developer/rhd-backups.git', ProcessRunner.new)
+  backup_reset.reset_backup_repository
+end

--- a/_docker/lib/backup/reset/run.rb
+++ b/_docker/lib/backup/reset/run.rb
@@ -1,0 +1,27 @@
+require_relative '../../../lib/process_runner'
+
+#
+# A simple wrapper class that provides a way of executing the backup-reset code
+# within the desired Docker container.
+#
+# @author rblake@redhat.com
+#
+class Run
+
+  def initialize(environments_directory, process_runner)
+    @environments_directory = environments_directory
+    @process_runner = process_runner
+  end
+
+  #
+  # Executes the docker-compose command that will run the backup reset process. This script is invoked by
+  # Jenkins.
+  #
+  def execute!
+    @process_runner.execute!("cd #{@environments_directory} && docker-compose -f drupal-production/docker-compose.yml run --rm --entrypoint 'ruby /home/jenkins_developer/developer.redhat.com/_docker/lib/backup/reset/backup_reset.rb' backup")
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  Run.new('../../../environments', ProcessRunner.new).execute!
+end

--- a/_docker/tests/backup/reset/test_backup_reset.rb
+++ b/_docker/tests/backup/reset/test_backup_reset.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../../test_helper'
+require_relative '../../../lib/backup/reset/backup_reset'
+
+class TestBackupReset < MiniTest::Test
+
+  def setup
+    @backup_dir = '/backups'
+    @backup_git_repository = 'https://github.com/redhat-developer/rhd-backups.git'
+    @process_runner = mock()
+    @backup_reset = BackupReset.new(@backup_dir, @backup_git_repository, @process_runner)
+  end
+
+  def test_should_clean_and_reset_repository
+    @process_runner.expects(:execute!).with("rm -rf #{@backup_dir}/* #{@backup_dir}/.git #{@backup_dir}/.gitattributes")
+    @process_runner.expects(:execute!).with("git lfs clone #{@backup_git_repository} #{@backup_dir}")
+
+    @backup_reset.reset_backup_repository
+  end
+end

--- a/_docker/tests/backup/reset/test_run.rb
+++ b/_docker/tests/backup/reset/test_run.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../../test_helper'
+require_relative '../../../lib/backup/reset/run'
+
+class TestRun < MiniTest::Test
+
+  def setup
+    @process_runner = mock()
+    @environments_directory = '/tmp/environments'
+    @run = Run.new(@environments_directory, @process_runner)
+  end
+
+  def test_should_correctly_invoke_docker_compose_command
+
+    @process_runner.expects(:execute!).with("cd #{@environments_directory} && docker-compose -f drupal-production/docker-compose.yml run --rm --entrypoint 'ruby /home/jenkins_developer/developer.redhat.com/_docker/lib/backup/reset/backup_reset.rb' backup")
+    @run.execute!
+  end
+end


### PR DESCRIPTION
This pull request introduces a couple of utility classes that help us reset the Git LFS repository checkout on the production VM.  The purpose for doing this is to prevent the Git repository consuming all available disk space on the VM.

The process here is pretty simple, it basically:

1. Deletes the current checkout of the rhd-backups repository
2. re-clones the repository using `git lfs clone`

`git lfs clone` is smart enough to only pull the files within the current branch i.e. master branch for a fresh checkout. Therefore we immediately reclaim the disk-space in use by the repository.

The `backup_reset.rb` class here is designed to run with the `backup` service Docker container definition in the `drupal-production` environment. It is designed this way so that credentials for the Git repo and access to the filesystem are managed as with all other jobs that run in that environment. We don't have to start storing credentials in Jenkins.

The `run.rb` is a small wrapper script that is executed by Jenkins that ensures we execute the correct `docker-compose` command to get the `backup_reset.rb` script to what it needs to do.

This is all tied together by the new job [developers.redhat.com-drupal-backup-reset](http://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/jboss.org/job/developers.redhat.com-drupal-backup-reset/) in Jenkins. This job has been configured to run at 04:00 each Monday morning ensuring that each week we start with a fresh checkout of the backup repository.
