### PR TITLE
DEVELOPER-4064 - CDK download page does not mention CDK 2.4 for the CDK 2.4 bits

### DIFF
--- a/javascripts/downloads.js
+++ b/javascripts/downloads.js
@@ -52,7 +52,7 @@ app.downloads.createDownloadTable = function(products) {
       }
 
       // if the next one isn't the same, or it's the last item, append it..
-      if((j + 1) === product.files.length || file.description !== lastDescription) {
+      if((j + 1) === product.files.length || file.description !== lastDescription || versionName !== '') {
         $table.append(row);
       }
 


### PR DESCRIPTION
To test: Navigate to '/products/cdk/download/' and notice that 2.4 should now be appearing in the download table.

The reason this was not being displayed is that the description 'Red Hat Container Tools' mirrored the 3.0 Beta version. As a result, 'Red Hat Container Tools' was being clipped off for version 2.4.