### PR TITLE
[DEVELOPER-4044] Sync production Drupal content into staging environment

### DIFF
--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -41,17 +41,43 @@ services:
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
-      - /data/drupal/files:/var/www/drupal/web/sites/default/files
-      - /data/drupal/config:/var/www/drupal/web/config/active
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
+    volumes_from:
+      - drupal_data
     environment:
       - http_proxy=proxy01.util.phx2.redhat.com:8080
       - https_proxy=proxy01.util.phx2.redhat.com:8080
 
+  # Drupal production data
+  drupal_data:
+    image: redhatdeveloper/drupal-data:latest
+    volumes:
+      - /var/www/drupal/web/config/active
+      - /var/www/drupal/web/sites/default/files
+      - /docker-entrypoint-initdb.d
+
   #
   # Environment actions
   #
+  database_sync:
+    user: root
+    build:
+      context: ../../backup
+      args:
+       http_proxy: proxy01.util.phx2.redhat.com:8080
+       https_proxy: proxy01.util.phx2.redhat.com:8080
+    entrypoint: "ruby developer.redhat.com/_docker/lib/staging-sync/run.rb"
+    volumes:
+      - ../../../:/home/jenkins_developer/developer.redhat.com
+      - /credentials/db/my.cnf:/root/.my.cnf
+      - /data/database-sync:/backup
+    volumes_from:
+      - drupal_data
+    environment:
+      - http_proxy=proxy01.util.phx2.redhat.com:8080
+      - https_proxy=proxy01.util.phx2.redhat.com:8080
+
   export:
     build:
       context: ../../export

--- a/_docker/lib/staging-sync/database_sync.rb
+++ b/_docker/lib/staging-sync/database_sync.rb
@@ -1,0 +1,65 @@
+require 'fileutils'
+require_relative '../process_runner'
+require_relative '../default_logger'
+
+module RedhatDeveloper
+  module StagingSync
+
+    #
+    # This class syncs the staging database with a latest production database dump. First it takes a backup of the
+    # current database. It then drops and re-creates the database before finally importing the current production
+    # database dump.
+    #
+    # @author rblake@redhat.com
+    class DatabaseSync
+
+      def initialize(backup_directory, production_db_gzip_dump, process_runner, database_name = 'rhd_mysql')
+        @backup_directory = backup_directory
+        @database_gzip_dump_location = production_db_gzip_dump
+        @process_runner = process_runner
+        @database_name = database_name
+        @log = DefaultLogger.logger
+      end
+
+      #
+      # Syncs the current production database dump into the configured database
+      #
+      def sync_database
+        backup_existing_database
+        drop_and_recreate_database
+        import_production_database
+      end
+
+      private
+
+      #
+      # Takes a backup of the existing database so that we can restore if we need to
+      #
+      def backup_existing_database
+        database_backup_name = "#{@backup_directory}/drupal-db.sync.sql.gz"
+        FileUtils.mv(database_backup_name, "#{database_backup_name}.old") if File.exist?(database_backup_name)
+        @log.info("Backing up current database to '#{database_backup_name}'...")
+        @process_runner.execute!("mysqldump #{@database_name} | gzip > #{database_backup_name}")
+        @log.info('Completed backup of current database.')
+      end
+
+      #
+      # Drops the current database and then immediately recreates it so that we can perform the import of content
+      #
+      def drop_and_recreate_database
+        @log.info("Dropping and re-creating database '#{@database_name}'...")
+        @process_runner.execute!("mysql -e 'drop database if exists #{@database_name};create database #{@database_name}'")
+        @log.info("Successfully dropped and re-created database '#{@database_name}'.")
+      end
+
+      #
+      # Imports the production database dump into the current empty database
+      #
+      def import_production_database
+        @log.info("Importing production database dump from #{@database_gzip_dump_location} to database #{@database_name}. This may take a while...")
+        @process_runner.execute!("gunzip -c #{@database_gzip_dump_location} | mysql #{@database_name}")
+        @log.info("Successfully imported database dump from #{@database_gzip_dump_location} to database #{@database_name}.")
+      end
+    end
+  end
+end

