### PR TITLE
[DEVELOPER-4212] Fixed image paths within _alerts.scss 

### DIFF
--- a/stylesheets/_alerts.scss
+++ b/stylesheets/_alerts.scss
@@ -8,7 +8,7 @@
     border-color: #87aac1;
 
     &.icon {
-      background-image: cdn("../images/design/icons/alerts/RHD_alerticon_info.png");
+      background-image: cdn("../images/icons/alerts/RHD_alerticon_info.png");
     }
   }
 
@@ -17,7 +17,7 @@
     border-color: #8db28a;
 
     &.icon {
-      background-image: cdn("../images/design/icons/alerts/RHD_alerticon_success.png");
+      background-image: cdn("../images/icons/alerts/RHD_alerticon_success.png");
     }
   }
 
@@ -26,7 +26,7 @@
     border-color: #deb142;
 
     &.icon {
-      background-image: cdn("../images/design/icons/alerts/RHD_alerticon_warning.png");
+      background-image: cdn("../images/icons/alerts/RHD_alerticon_warning.png");
     }
   }
 
@@ -35,7 +35,7 @@
     border-color: #d8aaab;  
 
     &.icon {
-      background-image: cdn("../images/design/icons/alerts/RHD_alerticon_error.png");
+      background-image: cdn("../images/icons/alerts/RHD_alerticon_error.png");
     }
   }
 


### PR DESCRIPTION
This PR fixes the image paths with _alerts.scss which is causing Awestruct to fail in staging and production.

Unfortunately I don't believe there is anyway to test this not in staging or prod as we don't use the cdn() function in PR environments.