### PR TITLE
[HOLD] DEVELOPER-3862 Updated user Auth header

### DIFF
--- a/_cucumber/features/primary_nav/primary_nav.feature
+++ b/_cucumber/features/primary_nav/primary_nav.feature
@@ -206,3 +206,11 @@ Feature: Site navigation menu
     When I log in with a valid password
     And I click the Logout link
     Then I should see the Login and Register links
+
+  # backend no yet ready for this scenario
+  @later @kc
+  Scenario: RHD registered user with no first and last name on record should see username n the site header 
+    Given I am an RHD registered user with no first and last name on record
+    When I log in with a valid username
+    Then I should be logged in   
+    And I should see my username in the site header 

--- a/javascripts/sso.js
+++ b/javascripts/sso.js
@@ -7,8 +7,15 @@ app.sso = function () {
             keycloak.updateToken().success(function () {
                 saveTokens();
 
+                var logged_in_user = keycloak.tokenParsed['name'];
+
+                // show username instead of full name if full name is empty or blank (only space character)
+                if (logged_in_user.replace(/\s/g, "").length < 1) {
+                    logged_in_user = keycloak.tokenParsed['preferred_username'];
+                }
+
                 $('a.logged-in-name')
-                    .text(keycloak.tokenParsed['name'])
+                    .text(logged_in_user)
                     .attr('href', app.ssoConfig.account_url)
                     .show();
                 $('li.login, li.register, li.login-divider, section.register-banner, .devnation-hidden-code').hide();


### PR DESCRIPTION
Jira: [DEVELOPER-3862](https://issues.jboss.org/browse/DEVELOPER-3862)

Progressive profiling support for RHD user management brings situation when user may be created without first and last name. RHD Website SSO code should show username instead of full name in the header if full name is not available. Check content of name field obtained from SSO token, if it is empty or blank (only space character) then it should show username instead in app.sso javascript function.