### PR TITLE
[DEVELOPER-4134] Provide easier access to Drupal log files for error debugging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cucumber_failures.log
 rerun.txt
 
 _docker/environments/drupal-pull-request/rhd.settings.yml
+_docker/environments/drupal-dev/drupal-logs
 _docker/drupal/prod_db.sql.gz
 prod_db.sql.gz*
 

--- a/_docker/drupal/Dockerfile
+++ b/_docker/drupal/Dockerfile
@@ -26,7 +26,8 @@ RUN yum-config-manager --enable remi-php70; \
            php-opcache \
            php-xml \
            sendmail \
-           tar; \
+           tar \
+           logrotate \
     yum clean all
 
 RUN { \
@@ -44,6 +45,7 @@ RUN curl https://getcomposer.org/installer > composer-installer && php composer-
 
 WORKDIR /var/www/drupal
 COPY apache/drupal.conf /etc/httpd/conf.d/drupal.conf
+COPY logrotate/httpd /etc/logrotate.d/httpd
 
 # Run composer to install Drupal and required dependencies
 COPY drupal-filesystem/scripts/ScriptHandler.php /var/www/drupal/scripts/

--- a/_docker/drupal/logrotate/httpd
+++ b/_docker/drupal/logrotate/httpd
@@ -1,0 +1,14 @@
+"/var/log/httpd/error_log" "/var/log/httpd/access_log" {
+    rotate 5
+    daily
+    ifempty
+    missingok
+    size 100M
+    noolddir
+    create
+    sharedscripts
+    postrotate
+        /sbin/service httpd reload > /dev/null 2>/dev/null || true
+    endscript
+    nodateext
+}

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   drupal:
     build: ../../drupal
     ports:
-      - "8080:80"
+      - "80:80"
     links:
     # We give the drupalmysql the 'docker' alias so that the rhd.settings.php for database host name
     # work both within the container and also when running Drupal outside of Docker

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   drupal:
     build: ../../drupal
     ports:
-      - "80:80"
+      - "8080:80"
     links:
     # We give the drupalmysql the 'docker' alias so that the rhd.settings.php for database host name
     # work both within the container and also when running Drupal outside of Docker
@@ -48,6 +48,7 @@ services:
       - ../../drupal/drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
+      - ./drupal-logs:/var/log/httpd
     volumes_from:
       - drupal_data
 

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - /data/drupal/config:/var/www/drupal/web/config/active
+      - /data/drupal-logs:/var/log/httpd
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
     environment:

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - ../../../images:/var/www/drupal/web/images:ro
       - ../../../stylesheets/fonts:/var/www/drupal/web/fonts:ro
+      - /data/drupal-logs:/var/log/httpd
     volumes_from:
       - drupal_data
     environment:


### PR DESCRIPTION
This PR makes it easier to access the Drupal log files without having to access the Drupal container. Additionally log files survive each Drupal deployment meaning that errors can be tracked over time.

Within this PR we configure [logrotate](http://www.linuxcommand.org/man_pages/logrotate8.html) within the Drupal container and also provide a configuration to ensure that we correctly rotate the Apache log files. Additionally we provide bind-mounts at the Apache log file location for `drupal-dev`, `drupal-staging` and `drupal-production` environments. This helps to ensure log files survive container restarts.

The logrotate configuration ensures:

- log files are rotated each day
- log files are rotated if they reach 100M in size or greater
- log files are suffixed with .1, .2, .3 etc. as they are rotated
- a maximum of 5 days of log files are maintained
- Apache is gracefully restarted when a log file is rotated to ensure that logging file handlers work correctly

**For reviewers:**

Using the `drupal-dev` environment and this PR:

- `cd _docker`
- `./control.rb -b`
- `./control.rb -r`
- Wait for Drupal to start and then access the web interface on your local machine
- Note that `access_log` and `error_log` now exist in `_docker/environments/drupal-dev/drupal-logs`
- `docker exec drupaldev_drupal_1 /bin/sh -c "logrotate -f /etc/logrotate.conf"`
- Notice that there are now `access_log` and `error_log` and `access_log.1` and `error_log.1` in the `_docker/environments/drupal-dev/drupal-logs` directory
- Verify that you can still access the Drupal web interface on your local machine
- Verify that `git status` in the root directory of the project is clean