### PR TITLE
[DEVELOPER-4224] Prevent "Directory Exists" error on export cache roll-over

### DIFF
--- a/_docker/lib/export/httrack_export_strategy.rb
+++ b/_docker/lib/export/httrack_export_strategy.rb
@@ -93,11 +93,15 @@ class HttrackExportStrategy
   #
   def roll_over_export_cache(export_directory, drupal_host)
     @log.info('Rolling over httrack export cache as maximum cache updates has been reached...')
-    FileUtils.mv("#{export_directory}/hts-cache", "#{export_directory}/hts-cache.rolled") if Dir.exist?("#{export_directory}/hts-cache")
+    htscache_rolled = "#{export_directory}/hts-cache.rolled"
+    FileUtils.rm_rf(htscache_rolled) if Dir.exist?(htscache_rolled)
+    FileUtils.mv("#{export_directory}/hts-cache", htscache_rolled) if Dir.exist?("#{export_directory}/hts-cache")
     FileUtils.mv("#{export_directory}/index.html","#{export_directory}/index.html.rolled") if File.exist?("#{export_directory}/index.html")
 
     export = determine_export_directory_from_drupal_host(drupal_host)
-    FileUtils.mv("#{export_directory}/#{export}", "#{export_directory}/#{export}.rolled") if Dir.exist?("#{export_directory}/#{export}")
+    export_rolled = "#{export_directory}/#{export}.rolled"
+    FileUtils.rm_rf(export_rolled) if Dir.exist?(export_rolled)
+    FileUtils.mv("#{export_directory}/#{export}", export_rolled) if Dir.exist?("#{export_directory}/#{export}")
   end
 
   #


### PR DESCRIPTION
We are experiencing random failures of the cache roll-over logic for  the export process. It would appear that `FileUtils.mv` in Ruby 2.1.0 will randomly fail when `mv`-ing a directory if the target directory already exists.

As a work-around to this issue, we now first delete any previous cache roll-over if it exists. It is safe for us to delete the previous cache roll-over as when we do so, we are in the process of creating a new one.

Unfortunately this isn't an easy one to test, so perhaps just a code review on this PR.