### PR TITLE
[DEVELOPER-3916] Updated homepage image src URLs to be HTTPS 

### DIFF
--- a/stylesheets/_home.scss
+++ b/stylesheets/_home.scss
@@ -5,7 +5,7 @@
 
 .homepage-main {
   color: $white;
-  background-image: url("http://static.jboss.org/images/rhd/hero/RHDP_home_hero_desktop_mmdbook_17feb2017.png");
+  background-image: url("https://static.jboss.org/images/rhd/hero/RHDP_home_hero_desktop_mmdbook_17feb2017.png");
   background-position: top left;
   background-size: cover;
   background-repeat: no-repeat;
@@ -273,7 +273,7 @@ ul.homepage-resources {
   .homepage-main {
     background-color: #b9b9b9;
     min-height: 440px;
-    background-image: url("http://static.jboss.org/images/rhd/hero/RHDev_homehero_tablet_mmdbook_17feb2017.png");
+    background-image: url("https://static.jboss.org/images/rhd/hero/RHDev_homehero_tablet_mmdbook_17feb2017.png");
     .homepage-cta {
       margin: 30px auto;
       a.button {
@@ -318,7 +318,7 @@ ul.homepage-resources {
 @include mobile-landscape-and-down {
   .homepage-main {
     background-color: #b9b9b9;
-    background-image: url("http://static.jboss.org/images/rhd/hero/RHDev_homehero_mobile_mmdbook_17feb2017.png");
+    background-image: url("https://static.jboss.org/images/rhd/hero/RHDev_homehero_mobile_mmdbook_17feb2017.png");
   }
   .spotlights-container {
     flex-direction: column;


### PR DESCRIPTION
See: https://issues.jboss.org/browse/DEVELOPER-3916

So as to avoid insecure content load warnings on the developers.redhat.com homepage, I've updated the image src URLs to be HTTPS endpoints.

To test:

- Visit the homepage of the exported site and verify that all images are loaded from a HTTPS endpoint