### PR TITLE
DEVELOPER-3978 - Modified the media browser/entity embed

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.node.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.node.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - node.type.article
     - node.type.books
+    - node.type.cheat_sheet
     - node.type.connectors
     - node.type.events
     - node.type.page
@@ -29,6 +30,7 @@ type_settings:
     - article
     - page
     - books
+    - cheat_sheet
     - connectors
     - events
     - rhd_microsite
@@ -39,7 +41,7 @@ type_settings:
     - topic
     - video_resource
   display_plugins:
-    - 'entity_reference:entity_reference_entity_id'
+    - 'view_mode:node.teaser'
   entity_browser: ''
   entity_browser_settings:
     display_review: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.media_browser.yml
@@ -13,40 +13,23 @@ name: media_browser
 label: 'Media browser'
 display: iframe
 display_configuration:
-  path: /media-browser
   width: 100%
   height: '640'
   link_text: 'Select entities'
   auto_open: true
+  path: /media-browser
 selection_display: no_display
 selection_display_configuration: {  }
-widget_selector: tabs
+widget_selector: single
 widget_selector_configuration: {  }
 widgets:
   134808d9-d854-4a0b-8699-d5eba006b8b7:
     settings:
-      submit_text: Place
       view: media
       view_display: entity_browser_1
+      submit_text: Place
       auto_select: false
     uuid: 134808d9-d854-4a0b-8699-d5eba006b8b7
     weight: -10
     label: Library
     id: view
-  8b142f33-59d1-47b1-9e3a-4ae85d8376fa:
-    settings:
-      submit_text: Place
-      form_mode: media_browser
-    uuid: 8b142f33-59d1-47b1-9e3a-4ae85d8376fa
-    weight: -8
-    label: 'Create embed'
-    id: embed_code
-  044d2af7-314b-4830-8b6d-64896bbb861e:
-    settings:
-      submit_text: Place
-      form_mode: media_browser
-      return_file: false
-    uuid: 044d2af7-314b-4830-8b6d-64896bbb861e
-    weight: -9
-    label: Upload
-    id: file_upload


### PR DESCRIPTION
Two of the three tabs in the media browser were not working, so I took
them out.

The node embed button was only embedding the node id, it is now
embedding the teaser view of the node.

I'm considering this as part of DEVELOPER-3978.

When you use the media library button you will only be able to place a media item. For Node embedding, you will now see the teaser form of the embedded node.