### PR TITLE
DEVELOPER-3846 - Fixed the tag export to reflect string representation

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
@@ -417,7 +417,7 @@ display:
             more_link: false
             more_link_text: ''
             more_link_path: ''
-            strip_tags: false
+            strip_tags: true
             trim: false
             preserve_tags: ''
             html: false
@@ -730,7 +730,7 @@ display:
               raw_output: true
             field_cheat_sheet_tags:
               alias: ''
-              raw_output: true
+              raw_output: false
             nid:
               alias: ''
               raw_output: true


### PR DESCRIPTION
For the tag field, I changed the REST export so that it lists a comma delimited string.  This allows for the name of the tag to be exported instead of the taxonomy id associated with it.