### PR TITLE
Fixes Technologies FE acceptance test

### DIFF
--- a/_cucumber/features/step_definitions/technologies_steps.rb
+++ b/_cucumber/features/step_definitions/technologies_steps.rb
@@ -42,6 +42,8 @@ Then(/^I should see a 'Get started' button for each product$/) do
     on TechnologiesPage do |page|
       if product == 'openjdk'
         expect(page.get_started_button_for(product)).to include "products/#{product}/overview"
+      if product == 'openshift'
+        expect(page.get_started_button_for(product)).to include "products/#{product}/overview"
       elsif @products_with_get_started.include?(product)
         expect(page.get_started_button_for(product)).to include "/products/#{product}/hello-world"
       elsif !@products_with_get_started.include?(product) && !@technologies_with_downloads.include?(product)


### PR DESCRIPTION
A link change in Drupal caused one of the FE Technologies scenario to fail. Updated the test to reflect the content change.