### PR TITLE
DEVELOPER-3914 - Remove company field from manditory checks

### DIFF
--- a/_cucumber/features/register/basic_registration.feature
+++ b/_cucumber/features/register/basic_registration.feature
@@ -139,7 +139,6 @@ Feature: Basic personal registration
       | password confirm field | Type in password again   |
       | first name field       | First name is required   |
       | last name field        | Last name is required    |
-      | company field          | Company name is required |
       | country field          | Country is required      |
 
   Scenario: Terms should link to relevant terms and conditions page

--- a/_cucumber/features/user_profile/user_profile_edit.feature
+++ b/_cucumber/features/user_profile/user_profile_edit.feature
@@ -25,7 +25,6 @@ Feature: User Profile Edit
       | field      | message                  |
       | First name | First name is required   |
       | Last name  | Last name is required    |
-      | Company    | Company name is required |
 
   @logout
   Scenario: First name field should accept no more than 45 characters


### PR DESCRIPTION
Company field is no longer required when registering. Removed tests for this.

NOTE: Registrations will continue to fail as the IT backends still return a 500 error so it's not possible to register.