### PR TITLE
DEVELOPER-4296 Removed search exclude from Drupal articles

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--article.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--article.html.twig
@@ -97,6 +97,3 @@ other methods (such as node.delete) will result in an exception.
   </div>
 
 </div>
-<noscript>
-    <meta name="DCP:WebpageSearchExclude" content="true">
-</noscript>


### PR DESCRIPTION
[DEVELOPER-4296 - Subscription article not showing up in on-site search](https://issues.jboss.org/browse/DEVELOPER-4296)

Removed DCP:WebpageSearchExclude tag from Drupal article pages, so articles will not be excluded from the search results.

Easiest way to review this is to go to one of the Drupal articles like '/articles/using-java-rhel-7-openjdk-8/' look at the page source and do a quick search for **DCP:WebpageSearchExclude**. The tag should not be found.



Note: articles will not be shown in the search results until this is merged and the DCP re-indexes the pages.