### PR TITLE
[HOLD] [DEVELOPER-3821] Include httrack SIGFAULT workaround into export process

### DIFF
--- a/_docker/lib/export/README.md
+++ b/_docker/lib/export/README.md
@@ -24,6 +24,19 @@ The following workflow is how content is exported from Drupal:
 * Post-process the export to ensure it works as expected
 * Optionally, rsync the export folder to a location of your choice
 
+### Environment variables affecting export process
+
+There are a number of environment variables that when set, will influence the behaviour of the export process. These are:
+
+* drupal.export.fail_on_missing (true/false) [default=true] - Determines if the export process will fail on missing content
+* drupal.export.final_base_url [default=https://developers.redhat.com] - The final URL of the site export which will be
+placed into the error pages of the export to ensure they work at all levels of the hierarchy
+* drupal.export.max_cache_updates [default=750] - The maximum number of times we will update the httrack export cache
+before rolling over to avoid a SIGFAULT inside httrack
+
+You should set the environment variable on the `export` container definition within the `docker-compose.yml` of the
+environment in which you are running the export for them to take affect.
+
 ### Httrack
 
 The export process relies on [httrack](https://www.httrack.com/) to perform the dump to HTML. We use a custom patched version of httrack to allow us to specify a particular structure for saving the HTML files of the site.

--- a/_docker/lib/export/httrack_export_strategy.rb
+++ b/_docker/lib/export/httrack_export_strategy.rb
@@ -94,6 +94,7 @@ class HttrackExportStrategy
   def roll_over_export_cache(export_directory, drupal_host)
     @log.info('Rolling over httrack export cache as maximum cache updates has been reached...')
     FileUtils.mv("#{export_directory}/hts-cache", "#{export_directory}/hts-cache.rolled") if Dir.exist?("#{export_directory}/hts-cache")
+    FileUtils.mv("#{export_directory}/index.html","#{export_directory}/index.html.rolled") if File.exist?("#{export_directory}/index.html")
 
     export = determine_export_directory_from_drupal_host(drupal_host)
     FileUtils.mv("#{export_directory}/#{export}", "#{export_directory}/#{export}.rolled") if Dir.exist?("#{export_directory}/#{export}")

--- a/_docker/lib/export/httrack_export_strategy.rb
+++ b/_docker/lib/export/httrack_export_strategy.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require_relative '../default_logger'
 require_relative 'export_html_post_processor'
 
@@ -6,6 +7,9 @@ require_relative 'export_html_post_processor'
 #
 # This implementation will attempt to make use of httracks built-in caching to speed-up exports
 # that are run against an already existing export.
+#
+# Additionally this class will roll-over the httrack cache when a maximum number of permitted updates
+# has been reached. Please see DEVELOPER-3821 as to why we roll-over the export cache.
 #
 # @author rblake@redhat.com
 #
@@ -16,6 +20,100 @@ class HttrackExportStrategy
     @export_inspector = export_inspector
     @export_post_processor = form_action_rewrite
     @log = DefaultLogger.logger
+  end
+
+
+  #
+  # Export the given links, from the specified drupal host into the given export directory
+  #
+  def export!(links_file, drupal_host, export_directory)
+
+    cache_updates = check_and_roll_over_cache(export_directory, drupal_host)
+
+    if check_if_update_to_existing_export(export_directory)
+      run_update_to_existing_export(export_directory)
+    else
+      run_new_export(links_file, drupal_host, export_directory)
+    end
+
+    write_new_httrack_cache_update(export_directory, cache_updates)
+
+    exported_to = "#{export_directory}/#{determine_export_directory_from_drupal_host(drupal_host)}"
+    @export_post_processor.post_process_html_export(drupal_host, exported_to)
+    @export_inspector.inspect_export(links_file, exported_to)
+    exported_to
+  end
+
+  private
+
+  #
+  # Determines the maximum number of times we will update the httrack export cache.
+  # Returns the default value of 750 unless the user has set the env variable 'drupal.export.max_cache_updates'
+  #
+  def max_httrack_cache_updates
+    user_setting = ENV['drupal.export.max_cache_updates']
+    return 750 if user_setting.nil? || user_setting.empty?
+    user_setting.to_i > 0 ? user_setting.to_i : 1
+  end
+
+  #
+  # Writes the number of cache-updates back to the tracking file
+  #
+  def write_new_httrack_cache_update(export_directory, cache_updates)
+    @log.info("Setting cache update count to '#{cache_updates}' of maximum permitted '#{max_httrack_cache_updates}' updates.")
+      File.open("#{export_directory}/cache-updates",'w+') do |file|
+        file.write(cache_updates)
+      end
+  end
+
+  #
+  # Reads the cache-update counter file to determine how many cache updates we have done so far
+  #
+  def current_httrack_cache_updates(export_directory)
+    cache_update_file = "#{export_directory}/cache-updates"
+    return 0 unless File.exist?(cache_update_file)
+
+    cache_updates = File.open(cache_update_file) do |file|
+      file.readline
+    end
+
+    return 0 if cache_updates.nil? || cache_updates.empty?
+
+    begin
+      return cache_updates.to_i
+    rescue
+
+    end
+
+    0
+  end
+
+  #
+  # Rolls over the export cache if we have reached the maximum allowed number of cache updates
+  #
+  def roll_over_export_cache(export_directory, drupal_host)
+    @log.info('Rolling over httrack export cache as maximum cache updates has been reached...')
+    FileUtils.mv("#{export_directory}/hts-cache", "#{export_directory}/hts-cache.rolled") if Dir.exist?("#{export_directory}/hts-cache")
+
+    export = determine_export_directory_from_drupal_host(drupal_host)
+    FileUtils.mv("#{export_directory}/#{export}", "#{export_directory}/#{export}.rolled") if Dir.exist?("#{export_directory}/#{export}")
+  end
+
+  #
+  # Checks the number of updates that have been performed to the httrack export cache, and
+  # if we have exceeded the maximum permissable number of updates, rolls the export over.
+  #
+  def check_and_roll_over_cache(export_directory, drupal_host)
+    current_cache_updates = current_httrack_cache_updates(export_directory)
+    max_cache_updates = max_httrack_cache_updates
+    @log.info("Export cache has been updated '#{current_cache_updates}' times out of a permitted '#{max_cache_updates}' updates.")
+
+    unless current_cache_updates < max_cache_updates
+      roll_over_export_cache(export_directory, drupal_host)
+      current_cache_updates = 0
+    end
+
+    current_cache_updates + 1
   end
 
   #
@@ -56,24 +154,5 @@ class HttrackExportStrategy
     @log.info("Completed update of existing httrack export in directory '#{export_directory}'")
 
   end
-
-  #
-  # Export the given links, from the specified drupal host into the given export directory
-  #
-  def export!(links_file, drupal_host, export_directory)
-
-    if check_if_update_to_existing_export(export_directory)
-      run_update_to_existing_export(export_directory)
-    else
-      run_new_export(links_file, drupal_host, export_directory)
-    end
-
-    exported_to = "#{export_directory}/#{determine_export_directory_from_drupal_host(drupal_host)}"
-    @export_post_processor.post_process_html_export(drupal_host, exported_to)
-    @export_inspector.inspect_export(links_file, exported_to)
-    exported_to
-  end
-
-  private :run_new_export, :run_update_to_existing_export, :check_if_update_to_existing_export
 
 end

--- a/_docker/tests/export/test_httrack_export_strategy.rb
+++ b/_docker/tests/export/test_httrack_export_strategy.rb
@@ -21,6 +21,126 @@ class TestHttrackExportStrategy < MiniTest::Test
 
   def teardown
     FileUtils.rm_rf(@export_directory)
+    ENV['drupal.export.max_cache_updates'] = nil
+  end
+
+  def cache_update_count
+    File.open("#{@export_directory}/cache-updates") do |file|
+      file.readline.to_i
+    end
+  end
+
+  def write_cache_update_count(count)
+    File.open("#{@export_directory}/cache-updates", 'w+') do |file|
+      file.write(count)
+    end
+  end
+
+  def test_correctly_handles_rollover_if_no_existing_directory_structure
+    ENV['drupal.export.max_cache_updates'] = '1'
+    write_cache_update_count(1)
+
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+    @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+    @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+    export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+    assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(1, cache_update_count)
+
+    refute(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
+    refute(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+  end
+
+  def test_correctly_handles_zero_cache_update_count
+    ENV['drupal.export.max_cache_updates'] = '0'
+
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+    @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+    @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+    export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+    assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(1, cache_update_count)
+  end
+
+  def test_correctly_handles_non_numeric_cache_update_count
+
+    ENV['drupal.export.max_cache_updates'] = 'foo'
+
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+    @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+    @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+    export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+    assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(1, cache_update_count)
+  end
+
+  def test_correctly_handles_negative_cache_update_count
+
+    ENV['drupal.export.max_cache_updates'] = '-1'
+
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+    @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+    @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+    export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+    assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(1, cache_update_count)
+
+  end
+
+  def test_should_roll_over_cache_if_updates_equal_to_permitted
+
+    ENV['drupal.export.max_cache_updates'] = '1'
+
+    Dir.mkdir("#{@export_directory}/hts-cache")
+    Dir.mkdir("#{@export_directory}/drupal_8080")
+    write_cache_update_count(1)
+
+    assert(Dir.exist?("#{@export_directory}/hts-cache"))
+    assert(Dir.exist?("#{@export_directory}/drupal_8080"))
+    refute(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
+    refute(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+
+    @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+    @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+    @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+    export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+    assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(1, cache_update_count)
+
+    assert(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
+    assert(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+
+  end
+
+
+  def test_should_roll_over_cache_if_max_updates_exceeded
+
+      ENV['drupal.export.max_cache_updates'] = '1'
+
+      Dir.mkdir("#{@export_directory}/hts-cache")
+      Dir.mkdir("#{@export_directory}/drupal_8080")
+      write_cache_update_count(2)
+
+      assert(Dir.exist?("#{@export_directory}/hts-cache"))
+      assert(Dir.exist?("#{@export_directory}/drupal_8080"))
+      refute(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
+      refute(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+
+      @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
+      @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
+      @export_inspector.expects(:inspect_export).with(@url_list_file, "#{@export_directory}/drupal_8080")
+
+      export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
+      assert_equal("#{@export_directory}/drupal_8080", export_dir)
+      assert_equal(1, cache_update_count)
+
+      assert(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
+      assert(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
   end
 
 
@@ -32,13 +152,14 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
     assert_equal("#{@export_directory}/drupal_8080", export_dir)
-
+    assert_equal(1, cache_update_count)
   end
 
   def test_should_update_existing_export
 
     Dir.mkdir("#{@export_directory}/hts-cache")
     FileUtils.touch("#{@export_directory}/hts-cache/doit.log")
+    write_cache_update_count(1)
 
     @process_runner.expects(:execute!).with("cd #{@export_directory} && httrack --update")
     @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
@@ -46,6 +167,7 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'drupal:8080', @export_directory)
     assert_equal("#{@export_directory}/drupal_8080", export_dir)
+    assert_equal(2, cache_update_count)
   end
 
   def test_should_run_first_time_export_with_no_host_port
@@ -55,12 +177,14 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'developer-drupal.web.stage.ext.phx2.redhat.com', @export_directory)
     assert_equal("#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com", export_dir)
+    assert_equal(1, cache_update_count)
   end
 
   def test_should_update_existing_export_with_no_host_port
 
     Dir.mkdir("#{@export_directory}/hts-cache")
     FileUtils.touch("#{@export_directory}/hts-cache/doit.log")
+    write_cache_update_count(1)
 
     @process_runner.expects(:execute!).with("cd #{@export_directory} && httrack --update")
     @export_post_processor.expects(:post_process_html_export).with('developer-drupal.web.stage.ext.phx2.redhat.com', "#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com")
@@ -68,6 +192,7 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     export_dir = @httrack_export_strategy.export!(@url_list_file, 'developer-drupal.web.stage.ext.phx2.redhat.com', @export_directory)
     assert_equal("#{@export_directory}/developer-drupal.web.stage.ext.phx2.redhat.com", export_dir)
+    assert_equal(2, cache_update_count)
 
   end
 end

--- a/_docker/tests/export/test_httrack_export_strategy.rb
+++ b/_docker/tests/export/test_httrack_export_strategy.rb
@@ -97,12 +97,15 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     Dir.mkdir("#{@export_directory}/hts-cache")
     Dir.mkdir("#{@export_directory}/drupal_8080")
+    FileUtils.touch("#{@export_directory}/index.html")
     write_cache_update_count(1)
 
     assert(Dir.exist?("#{@export_directory}/hts-cache"))
     assert(Dir.exist?("#{@export_directory}/drupal_8080"))
+    assert(File.exist?("#{@export_directory}/index.html"))
     refute(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
     refute(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+    refute(File.exist?("#{@export_directory}/index.html.rolled"))
 
     @process_runner.expects(:execute!).with("httrack --list #{@url_list_file.path} -O #{@export_directory} --disable-security-limits -c50 --max-rate 0 -v +\"http://#{@drupal_host}*\" -\"*/node*\" -o0 -N ?html?%h/%p/%n/index.html -N %h/%p/%n.%t --footer \"<!-- -->\"")
     @export_post_processor.expects(:post_process_html_export).with(@drupal_host, "#{@export_directory}/drupal_8080")
@@ -114,6 +117,7 @@ class TestHttrackExportStrategy < MiniTest::Test
 
     assert(Dir.exist?("#{@export_directory}/hts-cache.rolled"))
     assert(Dir.exist?("#{@export_directory}/drupal_8080.rolled"))
+    assert(File.exist?("#{@export_directory}/index.html.rolled"))
 
   end
 


### PR DESCRIPTION
Please see DEVELOPER-3821.

This PR incorporates the work-around to the httrack SIGFAULT error after a given number of exports has run into the export process itself. The work-around to the SIGFAULT error is to simply delete the httrack cache to get it to run from fresh. This PR adds a monitor to the number of times we have run the export process and once that count exceeds a threshold, performs the delete of the httrack cache automatically.

The default number of allowed exports has been set to 750, which is a "safe" number for production. We typically see the SIGFAULT error in httrack at around the ~1000 update mark in production.

**How to test**

Clone the branch for this PR into your local environment.

1. In the `drupal-dev` docker-compose.yml, add the following to the `export` container definition: `- drupal.export.max_cache_updates=1` in the `environment` section e.g:

```
export:
    links:
     - drupal:docker
    build: ../../export
    volumes:
     - ../../../:/home/jenkins_developer/developer.redhat.com
     - export:/export
    entrypoint: "ruby _docker/lib/export/export.rb docker"
    environment:
     - drupal.export.fail_on_missing
     - drupal.export.final_base_url=http://docker:9000/
     - drupal.export.max_cache_updates=1
```

2. `bundle exec _docker/control.rb --run-the-stack`
3. `bundle exec _docker/control.rb --export`
4. `bundle exec _docker/control.rb --export`

On the 2nd run of the export, in the log output you should see statements like `Rolling over httrack export cache as maximum cache updates has been reached...`. After these statement the export should proceed and complete as normal. You should be able to access the export at `docker:9000` after both the first and second runs of the export process.
