### PR TITLE
DEVELOPER-3912: Update Browserstack configuration for running on jenkins

### DIFF
--- a/_cucumber/environments/docker-compose.yml
+++ b/_cucumber/environments/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     - CUCUMBER_TAGS
     - RHD_JS_DRIVER
     - RHD_TEST_PROFILE
-    - RHD_DOCKER_DRIVER
+    - RHD_REMOTE_DRIVER
+    - RHD_BS_AUTHKEY
+    - RHD_BS_USERNAME
 
   selhub:
     image: selenium/hub

--- a/_cucumber/features/downloads/downloads_page.feature
+++ b/_cucumber/features/downloads/downloads_page.feature
@@ -1,4 +1,5 @@
 @smoke
+
 Feature: Download Page - Unauthorised customer
 
   In order to try out Red Hat software,

--- a/_cucumber/features/support/browsers.rb
+++ b/_cucumber/features/support/browsers.rb
@@ -9,23 +9,18 @@ class Browsers
 
   def setup(browser_name, device, user_agent)
     if browser_name.include?('bs_')
+      fail('To use browserstack you must set the RHD_BS_USERNAME & RHD_BS_AUTHKEY env variables in your path') if ENV['RHD_BS_USERNAME'].nil? || ENV['RHD_BS_AUTHKEY'].nil?
       browser = browserstack(browser_name)
     else
       case browser_name
         when 'chrome'
-          browser = chrome(device, ENV['RHD_DOCKER_DRIVER'])
+          browser = chrome(device, ENV['RHD_REMOTE_DRIVER'])
         when 'firefox'
           browser = firefox
         when 'phantomjs'
           browser = phantomjs(user_agent)
