### PR TITLE
DEVELOPER-4241 strips HTML tags from search input

### DIFF
--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -577,7 +577,12 @@ var RHDPSearchBox = (function (_super) {
     }
     Object.defineProperty(RHDPSearchBox.prototype, "term", {
         get: function () {
-            return this._term;
+            if ((this._term === null) || (this._term === '')) {
+                return this._term;
+            }
+            else {
+                return this._term.replace(/(<([^>]+)>)/ig, "");
+            }
         },
         set: function (val) {
             if (this._term === val)

--- a/typescript/rhdp-search/rhdp-search-box.ts
+++ b/typescript/rhdp-search/rhdp-search-box.ts
@@ -2,7 +2,11 @@ class RHDPSearchBox extends HTMLElement {
     _term = '';
 
     get term() {
-        return this._term;
+        if ((this._term===null) || (this._term==='')) {
+           return this._term;
+        } else {
+           return this._term.replace(/(<([^>]+)>)/ig,'');
+        }
     }
     set term(val) {
         if (this._term === val) return;


### PR DESCRIPTION
[DEVELOPER-4241 - Important security issue present on developers.redhat.com](https://issues.jboss.org/browse/DEVELOPER-4241)


To review:
1. go to /search/
2. insert this malicious content into Search field:
`<script>alert('test');</script>`

The term searched should be _alert('test');_ without the html _tags_

