### PR TITLE
DEVELOPER-4079 Renamed Red Hat JBoss AMQ

### DIFF
--- a/_cucumber/features/help/forums/DEVELOPER-3057_forums.feature
+++ b/_cucumber/features/help/forums/DEVELOPER-3057_forums.feature
@@ -8,7 +8,7 @@ Feature: DEVELOPER-3057 - Forums: Product forums landing page
       | Red Hat JBoss Enterprise Application Platform |
       | Red Hat JBoss Web Server                      |
       | Red Hat Software Collections                  |
-      | Red Hat JBoss A-MQ                            |
+      | Red Hat JBoss AMQ                            |
       | Red Hat JBoss BRMS                            |
       | Red Hat JBoss BPM Suite                       |
       | Red Hat JBoss Data Virtualization             |
@@ -22,7 +22,7 @@ Feature: DEVELOPER-3057 - Forums: Product forums landing page
       | Red Hat JBoss Enterprise Application Platform |
       | Red Hat JBoss Web Server                      |
       | Red Hat Software Collections                  |
-      | Red Hat JBoss A-MQ                            |
+      | Red Hat JBoss AMQ                            |
       | Red Hat JBoss BRMS                            |
       | Red Hat JBoss BPM Suite                       |
       | Red Hat JBoss Data Virtualization             |

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -338,7 +338,7 @@
                             </div>
                             <div class="sub-nav-group">
                               <a class="heading" href="/products#integration_and_automation">Integration and Automation</a>
-                              <a class="hide-on-mobile" href="/products/amq/overview">Red Hat JBoss A-MQ</a>
+                              <a class="hide-on-mobile" href="/products/amq/overview">Red Hat JBoss AMQ</a>
                               <a class="hide-on-mobile" href="/products/datavirt/overview">Red Hat JBoss Data Virtualization</a>
                               <a class="hide-on-mobile" href="/products/fuse/overview">Red Hat JBoss Fuse</a>
                               <a class="hide-on-mobile" href="/products/bpmsuite/overview">Red Hat JBoss BPM Suite</a>

--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -162,7 +162,7 @@
                     a.hide-on-mobile(href="#{site.base_url}/products/softwarecollections/overview/") Red Hat Software Collections
                   .sub-nav-group
                     a.heading(href="#{site.base_url}/products/#integration_and_automation/") Integration and Automation
-                    a.hide-on-mobile(href="#{site.base_url}/products/amq/overview/") Red Hat JBoss A-MQ
+                    a.hide-on-mobile(href="#{site.base_url}/products/amq/overview/") Red Hat JBoss AMQ
                     a.hide-on-mobile(href="#{site.base_url}/products/datavirt/overview/") Red Hat JBoss Data Virtualization
                     a.hide-on-mobile(href="#{site.base_url}/products/fuse/overview/") Red Hat JBoss Fuse
                     a.hide-on-mobile(href="#{site.base_url}/products/bpmsuite/overview/") Red Hat JBoss BPM Suite

--- a/products/amq/_common/product.yml
+++ b/products/amq/_common/product.yml
@@ -1,5 +1,5 @@
-name: Red Hat JBoss A-MQ
-abbreviated_name: JBoss A-MQ
+name: Red Hat JBoss AMQ
+abbreviated_name: JBoss AMQ
 current_version: 6.2.0
 documentation_path: Red_Hat_JBoss_A-MQ
 product_category: application-development


### PR DESCRIPTION
[DEVELOPER-4079](https://issues.jboss.org/browse/DEVELOPER-4079)

Took the '-' out of the name of the Red Hat JBoss AMQ product.

This should have been done in 2 places:

- 'Technology' menu drop-down under the INTEGRATION AND AUTOMATION section.
- downloads page in /downloads/
