### PR TITLE
DEVELOPER-4258 - Remove Node Check

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
@@ -97,7 +97,7 @@ function rhd_preprocess_html(array &$variables) {
   // I've seen LOTS of errors in  Drupal WatchDog because this is being applied
   // everywhere. Pretty sure we only want this applied when we're viewing an
   // actual node.
-  if (!is_null($variables['node_type'])) {
+  // if (!is_null($variables['node_type'])) {
     $environment = \Drupal::config('redhat_developers')->get('environment');
     $dtm_code = \Drupal::config('redhat_developers')->get('dtm_code');
     $sentry_track = \Drupal::config('redhat_developers')->get('sentry_track');
@@ -126,7 +126,7 @@ function rhd_preprocess_html(array &$variables) {
       ];
       $variables['page']['#attached']['html_head'][] = [$referrer, 'referrer'];
     }
-  }
+  // }
 }
 
 function rhd_js_settings_alter(array &$settings, \Drupal\Core\Asset\AttachedAssetsInterface $assets) {


### PR DESCRIPTION
The node check removed the ddo object on some pages, causing script errors and disabling other scripts.