### PR TITLE
DPAL updates for dev DTM

### DIFF
--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -24,7 +24,7 @@ database:
   username: 'drupal'
   password: 'drupal'
   name: 'drupal'
-dtm_code: //dpal-itmarketing.itos.redhat.com/developers
+dtm_code: https://dpal-it-marketing.int.open.paas.redhat.com/?developers
 sentry_track: true
-sentry_script: 'https://cdn.ravenjs.com/3.12.1/raven.min.js'
+sentry_script: 'https://cdn.ravenjs.com/3.17.0/raven.min.js'
 sentry_code: 'https://cc00364690f241ffb2fcb39254d7f23f@sentry.io/115436'

--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -24,7 +24,7 @@ database:
   username: 'drupal'
   password: 'drupal'
   name: 'drupal'
-dtm_code: https://dpal-it-marketing.int.open.paas.redhat.com/?developers
+dtm_code: https://dpal-it-marketing.int.open.paas.redhat.com/developers
 sentry_track: true
 sentry_script: 'https://cdn.ravenjs.com/3.17.0/raven.min.js'
 sentry_code: 'https://cc00364690f241ffb2fcb39254d7f23f@sentry.io/115436'

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -19,9 +19,9 @@ database:
   username: 'drupal'
   password: 'drupal'
   name: 'drupal'
-dtm_code: 'https://dpal-itmarketing.itos.redhat.com/developers'
+dtm_code: 'https://dpal-it-marketing.int.open.paas.redhat.com/?developers'
 rhd_base_url: "stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>"
 rhd_final_base_url: "developers-pr.stage.redhat.com/pr/<%= ENV['ghprbPullId'] %>/export"
 sentry_track: true
-sentry_script: 'https://cdn.ravenjs.com/3.15.0/raven.min.js'
+sentry_script: 'https://cdn.ravenjs.com/3.17.0/raven.min.js'
 sentry_code: 'https://cc00364690f241ffb2fcb39254d7f23f@sentry.io/115436'

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -19,7 +19,7 @@ database:
   username: 'drupal'
   password: 'drupal'
   name: 'drupal'
-dtm_code: 'https://dpal-it-marketing.int.open.paas.redhat.com/?developers'
+dtm_code: 'https://dpal-it-marketing.int.open.paas.redhat.com/developers'
 rhd_base_url: "stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>"
 rhd_final_base_url: "developers-pr.stage.redhat.com/pr/<%= ENV['ghprbPullId'] %>/export"
 sentry_track: true


### PR DESCRIPTION
Maintenance updates for dev environments to point to the correct URL for DTM staging since ITOS is being shut down.

@LightGuard or @paulrobinson this will need to be done on staging too. If you would change the Staging config's DTM code to point to: https://dpal-it-marketing.int.open.paas.redhat.com/developers

Also, if you want to update the Sentry config to point to version 3.17.0 this is probably a good time to do that too.