### PR TITLE
DEVELOPER-4056 Fixed articles layout nav

### DIFF
--- a/stylesheets/_global-wrapper.scss
+++ b/stylesheets/_global-wrapper.scss
@@ -36,6 +36,7 @@ p.sign-in-options {
 footer.bottom {
   background:$black;
   padding:20px 0 10px 0;
+  z-index: 0;
   h3 {
     font-size: 1rem;
     text-transform: uppercase;


### PR DESCRIPTION
[DEVELOPER-4056](https://issues.jboss.org/browse/DEVELOPER-4056)

Fixed: Side navigation in Article pages runs over footer when the height of the window is not tall enough to fit it in the content area.