### PR TITLE
DEVELOPER-4215 [PART 1] - Updated target_product export view

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
@@ -502,9 +502,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_entity_view
+          type: entity_reference_label
           settings:
-            view_mode: default
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
@@ -502,9 +502,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_label
+          type: entity_reference_entity_view
           settings:
-            link: true
+            view_mode: default
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
@@ -498,13 +498,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
+          hide_empty: true
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: true
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
This fixes the formatting of Drupal Target Products. These can be reviewed at:

http://stumpjumper.lab4.eng.bos.redhat.com:36906/drupal/videos/vimeo
http://stumpjumper.lab4.eng.bos.redhat.com:36906/drupal/videos/youtube

You will want to add a target product for both vimeo and youtube. Once you add the target product, observe that the string appears in the REST views above.

Part 2 will include the fixes to the JS. The target products are entity links, so the text is fixed and needs to be updated on the JS side.