-        when 'browserstack'
-          fail("No Browserstack browser env variable found, please set RHD_BS_STACK env variable \n
-                for example RHD_BS_STACK=bs_ie_11. List of available browsers/devices can be found at \n
-                _cucumber/driver/browserstack/browsers.json") if ENV['RHD_BS_STACK'].nil?
-          fail('To use browserstack you must set the RHD_BS_USERNAME & RHD_BS_AUTHKEY env variables') if ENV['RHD_BS_USERNAME'].nil? || ENV['RHD_BS_AUTHKEY'].nil?
-          browser = browserstack(ENV['RHD_BS_STACK'])
         else
-          browser = chrome(device, ENV['RHD_DOCKER_DRIVER'])
+          browser = chrome(device, ENV['RHD_REMOTE_DRIVER'])
       end
     end
     browser

--- a/_cucumber/lib/pages/abstract/generic_base_page.rb
+++ b/_cucumber/lib/pages/abstract/generic_base_page.rb
@@ -21,7 +21,7 @@ class GenericBasePage
       @browser.goto($host_to_test + url)
     end
     wait_for_ajax
-    print_page_load(url)
+    print_page_load(url) if ENV['RHD_JS_DRIVER'].include?('chrome')
   end
 
   def print_page_load(url = nil)
@@ -30,7 +30,7 @@ class GenericBasePage
       puts "Load Time: #{load_secs} seconds for url #{@browser.url}."
     else
       puts "Load Time: #{load_secs} seconds for url '#{url}'."
-    end if ENV['RHD_JS_DRIVER'].include?('chrome')
+    end
   end
 
   def self.expected_element(type, identifier)

--- a/_tests/_cucumber/test_run_tests_options.rb
+++ b/_tests/_cucumber/test_run_tests_options.rb
@@ -71,8 +71,6 @@ class TestRunTestsOptions < MiniTest::Test
 
   def test_non_docker_execution_using_browserstack
 
-    Kernel.expects(:abort).with("'foo' is not a recognised Cucumber profile, see '#{@cucumber_dir}/cucumber.yml' file for valid profiles.")
-
     ENV['RHD_BS_AUTHKEY'] = '12345'
     ENV['RHD_BS_USERNAME'] = 'foobar'
 
@@ -234,8 +232,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('bs_ie_11', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=bs_ie_11 RHD_TEST_PROFILE=desktop STUBBED_DATA=false RHD_BS_USERNAME=foobar RHD_BS_AUTHKEY=12345', test_configuration[:run_tests_command])
     assert_equal('bs_ie_11', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_firefox', ENV['RHD_REMOTE_DRIVER'])
-    assert_equal('docker_firefox', test_configuration[:docker_node])
+    assert_equal('docker_chrome', test_configuration[:docker_node])
     assert_equal(nil, ENV['github_status_sha1'])
     assert_equal(nil, ENV['github_status_context'])
     assert_equal('desktop', ENV['RHD_TEST_PROFILE'])

--- a/_tests/_cucumber/test_run_tests_options.rb
+++ b/_tests/_cucumber/test_run_tests_options.rb
@@ -25,6 +25,8 @@ class TestRunTestsOptions < MiniTest::Test
     ENV['RHD_TEST_PROFILE'] = nil
     ENV['RHD_DOCKER_DRIVER'] = nil
     ENV['STUBBED_DATA'] = nil
+    ENV['RHD_BS_AUTHKEY'] = nil
+    ENV['RHD_BS_USERNAME'] = nil
   end
 
   def test_non_docker_execution_with_no_args
@@ -132,7 +134,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('chrome', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_chrome RHD_TEST_PROFILE=desktop STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_chrome', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal(nil, ENV['github_status_sha1'])
     assert_equal(nil, ENV['github_status_context'])
     assert_equal('false', ENV['STUBBED_DATA'])
@@ -147,7 +149,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('chrome', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_chrome RHD_TEST_PROFILE=desktop STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_chrome', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('docker_chrome', test_configuration[:docker_node])
     assert_equal(nil, ENV['github_status_sha1'])
     assert_equal(nil, ENV['github_status_context'])
@@ -174,7 +176,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('iphone_6', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=iphone_6 RHD_TEST_PROFILE=desktop STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('iphone_6', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('docker_chrome', test_configuration[:docker_node])
     assert_equal(nil, ENV['github_status_sha1'])
     assert_equal(nil, ENV['github_status_context'])
@@ -191,7 +193,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('firefox', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_firefox RHD_TEST_PROFILE=desktop STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_firefox', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_firefox', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_firefox', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('docker_firefox', test_configuration[:docker_node])
     assert_equal(nil, ENV['github_status_sha1'])
     assert_equal(nil, ENV['github_status_context'])
@@ -213,7 +215,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('chrome', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_chrome RHD_TEST_PROFILE=desktop STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_chrome', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('123', ENV['github_status_sha1'])
     assert_equal('Drupal:FE Acceptance Tests', ENV['github_status_context'])
     assert_equal('desktop', ENV['RHD_TEST_PROFILE'])
@@ -230,7 +232,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('chrome', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_chrome RHD_TEST_PROFILE=mobile STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_chrome', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('123', ENV['github_status_sha1'])
     assert_equal('Drupal:Mobile FE Acceptance Tests', ENV['github_status_context'])
     assert_equal('mobile', ENV['RHD_TEST_PROFILE'])
@@ -247,7 +249,7 @@ class TestRunTestsOptions < MiniTest::Test
     assert_equal('chrome', test_configuration[:driver])
     assert_equal('bundle exec rake -f cucumber.rake features RHD_JS_DRIVER=docker_chrome RHD_TEST_PROFILE=kc_dm STUBBED_DATA=false', test_configuration[:run_tests_command])
     assert_equal('docker_chrome', ENV['RHD_JS_DRIVER'])
-    assert_equal('docker_chrome', ENV['RHD_DOCKER_DRIVER'])
+    assert_equal('docker_chrome', ENV['RHD_REMOTE_DRIVER'])
     assert_equal('123', ENV['github_status_sha1'])
     assert_equal('Drupal:FE KC/DM Acceptance Tests', ENV['github_status_context'])
     assert_equal('kc_dm', ENV['RHD_TEST_PROFILE'])


### PR DESCRIPTION
Updated the --run-tests and run-test-options to enable running tests via browserstack (in docker and outside)