### PR TITLE
DateFixVideoRESTExport - Date format is now UTC and ISO format

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
@@ -758,10 +758,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: datetime_default
+          type: datetime_custom
           settings:
-            timezone_override: ''
-            format_type: medium
+            timezone_override: UTC
+            date_format: Y-m-d
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1043,7 +1043,7 @@ display:
               raw_output: true
             field_video_publish_date:
               alias: ''
-              raw_output: true
+              raw_output: false
             nid:
               alias: ''
               raw_output: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
@@ -758,10 +758,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: datetime_default
+          type: datetime_custom
           settings:
-            timezone_override: ''
-            format_type: medium
+            timezone_override: UTC
+            date_format: Y-m-d
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1043,7 +1043,7 @@ display:
               raw_output: true
             field_video_publish_date:
               alias: ''
-              raw_output: true
+              raw_output: false
             nid:
               alias: ''
               raw_output: false


### PR DESCRIPTION
Updated the view for - https://issues.jboss.org/browse/DEVELOPER-3942

To test this: Visit http://stumpjumper.lab4.eng.bos.redhat.com:36894/drupal/videos/vimeo and http://stumpjumper.lab4.eng.bos.redhat.com:36894/drupal/videos/youtube and observe that 'field_video_publish_date' is now displaying in ISO format. This will be used for indexing the sys_created value in DCP.