### PR TITLE
[DEVELOPER-4077] Lock npm dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ _docker/awestruct/overlay/ssh-key/id*
 _docker/awestruct/overlay/ssh-key/known_hosts
 # Wes' front end deps for local dev
 node_modules/
-package.json
-gulpfile.js
 _gulp/
 _docker/awestruct/Gemfile
 _docker/awestruct/Gemfile.lock

--- a/package.json
+++ b/package.json
@@ -9,19 +9,19 @@
   "author": "Red Hat Inc.",
   "license": "",
   "devDependencies": {
-    "gulp": "^3.9.0",
-    "gulp-concat": "^2.6.0",
-    "gulp-debug": "^2.1.2",
-    "gulp-load-plugins": "^0.8.0",
-    "gulp-plumber": "^1.0.1",
-    "gulp-rename": "^1.2.2",
-    "gulp-notify": "^2.2.0",
-    "gulp-inject-string": "^1.1.0",
-    "del": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "node-sass": "^3.4.2",
-    "node-sass-utils": "^1.1.2",
-    "gulp-sass": "^2.1.1"
+    "gulp": "3.9.0",
+    "gulp-concat": "2.6.0",
+    "gulp-debug": "2.1.2",
+    "gulp-load-plugins": "0.8.0",
+    "gulp-plumber": "1.0.1",
+    "gulp-rename": "1.2.2",
+    "gulp-notify": "2.2.0",
+    "gulp-inject-string": "1.1.0",
+    "del": "2.2.0",
+    "gulp-sourcemaps": "1.6.0",
+    "node-sass": "3.4.2",
+    "node-sass-utils": "1.1.2",
+    "gulp-sass": "2.1.1"
   }
 }
 


### PR DESCRIPTION
This PR locks the versions of the npm dependencies used by the project to prevent using newer dependency versions that may not work.