### PR TITLE
Bugfix - Adding Polyfill for Array.includes function

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,6 +9,7 @@ var globs = {
   "scripts": [
     'javascripts/drupal-namespace.js',
     'javascripts/vendor/jquery.xdomainrequest.js',
+    'javascripts/vendor/includes.js',
     'javascripts/extensions.js',
     'javascripts/vendor/keycloak.js',
     'javascripts/sso.js',

--- a/javascripts/vendor/includes.js
+++ b/javascripts/vendor/includes.js
@@ -1,0 +1,48 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, 'includes', {
+    value: function(searchElement, fromIndex) {
+
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        // c. Increase k by 1.
+        // NOTE: === provides the correct "SameValueZero" comparison needed here.
+        if (o[k] === searchElement) {
+          return true;
+        }
+        k++;
+      }
+
+      // 8. Return false
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
PhantomJS and IE do not include the Array.prototype.includes function. This is a polyfill to make that call work as it is used in the urlFilters from search.js around line 606