### PR TITLE
DEVELOPER-4095 No more 404/error for Fuse Overview

### DIFF
--- a/_docker/drupal/drupal-filesystem/db-migrations/20170518195752_fuse_overview_fix.php
+++ b/_docker/drupal/drupal-filesystem/db-migrations/20170518195752_fuse_overview_fix.php
@@ -26,6 +26,11 @@ class FuseOverviewFix extends AbstractMigration
     $table = $this->table('node__field_product_pages');
     $table->insert($fuse_overview_row);
     $table->saveData();
+
+    // Apparently we need to do the same in this table
+    $table = $this->table('node_revision__field_product_pages');
+    $table->insert($fuse_overview_row);
+    $table->saveData();
   }
 
   /**
@@ -33,6 +38,7 @@ class FuseOverviewFix extends AbstractMigration
    */
   public function down() {
     $this->execute('DELETE FROM node__field_product_pages WHERE entity_id = 33945 AND revision_id = 14329315 AND delta = 8 AND langcode = "en"');
+    $this->execute('DELETE FROM node_revision__field_product_pages WHERE entity_id = 33945 AND revision_id = 14329315 AND delta = 8 AND langcode = "en"');
   }
 
 }

--- a/_docker/drupal/drupal-filesystem/db-migrations/20170518195752_fuse_overview_fix.php
+++ b/_docker/drupal/drupal-filesystem/db-migrations/20170518195752_fuse_overview_fix.php
@@ -1,0 +1,38 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class FuseOverviewFix extends AbstractMigration
+{
+  /**
+   * @inheritDoc
+   */
+  public function up() {
+    // INSERT INTO drupal.node__field_product_pages
+    // (bundle, deleted, entity_id, revision_id, langcode, delta,
+    //  field_product_pages_target_id, field_product_pages_target_revision_id)
+    // VALUES ('product', 0, 33945, 14329315, 'en', 8, 2075, 62205);
+    $fuse_overview_row = [
+      'bundle' => 'product',
+      'deleted' => 0,
+      'entity_id' => 33945,
+      'revision_id' => 14329315,
+      'langcode' => 'en',
+      'delta' => 8,
+      'field_product_pages_target_id' => 2075,
+      'field_product_pages_target_revision_id' => 62205
+    ];
+
+    $table = $this->table('node__field_product_pages');
+    $table->insert($fuse_overview_row);
+    $table->saveData();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function down() {
+    $this->execute('DELETE FROM node__field_product_pages WHERE entity_id = 33945 AND revision_id = 14329315 AND delta = 8 AND langcode = "en"');
+  }
+
+}


### PR DESCRIPTION
I'm attempting to "restore" the Overview page with this.

JIRA: https://issues.jboss.org/browse/DEVELOPER-4095

Hopefully, you don't need to flush the cache, but maybe it will be needed. You can test this by navigating to the Fuse Product Page and NOT receive a 404.