### PR TITLE
Added ignore_export to error pages

### DIFF
--- a/404-error.html.slim
+++ b/404-error.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Page Not Found
+ignore_export: true
 ---
 
 .row#error-page

--- a/general-error.html.slim
+++ b/general-error.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: base
 title: Page Does Not Exist
+ignore_export: true
 ---
 
 .row#error-page

--- a/search.html.slim
+++ b/search.html.slim
@@ -44,10 +44,10 @@ div(ng-app="search")
 
                 span(data-updated="{{r.fields.sys_created[0] | timestamp}}" ng-show="r.fields.sys_type != 'webpage' || r.fields.sys_type != 'article' || r.fields.sys_type != 'demo'" ng-bind="r.fields.sys_created[0] | MDY")
               p(ng-bind-html="r | description")
-              .tags-list
-                p
-                  span.tag-label(ng-bind="r.sys_tags.length ? 'Tags:' : null")
-                  span.tag(ng-repeat="tag in r.sys_tags" ng-bind="tag")
+              / .tags-list
+              /   p
+              /     span.tag-label(ng-bind="r.sys_tags.length ? 'Tags:' : null")
+              /     span.tag(ng-repeat="tag in r.sys_tags" ng-bind="tag")
 
 
           nav#paginator(ng-hide="loading" ng-if="paginate.pages > 1")


### PR DESCRIPTION
Minor changes:

- Added back 'ignore_export: true' to 404-error.html.slim and general-error.html.slim which had been removed as part of https://github.com/redhat-developer/developers.redhat.com/pull/1797

- Commented out the 'tags' portion of search results. These were not being displayed, per UX request, but the code was causing odd spacing.