### PR TITLE
DEVELOPER-3948 setting up Drupal Unit Tests

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -373,6 +373,10 @@ if $0 == __FILE__
     system_exec.execute_docker_compose(environment, :run, tasks[:unit_tests])
   end
 
+  if tasks[:drupal_unit_tests]
+    system_exec.execute_docker_compose(environment, :run, tasks[:drupal_unit_tests])
+  end
+
   start_and_wait_for_supporting_services(environment, tasks[:supporting_services], system_exec)
 
   if tasks[:awestruct_command_args]

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -112,6 +112,13 @@ services:
     - ../../../:/home/awestruct/developer.redhat.com
    entrypoint: "bundle exec rake test"
 
+  drupal_unit_tests:
+    build: ../../drupal
+    entrypoint: "../vendor/bin/phpunit -c core --testsuite unit --log-junit /tmp/test_output.xml --group rhd_common"
+    volumes:
+      - ../../drupal/drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom 
+
 #
 # Volumes
 #

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -108,3 +108,10 @@ services:
     volumes:
       - ../../../:/home/awestruct/developer.redhat.com
     entrypoint: "bundle exec rake test"
+
+  drupal_unit_tests:
+    build: ../../drupal
+    entrypoint: "../vendor/bin/phpunit -c core --testsuite unit --log-junit test_output.xml --group rhd_common"
+    volumes:
+      - ../../drupal/drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -109,3 +109,11 @@ services:
     - github_status_target_url=${BUILD_URL}
     - github_status_sha1=${ghprbActualCommit}
     - github_status_initialise=Drupal:Unit Tests,Drupal:FE Acceptance Tests,Drupal:Mobile FE Acceptance Tests,Drupal:FE KC/DM Acceptance Tests,Drupal:Exported Site Preview,Drupal:Drupal Site
+
+  drupal_unit_tests:
+    build: ../../drupal
+    entrypoint: "../vendor/bin/phpunit -c core --testsuite unit --log-junit test_output.xml --group rhd_common"
+    volumes:
+      - ../../drupal/drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
+

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -92,3 +92,11 @@ services:
     volumes:
       - ../../../:/home/awestruct/developer.redhat.com
     entrypoint: "bundle exec rake test"
+
+  drupal_unit_tests:
+    build: ../../drupal
+    entrypoint: "../vendor/bin/phpunit -c core --testsuite unit --log-junit test_output.xml --group rhd_common"
+    volumes:
+      - ../../drupal/drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
+

--- a/_docker/lib/options.rb
+++ b/_docker/lib/options.rb
@@ -54,6 +54,14 @@ class Options
         tasks[:docker_pull] = false
       end
 
+      opts.on('-d', '--drupal-unit-test', 'Run the Drupal unit tests') do |b|
+        tasks[:drupal_unit_tests] = drupal_unit_test_tasks
+        tasks[:decrypt] = false
+        tasks[:build] = false
+        tasks[:supporting_services] = []
+        tasks[:docker_pull] = false
+      end
+
       opts.on('-b', '--build', 'Build the containers') do |b|
         tasks[:decrypt] = true
         tasks[:unit_tests] = unit_test_tasks
@@ -78,6 +86,7 @@ class Options
       opts.on('--run-the-stack', 'build, restart and preview') do |rts|
         tasks[:decrypt] = true
         tasks[:unit_tests] = unit_test_tasks
+        tasks[:drupal_unit_tests] = drupal_unit_test_tasks
         tasks[:build] = true
         tasks[:kill_all] = true
         tasks[:awestruct_command_args] = %w(--rm --service-ports awestruct)
@@ -147,4 +156,9 @@ class Options
     %w(--no-deps --rm unit_tests)
   end
 
+  def self.drupal_unit_test_tasks
+    %w(--no-deps --rm drupal_unit_tests)
+  end
+
 end
+

--- a/_docker/tests/test_options.rb
+++ b/_docker/tests/test_options.rb
@@ -167,6 +167,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:kill_all])
     refute(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
+    assert_equal(tasks[:drupal_unit_tests], expected_drupal_unit_test_tasks)
     assert_equal(%w(apache drupalmysql drupal), tasks[:supporting_services])
     assert_equal(%w(--rm --service-ports awestruct), tasks[:awestruct_command_args])
   end
@@ -184,6 +185,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:kill_all])
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
+    assert_equal(tasks[:drupal_unit_tests], expected_drupal_unit_test_tasks)
     assert_equal(%w(apache drupalmysql drupal), tasks[:supporting_services])
     assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
@@ -195,6 +197,7 @@ class TestOptions < Minitest::Test
     assert(tasks[:kill_all])
     assert(tasks[:decrypt])
     assert_equal(tasks[:unit_tests], expected_unit_test_tasks)
+    assert_equal(tasks[:drupal_unit_tests], expected_drupal_unit_test_tasks)
     assert_equal(%w(drupalmysql drupal), tasks[:supporting_services])
     assert_equal(['--rm', '--service-ports', 'awestruct'], tasks[:awestruct_command_args])
   end
@@ -207,7 +210,20 @@ class TestOptions < Minitest::Test
     assert_equal(nil, tasks[:awestruct_command_args])
   end
 
+  def test_drupal_test_task
+    tasks = Options.parse(["-d"])
+    assert_equal(tasks[:build], false)
+    assert_equal(tasks[:decrypt], false)
+    assert_equal(tasks[:drupal_unit_tests], expected_drupal_unit_test_tasks)
+    assert_equal(nil, tasks[:awestruct_command_args])
+  end
+
   private def expected_unit_test_tasks
     %w(--no-deps --rm unit_tests)
   end
+
+  private def expected_drupal_unit_test_tasks
+    %w(--no-deps --rm drupal_unit_tests)
+  end
 end
+


### PR DESCRIPTION
We probably need to break up
https://issues.jboss.org/browse/DEVELOPER-3948 but here's a stab at
getting the infrastructure in place.

Unit tests for the rhd_common module can now be run via our control
script. We probably need to make some changes to the jobs in order to
get these to run as part our builds.

Drupal Unit Tests can be run using either `-d` or `--drupal-unit-test`.
This is probably the easiest way to run tests as running them locally
involves some knowledge of how to run it all.

Rob and I agreed that we should use the current infrastructure and
practices for functional and end-to-end testing.