### PR TITLE
DEVELOPER-4053 Fixed WebpageSearchExclude meta tags

### DIFF
--- a/_layouts/get-started-item.html.slim
+++ b/_layouts/get-started-item.html.slim
@@ -14,6 +14,10 @@ issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
     -page.image = page.metadata.thumbnail
 - page.og_determiner = 'auto'
 - page.og_type = 'article'
+
+noscript
+  meta name="DCP:WebpageSearchExclude" content="true"
+
 .row
   h2.large-title#developer-materials Developer Materials
 .row itemscope="" itemtype="http://schema.org/Article"


### PR DESCRIPTION
Adds 'DCP:WebpageSearchExclude' meta tag to quickstart, ticket-monster, and demo pages. This should have been part of [DEVELOPER-4053](https://issues.jboss.org/browse/DEVELOPER-4053)


To review: 

1.  go to https://developers-pr.stage.redhat.com/pr/1869/export/quickstarts/portal/
2.  open the page source
3.  search for the meta tag by doing a keyword search of 'DCP:WebpageSearchExclude'