### PR TITLE
Developer 3945 - Update Registration tests

### DIFF
--- a/_cucumber/features/register/basic_registration.feature
+++ b/_cucumber/features/register/basic_registration.feature
@@ -9,8 +9,7 @@ Feature: Basic personal registration
   Scenario Outline: United States, Canada and Mexico customer must be prompted to enter state and city.
     Given I am on the Registration page
     When I complete the registration form, selecting my country as "<country>"
-    Then I should receive an email containing a verify email link
-    And I navigate to the verify email link
+    And I verify my email address
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -59,8 +58,7 @@ Feature: Basic personal registration
   Scenario: Customers from Ukraine must be prompted to enter city when registering.
     Given I am on the Registration page
     When I complete the registration form, selecting my country as "Ukraine"
-    Then I should receive an email containing a verify email link
-    And I navigate to the verify email link
+    And I verify my email address
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -76,8 +74,7 @@ Feature: Basic personal registration
   Scenario: User can register by navigating directly to the /register page
     Given I navigate to the "/register" page
     When I complete the registration form
-    Then I should receive an email containing a verify email link
-    And I navigate to the verify email link
+    And I verify my email address
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -93,8 +90,7 @@ Feature: Basic personal registration
   Scenario: Site visitor completes the registration form accepting terms by clicking "accept all terms and conditions"
     Given I am on the Registration page
     When I complete the registration form
-    Then I should receive an email containing a verify email link
-    And I navigate to the verify email link
+    And I verify my email address
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -111,8 +107,7 @@ Feature: Basic personal registration
   Scenario: Back Button test after registration should not raise error
     Given I am on the Registration page
     When I complete the registration form
-    Then I should receive an email containing a verify email link
-    And I navigate to the verify email link
+    And I verify my email address
     Then I should be registered and logged in
     When I go back
     Then I should see the Registration page

--- a/_cucumber/features/register/basic_registration.feature
+++ b/_cucumber/features/register/basic_registration.feature
@@ -9,6 +9,8 @@ Feature: Basic personal registration
   Scenario Outline: United States, Canada and Mexico customer must be prompted to enter state and city.
     Given I am on the Registration page
     When I complete the registration form, selecting my country as "<country>"
+    Then I should receive an email containing a verify email link
+    And I navigate to the verify email link
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -57,6 +59,8 @@ Feature: Basic personal registration
   Scenario: Customers from Ukraine must be prompted to enter city when registering.
     Given I am on the Registration page
     When I complete the registration form, selecting my country as "Ukraine"
+    Then I should receive an email containing a verify email link
+    And I navigate to the verify email link
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -72,6 +76,8 @@ Feature: Basic personal registration
   Scenario: User can register by navigating directly to the /register page
     Given I navigate to the "/register" page
     When I complete the registration form
+    Then I should receive an email containing a verify email link
+    And I navigate to the verify email link
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -87,6 +93,8 @@ Feature: Basic personal registration
   Scenario: Site visitor completes the registration form accepting terms by clicking "accept all terms and conditions"
     Given I am on the Registration page
     When I complete the registration form
+    Then I should receive an email containing a verify email link
+    And I navigate to the verify email link
     Then I should be registered and logged in
     When I am on the Edit Details page
     And the following newly registered details should be added to my profile:
@@ -103,6 +111,8 @@ Feature: Basic personal registration
   Scenario: Back Button test after registration should not raise error
     Given I am on the Registration page
     When I complete the registration form
+    Then I should receive an email containing a verify email link
+    And I navigate to the verify email link
     Then I should be registered and logged in
     When I go back
     Then I should see the Registration page

--- a/_cucumber/features/step_definitions/register_steps.rb
+++ b/_cucumber/features/step_definitions/register_steps.rb
@@ -273,6 +273,13 @@ Then(/^each term should link to relevant terms and conditions page:$/) do |table
   end
 end
 
+And(/^I verify my email address$/) do
+  verification_email = get_email(@site_user.details[:email])
+  expect(verification_email.to_s).to include('first-broker-login?')
+  close_and_reopen_browser
+  @browser.goto(verification_email)
+end
+
 Then(/^I should receive an email containing a verify email link$/) do
   @verification_email = get_email(@site_user.details[:email])
   expect(@verification_email.to_s).to include('first-broker-login?')

--- a/_cucumber/features/step_definitions/register_steps.rb
+++ b/_cucumber/features/step_definitions/register_steps.rb
@@ -275,14 +275,14 @@ end
 
 And(/^I verify my email address$/) do
   verification_email = get_email(@site_user.details[:email])
-  expect(verification_email.to_s).to include('first-broker-login?')
+  expect(verification_email.to_s).to include('email-verification?')
   close_and_reopen_browser
   @browser.goto(verification_email)
 end
 
 Then(/^I should receive an email containing a verify email link$/) do
   @verification_email = get_email(@site_user.details[:email])
-  expect(@verification_email.to_s).to include('first-broker-login?')
+  expect(@verification_email.to_s).to include('email-verification?')
 end
 
 And(/^I navigate to the verify email link$/) do


### PR DESCRIPTION
This PR fixes the broken registration flow for KC DM tests. Until recently the flow was broken, now it has been fixed and verify email address has been introduced. 