### PR TITLE
DEVELOPER-3994 - rel="canonical" absolute links

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/metatag.metatag_defaults.global.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/metatag.metatag_defaults.global.yml
@@ -7,6 +7,7 @@ _core:
 id: global
 label: Global
 tags:
+  canonical_url: '[current-page:url:absolute]'
   title: '[current-page:title] | [site:name]'
   og_type: '[node:content-type:machine-name]'
   twitter_cards_type: summary


### PR DESCRIPTION
Look at any page within Drupal and also some product pages. Make sure they are absolute links. Ideally the export process works just fine, however, they may not. This is just on the Drupal side for testing.