### PR TITLE
DEVELOPER-3936 - Replace JBDS downloads with Dev Suite

### DIFF
--- a/_cucumber/features/downloads/downloads_page.feature
+++ b/_cucumber/features/downloads/downloads_page.feature
@@ -10,7 +10,7 @@ Feature: Download Page - Unauthorised customer
     Then a "MOST POPULAR" Downloads section with the following Downloads:
       | Red Hat Enterprise Linux                      |
       | Red Hat JBoss Enterprise Application Platform |
-      | Red Hat JBoss Developer Studio                |
+      | Red Hat Development Suite                     |
       | Red Hat JBoss Fuse                            |
     And a 'DOWNLOAD' button for each Most Popular Download
 

--- a/downloads.html.slim
+++ b/downloads.html.slim
@@ -13,7 +13,7 @@ description: Discover the product downloads available from Red Hat, and locate t
     .large-24.column
       h3 Most Popular
   .row
-    - for code in ['rhel', 'eap', 'devstudio', 'fuse']
+    - for code in ['rhel', 'eap', 'devsuite', 'fuse']
       .large-6.column
         - product = site.products[code]
         .popular-download-box


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3936

Should replace the third item "JBoss Developer Studio" with "Red Hat Development Suite" in the Most Popular section on /downloads