### PR TITLE
Recognize 'EA' as a pre-GA release on download pages

### DIFF
--- a/javascripts/downloads.js
+++ b/javascripts/downloads.js
@@ -133,7 +133,7 @@ app.downloads.display = function(data) {
 
   // We split this into two parts - everything up to and including the latest GA, and everything after it
   for (var i = 0; i < productArray.length; i++) {
-    var match = productArray[i].versionName.match(/alpha|beta/gi);
+    var match = productArray[i].versionName.match(/alpha|beta|EA/gi);
     if(!match) {
       break;
     }


### PR DESCRIPTION
OpenJDK has an early access (EA) release of OpenJDK 9. Currently this is not recognized as a pre-GA release, and thus takes the primary slot on the page. 

I've updated the code to recognize this as a pre-release, resulting in both the EA of OpenJDK 9 and the latest OpenJDK 8 GA being shown. 

See: https://developers-pr.stage.redhat.com/pr/1791/export/products/openjdk/download/

The OpenJDK team are happy with this change.