### PR TITLE
DEVELOPER-3682 and 	DEVELOPER-3623 Fixed Topics' white cards

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/topic/node--topic.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/topic/node--topic.html.twig
@@ -124,16 +124,16 @@ other methods (such as node.delete) will result in an exception.
                     </div>
                     <div class="large-16 columns">
                         <div class="row">
-                            <div class="large-12 columns">
+                            <div class="large-12 white-card columns">
                                 {{ content.field_top_left_white_card }}
                             </div>
-                            <div class="large-12 columns">
+                            <div class="large-12 white-card columns">
                                 {{ content.field_top_right_white_card }}
                             </div>
-                            <div class="large-12 columns">
+                            <div class="large-12 white-card columns">
                                 {{ content.field_bottom_left_white_card }}
                             </div>
-                            <div class="large-12 columns">
+                            <div class="large-12 white-card columns">
                                 {{ content.field_bottom_right_white_card }}
                             </div>
                         </div>

--- a/javascripts/topics.js
+++ b/javascripts/topics.js
@@ -27,7 +27,7 @@ app.topics.fetch = function() {
         tagsString += (tags[i]).toLowerCase();
       }
     }
-  $.getJSON(app.dcp.url.search + '/developer_materials?tags_or_logic=true&newFirst=true&size15=true&tag=' + tagsString + '&&type=jbossdeveloper_vimeo&type=jbossdeveloper_youtube&type=jbossdeveloper_book&type=jbossorg_blog', function(data){
+  $.getJSON(app.dcp.url.search + '/developer_materials?tags_or_logic=true&newFirst=true&size15=true&type=jbossdeveloper_vimeo&type=jbossdeveloper_youtube&type=jbossdeveloper_book&type=jbossorg_blog&tag=' + tagsString, function(data){
     if(data.hits && data.hits.hits) {
       app.topics.render(data.hits.hits);
     }

--- a/javascripts/topics.js
+++ b/javascripts/topics.js
@@ -27,7 +27,7 @@ app.topics.fetch = function() {
         tagsString += (tags[i]).toLowerCase();
       }
     }
-  $.getJSON(app.dcp.url.search + '/developer_materials?tags_or_logic=true&newFirst=true&size25=true&tag=' + tagsString + '&&type=jbossdeveloper_vimeo&type=jbossdeveloper_youtube&type=jbossdeveloper_book&type=jbossorg_blog', function(data){
+  $.getJSON(app.dcp.url.search + '/developer_materials?tags_or_logic=true&newFirst=true&size15=true&tag=' + tagsString + '&&type=jbossdeveloper_vimeo&type=jbossdeveloper_youtube&type=jbossdeveloper_book&type=jbossorg_blog', function(data){
     if(data.hits && data.hits.hits) {
       app.topics.render(data.hits.hits);
     }

--- a/stylesheets/_topics.scss
+++ b/stylesheets/_topics.scss
@@ -262,6 +262,7 @@
       max-height: 43px;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
+      margin-bottom: 0;
     }
     .promo-tags .promo-tags-label, .promo-tags ul li, .promo-tags .field__item {
       color: #424242;
@@ -334,6 +335,18 @@
   }
 }
 .white-card .field, .white-card .field__item { display: block; }
+
+.white-card .field__item .text-formatted{
+  font-size: 1em;
+  line-height: 1.4;
+  color: #424242;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  max-height: 86px;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
 
 ul.topic-resources.topic-resources-list{
   list-style: none;

--- a/stylesheets/_topics.scss
+++ b/stylesheets/_topics.scss
@@ -333,11 +333,11 @@
     margin-bottom: 8px;
   }
 }
+.white-card .field, .white-card .field__item { display: block; }
+
 ul.topic-resources.topic-resources-list{
   list-style: none;
   padding-left: 10px;
-  max-height: 691px;
-  overflow: hidden;
   &.loading {
     background:cdn("../images/icons/ajax-loader.gif") center 80px no-repeat;
     min-height:250px;
@@ -392,11 +392,12 @@ ul.topic-resources.topic-resources-list{
       color: $white;
     }
   }
+  // Query returns 15 results, only 12 should be displayed
+  a:nth-of-type(1n+13) {display: none;}
 }
 
 @include tablet-portrait-and-down {
   ul.topic-resources.topic-resources-list {
-    max-height: 2266px;
     li {
       width: calc(50% - 34px);
     }
@@ -404,7 +405,6 @@ ul.topic-resources.topic-resources-list{
 }
 @include mobile-landscape-and-down {
   ul.topic-resources.topic-resources-list {
-    height: 3605px;
     li {
       width: calc(100% - 34px);
     }


### PR DESCRIPTION
HACKATHON

**1.  [DEVELOPER-3682 - Topic white cards are not fully loaded for mobile views](https://issues.jboss.org/browse/DEVELOPER-3682)**

What to check: 16 white cards should be loaded on desktop, tablet and mobile.

Also fixed width of 4 top white cards on tablet.


**2. [DEVELOPER-3623 - Topics page cards overflow and disrupt page structure](https://issues.jboss.org/browse/DEVELOPER-3623)**

In short, this was fixed (screenshot from /devops) : https://www.dropbox.com/s/81kihngprckaviq/Screenshot%202017-06-15%2011.22.54.png?dl=0