--- a/_docker/lib/staging-sync/run.rb
+++ b/_docker/lib/staging-sync/run.rb
@@ -1,0 +1,10 @@
+require_relative '../process_runner'
+require_relative 'database_sync'
+
+module RedhatDeveloper
+  module StagingSync
+    if $0 == __FILE__
+      DatabaseSync.new('/backup','/docker-entrypoint-initdb.d/drupal-db.sql.gz', ProcessRunner.new).sync_database
+    end
+  end
+end

--- a/_docker/tests/staging-sync/test_database_sync.rb
+++ b/_docker/tests/staging-sync/test_database_sync.rb
@@ -1,0 +1,49 @@
+require 'tmpdir'
+require 'fileutils'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+require_relative '../../lib/staging-sync/database_sync'
+require_relative '../test_helper'
+
+module RedhatDeveloper
+  module StagingSync
+    class TestDatabaseSync < MiniTest::Test
+
+      def setup
+        @backup_directory = Dir.mktmpdir
+        @process_runner = mock()
+        @database_sync = RedhatDeveloper::StagingSync::DatabaseSync.new(@backup_directory,'/drupal-db.sql.gz',@process_runner)
+      end
+
+      def teardown
+        FileUtils.rm_rf(@backup_directory)
+      end
+
+      def test_should_correctly_sync_database
+        refute(File.exist?("#{@backup_directory}/drupal-db.sync.sql.gz"))
+
+        @process_runner.expects(:execute!).with("mysqldump rhd_mysql | gzip > #{@backup_directory}/drupal-db.sync.sql.gz")
+        @process_runner.expects(:execute!).with('mysql -e \'drop database if exists rhd_mysql;create database rhd_mysql\'')
+        @process_runner.expects(:execute!).with('gunzip -c /drupal-db.sql.gz | mysql rhd_mysql')
+
+        @database_sync.sync_database
+      end
+
+      def test_should_correctly_sync_database_and_move_existing_backup
+        FileUtils.touch("#{@backup_directory}/drupal-db.sync.sql.gz")
+        assert(File.exist?("#{@backup_directory}/drupal-db.sync.sql.gz"))
+
+        @process_runner.expects(:execute!).with("mysqldump rhd_mysql | gzip > #{@backup_directory}/drupal-db.sync.sql.gz")
+        @process_runner.expects(:execute!).with('mysql -e \'drop database if exists rhd_mysql;create database rhd_mysql\'')
+        @process_runner.expects(:execute!).with('gunzip -c /drupal-db.sql.gz | mysql rhd_mysql')
+
+        @database_sync.sync_database
+
+        refute(File.exist?("#{@backup_directory}/drupal-db.sync.sql.gz"))
+        assert(File.exist?("#{@backup_directory}/drupal-db.sync.sql.gz.old"))
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This pull-request adds the ability to sync content from production environment Drupal instance into the staging environment (developers.stage.redhat.com) Drupal instance. This is needed so that staging is more representative of production.

The work in this PR builds on what we know already works in dev and PR environments, namely using a Docker data image to obtain most of the content from Production. The staging Drupal instance has been re-configured in the `docker-compose.yml` for the `drupal-staging` environment to mount the active Drupal configuration and any images from production.

The major difference here is how we apply the database synchronisation. As the database in the staging environment is a fully IT managed MariaDB instance, we cannot use the current Docker-based approach to seed it with data from production. Therefore this PR adds a small Ruby class that will:

1. Take a backup of the current database
2. Drop the current database and re-create and empty version of it
3. Import the latest production database dump from the command line into this empty database.

All of the above is controlled via the [Sync_Production_Data](https://redhat-dev-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/developers.stage.redhat.com%20(Staging)/job/Sync_Production_Data/) Jenkins job. This job runs every night and resets the developers.stage.redhat.com Drupal instance to contain the latest production data. This means that essentially each night, the staging environment resets itself to be a mirror of production.

**For Reviewers:**

Unfortunately there isn't really a convenient way to test this PR ( a side-effect of different ways of managing databases in our environments) that doesn't involve playing around with the Docker configuration for the drupal-dev environment on your machine, but not committing the changes. 

I have tested it myself when working on it with a temporary Docker configuration on my local machine and have verified it works as expected, so perhaps just a comprehensive code review.

