### PR TITLE
DEVELOPER-4042 Fixed .Net product name

### DIFF
--- a/_cucumber/features/help/forums/DEVELOPER-3057_forums.feature
+++ b/_cucumber/features/help/forums/DEVELOPER-3057_forums.feature
@@ -13,7 +13,7 @@ Feature: DEVELOPER-3057 - Forums: Product forums landing page
       | Red Hat JBoss BPM Suite                       |
       | Red Hat JBoss Data Virtualization             |
       | Red Hat JBoss Fuse                            |
-      | .NET Runtime for Red Hat Linux                |
+      | .NET Runtime for Red Hat Enterprise Linux     |
 
   Scenario: Each available product title should link to the relevant product forum page
     Given I am on the Product forums page
@@ -27,5 +27,5 @@ Feature: DEVELOPER-3057 - Forums: Product forums landing page
       | Red Hat JBoss BPM Suite                       |
       | Red Hat JBoss Data Virtualization             |
       | Red Hat JBoss Fuse                            |
-      | .NET Runtime for Red Hat Linux                |
+      | .NET Runtime for Red Hat Enterprise Linux     |
     And each product title should link to the relevant product forum page

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -351,7 +351,7 @@
                           <div class="sub-nav-group">
                             <a class="heading" href="/products#runtimes">Runtimes</a>
                             <a class="hide-on-mobile" href="/products/openjdk/overview">OpenJDK</a>
-                            <a class="hide-on-mobile" href="/products/dotnet/overview">.NET Runtime for Red Hat Linux</a>
+                            <a class="hide-on-mobile" href="/products/dotnet/overview">.NET Runtime for Red Hat Enterprise Linux</a>
                           </div>
                         </div>
                     </li>

--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -176,7 +176,7 @@
                   .sub-nav-group
                     a.heading(href="#{site.base_url}/products/#runtimes/") Runtimes
                     a.hide-on-mobile(href="#{site.base_url}/products/openjdk/overview/") OpenJDK
-                    a.hide-on-mobile(href="#{site.base_url}/products/dotnet/overview/") .NET Runtime for Red Hat Linux
+                    a.hide-on-mobile(href="#{site.base_url}/products/dotnet/overview/") .NET Runtime for Red Hat Enterprise Linux
               li.has-sub-nav(class=((page.url.include?('/community')) && !(page.url.include?('/products/')) ? 'active' : ''))
                 a(href="#")
                   | Community

--- a/products/dotnet/_common/product.yml
+++ b/products/dotnet/_common/product.yml
@@ -1,4 +1,4 @@
-name: .NET Runtime for Red Hat Linux
+name: .NET Runtime for Red Hat Enterprise Linux
 abbreviated_name: DotNet
 current_version:
 product_category: application-development


### PR DESCRIPTION
[DEVELOPER-4042](https://issues.jboss.org/browse/DEVELOPER-4042)

Changed ".NET Runtime for Red Hat Linux" to ".NET Runtime for Red Hat Enterprise Linux" in:

- /products/
- /downloads/
- Main navigation
- /forums/

and updated acceptance tests