### PR TITLE
DEVELOPER-3976 CKEditor buttons for media library

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - media_entity.bundle.image
   module:
     - image
-third_party_settings: { }
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -37,4 +36,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_library_image: true
   uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_browser.yml
@@ -1,3 +1,4 @@
+uuid: b35f7a16-2694-4c7d-a42c-4bdf3b1967f6
 langcode: en
 status: true
 dependencies:
@@ -36,4 +37,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_library_image: true
   uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
@@ -1,4 +1,4 @@
-uuid: ed7f1640-23bc-4d39-8939-9b97a96fb06a
+uuid: e0dcfcd4-98fd-4805-95fc-4711f4b5ab8c
 langcode: en
 status: true
 dependencies:
@@ -19,7 +19,7 @@ content:
     weight: -10
     settings:
       match_operator: CONTAINS
-      size: 60
+      size: '60'
       placeholder: ''
     third_party_settings: {  }
   field_moderation_state:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.scheduled_update.node_embargo.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.scheduled_update.node_embargo.default.yml
@@ -1,4 +1,4 @@
-uuid: 4f857ab3-08d7-4551-bd7f-283b0ab6e3df
+uuid: 342ed2cc-e00f-43db-806d-35a97b106e30
 langcode: en
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.default.yml
@@ -25,6 +25,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_library_image: true
   field_media_in_library: true
   name: true
   thumbnail: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.embedded.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.embedded.yml
@@ -1,3 +1,4 @@
+uuid: d46416e9-a313-4165-9b7f-2a22d2db633b
 langcode: en
 status: true
 dependencies:
@@ -25,6 +26,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_library_image: true
   field_media_in_library: true
   name: true
   thumbnail: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -1,3 +1,4 @@
+uuid: c328b717-aec8-4161-b24d-bb41c7c5abbb
 langcode: en
 status: true
 dependencies:
@@ -22,6 +23,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_library_image: true
   field_media_in_library: true
   name: true
   thumbnail: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -38,10 +38,10 @@ module:
   interval: 0
   key_value: 0
   layoutmanager: 0
-  lightning: 1
   lightning_core: 0
   lightning_media: 0
   lightning_media_image: 0
+  lightning_workflow: 0
   link: 0
   linkit: 0
   media_entity: 0
@@ -91,6 +91,7 @@ module:
   entity_reference_revisions: 1
   field_collection: 1
   field_group: 1
+  lightning: 1
   menu_link_content: 1
   paragraphs: 1
   pathauto: 1

--- a/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rhd_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rhd_html.yml
@@ -36,7 +36,6 @@ settings:
             - Blockquote
             - media_browser
             - node
-            - video_embed
         -
           name: 'Block Formatting'
           items:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
@@ -16,7 +16,7 @@ type_settings:
   entity_type: media
   bundles: {  }
   display_plugins:
-    - 'entity_reference:entity_reference_entity_view'
+    - 'entity_reference:media_thumbnail'
   entity_browser: media_browser
   entity_browser_settings:
     display_review: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.image_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.image_browser.yml
@@ -1,3 +1,4 @@
+uuid: 1fa7add7-f7ef-4c5b-bd2b-cc0a04b4dffb
 langcode: en
 status: true
 dependencies:
@@ -21,6 +22,7 @@ widgets:
     settings:
       submit_text: Select
       return_file: true
+      form_mode: media_browser
     uuid: 44d52e51-9627-43b5-a637-3b0462041d1c
     weight: -9
     label: Upload
@@ -30,6 +32,7 @@ widgets:
       view: media
       view_display: image_browser
       submit_text: Select
+      auto_select: false
     uuid: 58383135-0f34-4a4a-85fc-5cf9b5de2fdd
     weight: -10
     label: Library

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.media.image.image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.media.image.image.yml
@@ -1,3 +1,4 @@
+uuid: bf376445-63a1-449a-abdc-650553136df6
 langcode: und
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.scheduled_update.multiple_node_embargo.field_moderation_state.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.scheduled_update.multiple_node_embargo.field_moderation_state.yml
@@ -1,4 +1,4 @@
-uuid: cabc6863-ac84-4c9d-985f-e129a7d01083
+uuid: 6b49d34f-79dc-4f64-9ada-461f389bb37e
 langcode: en
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.scheduled_update.node_embargo.field_moderation_state.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.scheduled_update.node_embargo.field_moderation_state.yml
@@ -1,4 +1,4 @@
-uuid: 6a67d865-b8ed-4c9b-9c43-ccd655da4f42
+uuid: a347fd16-a7ba-47d4-81fc-06bd0aebadb4
 langcode: en
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.scheduled_update.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.scheduled_update.yml
@@ -1,4 +1,4 @@
-uuid: 8f1a53b4-ffa8-45d3-a7c0-8f35923c6637
+uuid: fa6bbeeb-2196-438e-91ce-5fb4c6057623
 langcode: en
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.scheduled_update.field_moderation_state.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.scheduled_update.field_moderation_state.yml
@@ -1,4 +1,4 @@
-uuid: 2a28614d-242e-4ab9-9ec6-1442abf94e05
+uuid: aff2145d-55e0-41a4-a29a-83566462fe50
 langcode: en
 status: true
 dependencies:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
@@ -88,7 +88,7 @@ filters:
   video_embed_wysiwyg:
     id: video_embed_wysiwyg
     provider: video_embed_wysiwyg
-    status: true
+    status: false
     weight: -47
     settings: {  }
   entity_embed:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/media_entity.bundle.image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/media_entity.bundle.image.yml
@@ -1,3 +1,4 @@
+uuid: 7748f8ff-d62e-400c-b1a7-49be60912369
 langcode: und
 status: true
 dependencies:
@@ -5,11 +6,13 @@ dependencies:
     - media_entity_image
 _core:
   default_config_hash: VkPfZJrZ0ZdHG3-gS9hH-0chO52UGwahux7soQSg_GY
-id: image_library
+id: image
 label: Image
 description: 'Locally hosted images.'
 type: image
+queue_thumbnail_downloads: false
+new_revision: false
 type_configuration:
   source_field: image
-  gather_exif: '0'
+  gather_exif: false
 field_map: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/scheduled_updates.scheduled_update_type.multiple_node_embargo.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/scheduled_updates.scheduled_update_type.multiple_node_embargo.yml
@@ -1,4 +1,4 @@
-uuid: 6d2e2e95-7012-4c6a-8449-893286b25a45
+uuid: 21730d2f-4ea2-468b-a647-1bae752bd1a2
 langcode: en
 status: true
 dependencies: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/scheduled_updates.scheduled_update_type.node_embargo.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/scheduled_updates.scheduled_update_type.node_embargo.yml
@@ -1,4 +1,4 @@
-uuid: cd2fd490-df5e-4a12-96d1-e070c1fd8374
+uuid: 3340cf8a-e8ae-4fd3-b240-352524ae1142
 langcode: en
 status: true
 dependencies: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.moderation_history.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.moderation_history.yml
@@ -1,4 +1,4 @@
-uuid: 78b19300-b178-4b8f-aaec-17656a01527b
+uuid: eb724d1b-0750-4ab6-9ae2-bbc4eb3e4c4e
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/DEVELOPER-3976

Within CKEditor (the WYSIWYG editor in Drupal) you should see two new icons: a star and an 'E'. The star is for media (there may be two already in the view). The 'E' is for embedding nodes.

You should be able to click on the star, upload a new image into the media library and place an image from the library into the editor.