### PR TITLE
DEVELOPER-4075 - Both Topics and Technologies menu items are active for dotnet

### DIFF
--- a/javascripts/nav-highlight.js
+++ b/javascripts/nav-highlight.js
@@ -11,7 +11,7 @@ jQuery(function() {
     var hLength = helpPages.length;
 
     while (tLength--) {
-        if (href.indexOf(topicPages[tLength]) !== -1) {
+        if (href.indexOf(topicPages[tLength]) !== -1 && href.indexOf('/products') < 0) {
             jQuery('.sub-nav-topics').addClass('active');
         }
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4075

When on dotnet topic and dotnet product pages only the correct navigation heading should be highlighted not both.