### PR TITLE
DEVELOPER-4201 - New search 'Load More' has inconsistent behavior

### DIFF
--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -1264,9 +1264,9 @@ var RHDPSearchResults = (function (_super) {
             for (var i = 0; i < l; i++) {
                 this.addResult(hits[i]);
             }
-            if (l > 0 && this.last + 1 < results.hits.total) {
+            this.last = this.last + l;
+            if (l > 0 && this.last < results.hits.total) {
                 this.appendChild(this.loadMore);
-                this.last = this.last + l - 1;
             }
             else if (this.querySelector('.moreBtn')) {
                 this.removeChild(this.loadMore);

--- a/typescript/rhdp-search/rhdp-search-results.ts
+++ b/typescript/rhdp-search/rhdp-search-results.ts
@@ -85,9 +85,9 @@ class RHDPSearchResults extends HTMLElement {
             for( let i = 0; i < l; i++ ) {
                 this.addResult(hits[i]);
             }
-            if (l > 0 && this.last+1 < results.hits.total) {
+            this.last = this.last + l;
+            if (l > 0 && this.last < results.hits.total) {
                 this.appendChild(this.loadMore);
-                this.last = this.last + l - 1;
             } else if (this.querySelector('.moreBtn')) {
                 this.removeChild(this.loadMore);
             }


### PR DESCRIPTION
To test: Navigate to http://stumpjumper.lab4.eng.bos.redhat.com:36928/search?q=fuse and check the Demo or Quickstart filter. Load More should no longer load duplicates. For reference, you can check the main site with the same filters. You will notice that the last items are often duplicated.

https://issues.jboss.org/browse/DEVELOPER-4201