### PR TITLE
DEVELOPER-4053 Added WebpageSearchExclude meta tag

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--article.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--article.html.twig
@@ -97,3 +97,6 @@ other methods (such as node.delete) will result in an exception.
   </div>
 
 </div>
+<noscript>
+    <meta name="DCP:WebpageSearchExclude" content="true">
+</noscript>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/video/node--video-resource.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/video/node--video-resource.html.twig
@@ -26,3 +26,6 @@
         </div>
     </div>
 </div>
+<noscript>
+    <meta name="DCP:WebpageSearchExclude" content="true">
+</noscript>

--- a/_layouts/quickstart.html.slim
+++ b/_layouts/quickstart.html.slim
@@ -34,3 +34,6 @@ layout: base
         = page._details
   .large-4.columns
     p sidebar
+  
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/_layouts/ticket-monster.html.slim
+++ b/_layouts/ticket-monster.html.slim
@@ -33,3 +33,6 @@ layout: base
       br
       .flex-video.large.24
         = page._followalong
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/_layouts/video_page.html.slim
+++ b/_layouts/video_page.html.slim
@@ -12,6 +12,8 @@ layout: base
 - if !page.video.nil? && !page.video.target_product.nil? && !page.video.target_product[0].nil? && !page.video.target_product[0].empty?
   - product = site.products[page.video.target_product[0]]
 
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"
 
 .row.content
 

--- a/events/devnation/2016/index.html.slim
+++ b/events/devnation/2016/index.html.slim
@@ -111,5 +111,8 @@ section.wide.wide-hero(class="#{page.hero_class}")
                   - if c.speaker
                     p #{c.speaker_intro}
 
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"
+
 = javascripts('devnation2016-index', true) do
   script src="#{site.base_url}/javascripts/devnation2016.js"

--- a/events/devoxx/2015/index.html.slim
+++ b/events/devoxx/2015/index.html.slim
@@ -138,3 +138,5 @@ ignore_export: true
                           a.button(href='#{site.base_url}/video/youtube/#{a.youtube_id}') watch now
                     .desc-wrapper
                       p #{a.description}
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/devoxxfrance/2016/index.html.slim
+++ b/events/devoxxfrance/2016/index.html.slim
@@ -5,7 +5,7 @@ primary_nav_hidden: true
 interpolate: true
 hero_class: devoxxfrance
 title: DevoxxFrance
-description: Red Hat is a Devoxx France 2016 sponsor.  Come find us, s'il vous plaît
+description: Red Hat is a Devoxx France 2016 sponsor. Come find us, s'il vous plaît
 ignore_export: true
 ---
 
@@ -90,3 +90,5 @@ section.wide.wide-hero(class="#{page.hero_class}")
             i.fa.fa-twitter
           li: a(href="https://plus.google.com/103877536668756379905/posts")
             i.fa.fa-google-plus
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/gids/2016/index.html.slim
+++ b/events/gids/2016/index.html.slim
@@ -83,3 +83,6 @@ ignore_export: true
             i.fa.fa-twitter
           li: a(href="https://plus.google.com/103877536668756379905/posts")
             i.fa.fa-google-plus
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/javaone/2015/index.html.slim
+++ b/events/javaone/2015/index.html.slim
@@ -114,3 +114,6 @@ ignore_export: true
             p
               a(href='http://www.jboss.org/events/javaone/2009') JavaOne 2009
               | &emsp;June 2 - June 5, 2009 | San Francisco                       
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/javaone/2016/index.html.slim
+++ b/events/javaone/2016/index.html.slim
@@ -65,3 +65,6 @@ ignore_export: true
                     | Speaker:
                     strong  #{session.speaker}
                   p #{session.description}
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/judcon/2016/brno/index.html.slim
+++ b/events/judcon/2016/brno/index.html.slim
@@ -57,3 +57,6 @@ ignore_export: true
             li 
               h5 #{b.title}
               p #{b.description}
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"

--- a/events/msbuild/2016/index.html.slim
+++ b/events/msbuild/2016/index.html.slim
@@ -116,3 +116,6 @@ ignore_export: true
             i.fa.fa-twitter
           li: a(href="https://plus.google.com/103877536668756379905/posts")
             i.fa.fa-google-plus
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"


### PR DESCRIPTION
[DEVELOPER-4053](https://issues.jboss.org/browse/DEVELOPER-4053)

Add `<meta name="DCP:WebpageSearchExclude" content="true">` to webpages that should not appear in the rht_website results. I.e those that have a more specific version of the content.