### PR TITLE
[DEVELOPER-4023] Ensure sitemap.xml contains correct URL for each environment

### DIFF
--- a/_docker/lib/export/drupal_page_url_list_generator.rb
+++ b/_docker/lib/export/drupal_page_url_list_generator.rb
@@ -3,6 +3,7 @@ require 'net/http'
 require 'nokogiri'
 
 require_relative '../default_logger'
+require_relative 'export_urls'
 
 #
 # Fetches a sitemap.xml from the passed Drupal host and generates a list of links from that
@@ -11,6 +12,8 @@ require_relative '../default_logger'
 # @author rblake@redhat.com
 #
 class DrupalPageUrlListGenerator
+
+  include RedhatDeveloper::Export::Urls
 
   def initialize(drupal_host, export_directory)
     @drupal_host = drupal_host
@@ -87,7 +90,7 @@ class DrupalPageUrlListGenerator
       # We need to rewrite the URI to point to production, but only the loc nodes
       sitemap_xml = Nokogiri::XML(sitemap)
       sitemap_xml.xpath('//xmlns:loc').each do |loc|
-        loc.content = loc.content.gsub(%r{http://.*?/}, 'https://developers.redhat.com/')
+        loc.content = loc.content.gsub(%r{http://.*?/}, final_base_url_location)
       end
       file.puts(sitemap_xml.to_s)
     end

--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require 'nokogiri'
 require 'fileutils'
 require_relative '../default_logger'
+require_relative 'export_urls'
 
 #
 # This class is used to post-process an httrack export of a site. It performs primarily 2 tasks:
@@ -15,6 +16,8 @@ require_relative '../default_logger'
 # Default out-of-the-box, we can only do the latter with Httrack, hence all of this post-processing logic to get us to the former!
 #
 class ExportHtmlPostProcessor
+
+  include RedhatDeveloper::Export::Urls
 
   def initialize(process_runner, static_file_directory)
     @log = DefaultLogger.logger
@@ -116,16 +119,6 @@ class ExportHtmlPostProcessor
 
       rewrite_error_page(html_doc, html_file)
     end
-  end
-
-  #
-  # Returns the URL at which this export will be hosted. By default this will be https://developers.redhat.com unless the
-  # user has set an environment variable to alter this for another environment e.g. staging
-  #
-  def final_base_url_location
-    user_provided_value = ENV['drupal.export.final_base_url']
-    user_provided_value = 'https://developers.redhat.com' if user_provided_value.nil? || user_provided_value.empty?
-    return user_provided_value.end_with?('/') ? user_provided_value : "#{user_provided_value}/"
   end
 
   #

--- a/_docker/lib/export/export_urls.rb
+++ b/_docker/lib/export/export_urls.rb
@@ -1,0 +1,20 @@
+#
+# Small module that can be used a a mixin, primarily for working with URLs provided by the user for
+# the export process
+#
+# @author rblake@redhat.clom
+module RedhatDeveloper
+  module Export
+    module Urls
+      #
+      # Returns the URL at which this export will be hosted. By default this will be https://developers.redhat.com unless the
+      # user has set an environment variable to alter this for another environment e.g. staging
+      #
+      def final_base_url_location
+        user_provided_value = ENV['drupal.export.final_base_url']
+        user_provided_value = 'https://developers.redhat.com' if user_provided_value.nil? || user_provided_value.empty?
+        return user_provided_value.end_with?('/') ? user_provided_value : "#{user_provided_value}/"
+      end
+    end
+  end
+end

--- a/_docker/tests/export/test_export_urls.rb
+++ b/_docker/tests/export/test_export_urls.rb
@@ -1,0 +1,43 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../test_helper'
+require_relative '../../lib/export/export_urls'
+
+module RedhatDeveloper
+  module Export
+    module Urls
+      class TestExportUrls < Minitest::Test
+
+        include RedhatDeveloper::Export::Urls
+
+        def setup
+          clear_env
+        end
+
+        def teardown
+          clear_env
+        end
+
+        def clear_env
+          ENV['drupal.export.final_base_url'] = nil
+        end
+
+        def test_should_read_env_variable
+          ENV['drupal.export.final_base_url'] = 'http://foo.com'
+          assert_equal('http://foo.com/', final_base_url_location)
+        end
+
+        def test_should_return_default_value
+          assert_equal('https://developers.redhat.com/', final_base_url_location)
+        end
+
+        def test_should_return_default_value_if_user_value_empty
+          ENV['drupal.export.final_base_url'] = ''
+          assert_equal('https://developers.redhat.com/', final_base_url_location)
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the fetch, save and re-write of the sitemap.xml during the export process to take into account the `drupal.export.final_base_url` environment parameter.

This allows the user to set the URL that should appear within the exported sitemap.xml on a per-environment basis. We already use this parameter to re-write URL locations on error pages as part of the export HTML post-processing, so integration here was fairly trivial.

For reviewers:

1. Allow the export for this PR to run
2. Visit the sitemap.xml for this PR and ensure that it has the correct URL for the export location and not https://developers.redhat.com
3. Ensure that the links within the sitemap.xml are pointing to genuine locations.
