### PR TITLE
Allowing product editors access to edit products

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.product_team.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.product_team.yml
@@ -38,3 +38,8 @@ permissions:
   - 'use draft_draft transition'
   - 'use published_draft transition'
   - 'use draft_needs_review transition'
+  - 'view all revisions'
+  - 'delete own article content'
+  - 'delete own product content'
+  - 'view the administration theme'
+  - 'access toolbar'


### PR DESCRIPTION
I'm helping some product people and noticed some changes to the permissions that need to be made.