### PR TITLE
Reduced Blinkr threads to 15 

### DIFF
--- a/_blinkr/config/pr_blinkr.yaml
+++ b/_blinkr/config/pr_blinkr.yaml
@@ -19,5 +19,5 @@ max_page_retys: 5
 max_retrys: 5
 browser: phantomjs
 ignore_fragments: true
-phantomjs_threads: 20
+phantomjs_threads: 15
 report: blinkr.html

--- a/_blinkr/config/stage_blinkr.yaml
+++ b/_blinkr/config/stage_blinkr.yaml
@@ -19,5 +19,5 @@ max_page_retys: 5
 max_retrys: 5
 browser: phantomjs
 ignore_fragments: true
-phantomjs_threads: 20
+phantomjs_threads: 15
 report: blinkr.html


### PR DESCRIPTION
Dropped Blinkr threads to 15 as using 20 may be causing intermittent timeouts.