### PR TITLE
DEVELOPER-4252 - Broken download page layout in Firefox

### DIFF
--- a/javascripts/downloads.js
+++ b/javascripts/downloads.js
@@ -84,12 +84,11 @@ app.downloads.createDownloadLink = function(data) {
     return "";
   }
   // Pull the first one from the sorted array
-  var $downloadLink = $('<div class="large-8 columns">').addClass('download-link').append(
-    $('<a class="button">').attr('href', data[0].featuredArtifact.url).text(' Download').prepend(
-      $('<i>').addClass('fa fa-download')
-    ),
-    $('<div class="version-name">').text(data[0].name + ' ' + data[0].featuredArtifact.versionName)
-  );
+  var icn = '<i class="fa fa-download"></i>',
+      lnk = '<a class="button" href="'+data[0].featuredArtifact.url+'">'+icn+' Download</a>',
+      ver = '<div class="version-name">'+data[0].name + ' ' + data[0].featuredArtifact.versionName+'</div>',
+      $downloadLink = $('<div class="large-8 columns download-link">'+lnk+ver+'</div>');
+      
   return $downloadLink;
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4252

Specifically the /products/amq/download/ page layout in Firefox was all messed up.
Local environment isn't working at the moment, so putting this change in to give it a look in FF.