### PR TITLE
[HOLD] DEVELOPER-3819 - Fix for Download button product pages (mobile view only)

### DIFF
--- a/_layouts/product-base.html.slim
+++ b/_layouts/product-base.html.slim
@@ -21,7 +21,7 @@ div(class="mobile product-color #{page.product.product_category}")
     .large-24
       h3 #{page.product.name}
       - if(page.url.include?('overview'))
-        a.button(href='#{site.base_url}/products/#{page.product.id}/download/') Download
+        a.button(href='#{site.base_url}/products/#{page.product.id}/downloads/') Download
         a.button.inverse(href='#{site.base_url}/products/#{page.product.id}/get-started/') Get Started
 
 section(class="product-graphics #{page.product.product_category}")


### PR DESCRIPTION
This PR should hopefully fix lots of broken links around /product pages when in mobile view as all occurrences of the "DOWNLOAD" button were returning a 403 error.

Once built I will confirm by running broken link check against this PR export site preview.