### PR TITLE
DEVELOPER-3585 Fixes topics main promo mobile height

### DIFF
--- a/stylesheets/_topics.scss
+++ b/stylesheets/_topics.scss
@@ -121,7 +121,7 @@
       overflow: hidden;
       text-overflow: ellipsis;
       display: -webkit-box;
-      max-height: 153px;
+      max-height: 150px;
       -webkit-line-clamp: 5;
       -webkit-box-orient: vertical;
       .field__item p{
@@ -150,7 +150,7 @@
       }
     }
     @include mobile-landscape-and-down {
-      height: auto;
+      height: 450px;
     }
   }
 


### PR DESCRIPTION
[DEVELOPER-3585](https://issues.jboss.org/browse/DEVELOPER-3585)

Fixes the ovelapping text in Topics pages' blue box.  [See screenshot](https://www.dropbox.com/s/7x92w5maqkbu250/Screenshot%202017-03-08%2013.04.38.png?dl=0)

