### PR TITLE
[DEVELOPER-4262] Delete all Docker images associated with a pull request

### DIFF
--- a/_docker/lib/pull_request/clean_up/pull_request_cleaner.rb
+++ b/_docker/lib/pull_request/clean_up/pull_request_cleaner.rb
@@ -43,6 +43,7 @@ class PullRequestCleaner
     pull_requests.each do |pull_request|
       @log.info("Cleaning up Docker resources for pull request '#{pull_request}'...")
       @process_runner.execute!("cd #{@docker_environment_directory} && docker-compose -p rhdpr#{pull_request} down -v --remove-orphans --rmi local")
+      @process_runner.execute!("docker rmi $(docker images --format \"{{.Repository}}\" rhdpr#{pull_request}*)")
     end
   end
 

--- a/_docker/tests/pull_request/clean_up/test_pull_request_cleaner.rb
+++ b/_docker/tests/pull_request/clean_up/test_pull_request_cleaner.rb
@@ -20,7 +20,9 @@ class TestPullRequestCleaner < MiniTest::Test
     @pull_requests.expects(:list_closed).returns(%w(1 2))
 
     @process_runner.expects(:execute!).with("cd #{@docker_directory} && docker-compose -p rhdpr1 down -v --remove-orphans --rmi local")
+    @process_runner.expects(:execute!).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr1*)')
     @process_runner.expects(:execute!).with("cd #{@docker_directory} && docker-compose -p rhdpr2 down -v --remove-orphans --rmi local")
+    @process_runner.expects(:execute!).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr2*)')
     @process_runner.expects(:execute!).with("rsync --partial --archive --checksum --compress --omit-dir-times --quiet --ignore-non-existing --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --delete #{@empty_dir}/ rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/1")
     @process_runner.expects(:execute!).with("rsync --partial --archive --checksum --compress --omit-dir-times --quiet --ignore-non-existing --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --delete #{@empty_dir}/ rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/2")
 


### PR DESCRIPTION
This PR updates very slightly the PR clean-up code to ensure that we delete all Docker images associated with a pull request.

**For Reviewers:**

There isn't really a good way to test this. Unit tests have been updated as part of the PR, so probably best just to perform a code review.