### PR TITLE
DEVELOPER-1754 Fixed visibility of logout link

### DIFF
--- a/_cucumber/features/primary_nav/primary_nav.feature
+++ b/_cucumber/features/primary_nav/primary_nav.feature
@@ -169,3 +169,20 @@ Feature: Site navigation menu
       | Resources          |
       | Forums             |
       | Stack Overflow Q&A |
+
+  @kc @logout
+  Scenario: Log Out link should only be visible when user is logged-in
+    Given I am a RHD registered site visitor
+    And I am on the Login page
+    When I log in with a valid password
+    Then I should see the Log Out link
+    And I click the Logout link
+    Then I should not see the Log Out link
+
+  @kc @logout
+  Scenario: Register and Login links should only be visible when user is not logged-in
+    Given I am a RHD registered site visitor
+    And I am on the Login page
+    When I log in with a valid password
+    And I click the Logout link
+    Then I should see the Login and Register links

--- a/_cucumber/features/step_definitions/common/navigation_steps.rb
+++ b/_cucumber/features/step_definitions/common/navigation_steps.rb
@@ -142,3 +142,19 @@ end
 Given(/^I navigate to the "(.*)" page$/) do |url|
   @browser.goto($host_to_test + url)
 end
+
+Then(/^I should see the Log Out link$/) do
+  logout_link = @browser.link text: 'Log Out'
+  logout_link.present?
+end
+
+Then(/^I should not see the Log Out link$/) do
+  logout_link = @browser.link text: 'Log Out'
+  expect(logout_link.present?).to be false
+end
+
+Then(/^I should see the Login and Register links$/) do
+  register_link = @browser.link text: 'Register'
+  login_link = @browser.link text: 'Log In'
+  expect(login_link.present? && register_link.present?).to be true
+end

--- a/javascripts/sso.js
+++ b/javascripts/sso.js
@@ -12,7 +12,7 @@ app.sso = function () {
                     .attr('href', app.ssoConfig.account_url)
                     .show();
                 $('li.login, li.register, li.login-divider, section.register-banner, .devnation-hidden-code').hide();
-                $('section.contributors-banner, .devnation-code').show();
+                $('section.contributors-banner, .devnation-code, li.logged-in').show();
                 $('li.login a, a.keycloak-url').attr("href", keycloak.createAccountUrl())
                 // once the promise comes back, listen for a click on logout
                 $('a.logout').on('click',function(e) {
@@ -36,7 +36,7 @@ app.sso = function () {
             }).error(clearTokens);
         } else {
             $('li.login, section.register-banner, .devnation-hidden-code').show();
-            $('li.logged-in, section.contributors-banner, .devnation-code').hide();
+            $('li.logged-in, section.contributors-banner, .devnation-code, li.logged-in').hide();
             $('li.logged-in').hide();
             $('li.login a').on('click',function(e){
                 e.preventDefault();

--- a/stylesheets/_header.scss
+++ b/stylesheets/_header.scss
@@ -157,7 +157,9 @@ nav.accounts {
     a.logged-in-name{
       border-left: none;
     }
-
+    li.logged-in {
+      display: none;
+    }
     a {
       color:white;
       // border-left:1px solid white;


### PR DESCRIPTION
Jira: [DEVELOPER-1754](https://issues.jboss.org/browse/DEVELOPER-1754)


Definition of Done
- During page rendering we only display Login | Register links .
- Login | Register should then be replaced by user name and logout link once Keycloak JS client detects logged in user.
