### PR TITLE
DEVELOPER-4071 - Remove the requirement for an ISBN for books

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.books.field_isbn.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.books.field_isbn.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: books
 label: ISBN
 description: 'The book''s ISBN number'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
@@ -541,7 +541,7 @@ display:
             external: false
             replace_spaces: false
             path_case: none
-            trim_whitespace: false
+            trim_whitespace: true
             alt: ''
             rel: ''
             link_class: ''
@@ -568,7 +568,7 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
+          hide_empty: true
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
@@ -1101,6 +1101,9 @@ display:
         type: data_field
         options:
           field_options:
+            nid:
+              alias: ''
+              raw_output: false
             title:
               alias: ''
               raw_output: true
@@ -1121,7 +1124,7 @@ display:
               raw_output: true
             field_isbn:
               alias: ''
-              raw_output: true
+              raw_output: false
             field_preview_url:
               alias: ''
               raw_output: true

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
@@ -191,11 +191,11 @@ function add_books_validations(array &$form, FormStateInterface $form_state)
     $isbn_validator = function (array &$element, FormStateInterface $form_state) {
         // Basic date comparison
         $isbn_number = $form_state->getValue('field_isbn')[0]['value'];
-        if (!is_numeric($isbn_number))
+        if (!is_numeric($isbn_number) && !empty($isbn_number))
         {
             $form_state->setError($element, t('The ISBN field must be a number!')); // Create the error
         }
-        if (strlen($isbn_number) != 13 && strlen($isbn_number) != 10)
+        if (strlen($isbn_number) != 13 && strlen($isbn_number) != 10 && !empty($isbn_number))
         {
             $form_state->setError($element, t('The ISBN field must be a valid 10 or 13 digit number!')); // Create the error
         }


### PR DESCRIPTION
This fixes the ISBN requirement. The export view should display an empty string if there is no ISBN available.