### PR TITLE
Could not embed videos previously.

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
@@ -17,6 +17,7 @@ type_settings:
   bundles: {  }
   display_plugins:
     - 'entity_reference:media_thumbnail'
+    - 'view_mode:media.embedded'
   entity_browser: media_browser
   entity_browser_settings:
     display_review: false


### PR DESCRIPTION
You'll have to pick either an embedded or thumbnail view when you place
a media item.

To test this you'll want to try to embed a video using the media embed button. You'll see an option for how you want to embed the media.