### PR TITLE
[HOLD] DEVELOPER-4049 Move all topics under /topics URL

### DIFF
--- a/_cucumber/features/primary_nav/primary_nav.feature
+++ b/_cucumber/features/primary_nav/primary_nav.feature
@@ -59,15 +59,15 @@ Feature: Site navigation menu
     Given I am on the Home page
     When I click on the Topics menu item
     Then each Topics sub-menu item should contain a link to its retrospective page:
-      | name                    | href                    |
-      | Containers              | containers              |
-      | Mobile                  | mobile                  |
-      | DevOps                  | devops                  |
-      | Web and API Development | web-and-api-development |
-      | Enterprise Java         | enterprise-java         |
-      | .NET                    | dotnet                  |
-      | Internet of Things      | iot                     |
-      | Microservices           | microservices           |
+      | name                    | href                           |
+      | Containers              | topics/containers              |
+      | Mobile                  | topics/mobile                  |
+      | DevOps                  | topics/devops                  |
+      | Web and API Development | topics/web-and-api-development |
+      | Enterprise Java         | topics/enterprise-java         |
+      | .NET                    | topics/dotnet                  |
+      | Internet of Things      | topics/iot                     |
+      | Microservices           | topics/microservices           |
 
   @mobile
   Scenario: Tapping TOPICS from drop down menu on Mobile/Tablet should display additional topics

--- a/_cucumber/features/search/search.feature
+++ b/_cucumber/features/search/search.feature
@@ -197,14 +197,14 @@
 #    Then the related topic page for "<url>" should be the first result
 #
 #    Examples: of Red hat Topics
-#      | topic                   | url                     |
-#      | Containers              | containers              |
-#      | Mobile                  | mobile                  |
-#      | DevOps                  | devops                  |
-#      | Web and API Development | web-and-api-development |
-#      | Enterprise Java         | enterprise-java         |
-#      | .NET                    | dotnet                  |
-#      | Internet of Things      | iot                     |
+#      | topic                   | url                            |
+#      | Containers              | topics/containers              |
+#      | Mobile                  | topics/mobile                  |
+#      | DevOps                  | topics/devops                  |
+#      | Web and API Development | topics/web-and-api-development |
+#      | Enterprise Java         | topics/enterprise-java         |
+#      | .NET                    | topics/dotnet                  |
+#      | Internet of Things      | topics/iot                     |
 #
 #  Scenario: DEVELOPER-3078 - User searches on /search for 'red hat developers', the first result should be for https://developers.redhat.com/about.
 #    Given I am on the Home page

--- a/_cucumber/features/smoke_test/smoke_tests.feature
+++ b/_cucumber/features/smoke_test/smoke_tests.feature
@@ -22,14 +22,14 @@ Feature: Sanity checks of production
     Then the page should load within "6" seconds
 
     Examples: urls
-      | url                     |
-      | containers              |
-      | mobile                  |
-      | devops                  |
-      | web-and-api-development |
-      | enterprise-java         |
-      | dotnet                  |
-      | iot                     |
+      | url                            |
+      | topics/containers              |
+      | topics/mobile                  |
+      | topics/devops                  |
+      | topics/web-and-api-development |
+      | topics/enterprise-java         |
+      | topics/dotnet                  |
+      | topics/iot                     |
 
   Scenario Outline: Verify Production page load of Technologies
     Given I am on the Product Overview page for each <product id>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/solution/page--rhd-solution-overview.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/solution/page--rhd-solution-overview.html.twig
@@ -86,27 +86,27 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
             <li class="side-nav-toggle"><a href="#">More</a></li>
             {% if (valid_path("%s/overview"|format(solution_name_hyphen))) %}
                 <li class="{{ active_page_class('overview') }}">
-                    <a href="/{{ solution_name_hyphen }}/overview">Overview</a>
+                    <a href="/topics/{{ solution_name_hyphen }}/overview">Overview</a>
                 </li>
             {% endif %}
             {% if (valid_path("%s/adoption"|format(solution_name_hyphen))) %}
                 <li  class="{{ active_page_class('adoption') }}">
-                    <a href="/{{ solution_name_hyphen }}/adoption">Adoption</a>
+                    <a href="/topics/{{ solution_name_hyphen }}/adoption">Adoption</a>
                 </li>
             {% endif %}
             {% if (valid_path("%s/benefits"|format(solution_name_hyphen))) %}
                 <li  class="{{ active_page_class('benefits') }}">
-                    <a href="/{{ solution_name_hyphen }}/benefits">Benefits</a>
+                    <a href="/topics/{{ solution_name_hyphen }}/benefits">Benefits</a>
                 </li>
             {% endif %}
             {% if (valid_path("%s/learn"|format(solution_name_hyphen))) %}
                 <li  class="{{ active_page_class('learn') }}">
-                    <a href="/{{ solution_name_hyphen }}/learn">Learn</a>
+                    <a href="/topics/{{ solution_name_hyphen }}/learn">Learn</a>
                 </li>
             {% endif %}
             {% if (valid_path("%s/buzz"|format(solution_name_hyphen))) %}
                 <li  class="{{ active_page_class('buzz') }}">
-                    <a href="/{{ solution_name_hyphen }}/buzz">Buzz</a>
+                    <a href="/topics/{{ solution_name_hyphen }}/buzz">Buzz</a>
                 </li>
             {% endif %}
         </ul>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -130,16 +130,12 @@
             pageType = primary;
             contentType = subs.length > 0 ? subs[0] : '';
             break;
-          case 'containers':
-          case 'devops':
-          case 'enterprise-java':
-          case 'iot':
-          case 'microservices':
-          case 'mobile':
-          case 'web-and-api-development':
-          case 'dotnet':
-            pageType = 'topic';
-            contentType = primary;
+          case 'topics':
+            pageType = primary;
+            if(subs.length > 0) {
+              pageType = pageType.replace(/s$/,'');
+              contentType = subs[0];
+            }
             break;
           case 'resources':
           case 'search':
@@ -333,14 +329,14 @@
                     <li class="has-sub-nav">
                         <a href="#" class="sub-nav-topics">Topics<i class="fa fa-angle-down "></i></a>
                         <div class="sub-nav" id="sub-nav-topics">
-                            <a href="/containers">Containers</a>
-                            <a href="/devops">DevOps</a>
-                            <a href="/enterprise-java">Enterprise Java</a>
-                            <a href="/iot">Internet of Things</a>
-                            <a href="/microservices">Microservices</a>
-                            <a href="/mobile">Mobile</a>
-                            <a href="/web-and-api-development">Web and API Development</a>
-                            <a href="/dotnet">.NET</a>
+                            <a href="/topics/containers">Containers</a>
+                            <a href="/topics/devops">DevOps</a>
+                            <a href="/topics/enterprise-java">Enterprise Java</a>
+                            <a href="/topics/iot">Internet of Things</a>
+                            <a href="/topics/microservices">Microservices</a>
+                            <a href="/topics/mobile">Mobile</a>
+                            <a href="/topics/web-and-api-development">Web and API Development</a>
+                            <a href="/topics/dotnet">.NET</a>
                         </div>
                     </li>
                     <li class="has-sub-nav">


### PR DESCRIPTION
PLEASE REVIEW BUT DO NOT MERGE -- If approved it will be merged once the redirects are ready to go live

[DEVELOPER-4049 - Move all topics under '/topics' URL](https://issues.jboss.org/browse/DEVELOPER-4049)

- Updated main navigation Topics' links from '/<topic-name>' to '/topics/<topic-name>'
- Updated Acceptance tests
- Updated links in page--rhd-solution-overview.html.twig
- Updated DTM code