### PR TITLE
[DEVELOPER-4169] Fix broken Java Docker image

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -232,7 +232,7 @@ def build_base_docker_images(environment, system_exec)
   end
 
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/base:2.0.0).concat(build_args).concat(%w(./base)))
-  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/java:2.0.0).concat(build_args).concat(%w(./java)))
+  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/java:3.0.0).concat(build_args).concat(%w(./java)))
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/ruby:2.0.0).concat(build_args).concat(%w(./ruby)))
 end
 

--- a/_docker/java/Dockerfile
+++ b/_docker/java/Dockerfile
@@ -3,11 +3,8 @@ FROM developer.redhat.com/base:2.0.0
 ARG http_proxy
 ARG https_proxy
 
-ENV JAVA_VERSION 7u25
-ENV BUILD_VERSION b15
-
 # Install Java
-RUN curl --junk-session-cookies --insecure --location --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}-${BUILD_VERSION}/jdk-${JAVA_VERSION}-linux-x64.rpm" > /tmp/jdk-8-linux-x64.rpm && \
+RUN curl --junk-session-cookies --insecure --location --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm" > /tmp/jdk-8-linux-x64.rpm && \
     yum -y install /tmp/jdk-8-linux-x64.rpm && \
     alternatives --install /usr/bin/java jar /usr/java/latest/bin/java 200000 && \
     alternatives --install /usr/bin/javaws javaws /usr/java/latest/bin/javaws 200000 && \

--- a/_docker/searchisko/Dockerfile
+++ b/_docker/searchisko/Dockerfile
@@ -1,4 +1,4 @@
-FROM developer.redhat.com/java:2.0.0
+FROM developer.redhat.com/java:3.0.0
 
 RUN yum -y install mysql && \
     yum clean all

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -265,7 +265,7 @@ class TestControl < Minitest::Test
     system_exec = mock()
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 ./base))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:2.0.0 ./java))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 ./java))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.0.0 ./ruby))
 
     build_base_docker_images(environment, system_exec)
@@ -283,7 +283,7 @@ class TestControl < Minitest::Test
     system_exec = mock()
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./base))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./java))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./java))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./ruby))
 
     build_base_docker_images(environment, system_exec)


### PR DESCRIPTION
This PR updates the Dockerfile for the Java image used on the project to correctly install the latest JDK 8 update. We had to move from JDK 7 as Oracle has removed support for it unless you have a contract with them.

In this PR we:

1. Update the Java Dockerfile to install the latest JDK 8
2. Ensure that we tag the build of the Java image as version 3.0.0 to show things have changed
3. Update any dependent images to use the new Java image version (searchisko only really)
4. Update the tests to ensure we're building images as expected

For reviewers:

Verify that all docker images built as part of this build (the build not failing will ensure this is working.)


