### PR TITLE
[DEVELOPER-4262] Ignore failure of docker rmi command if there are no images to remove

### DIFF
--- a/_docker/lib/process_runner.rb
+++ b/_docker/lib/process_runner.rb
@@ -14,16 +14,20 @@ class ProcessRunner
 
   end
 
-  #
-  # Initialise the instance. If verbose is true, then full output of stdout and stderr is printed to the
-  # console
-  #
   def initialize
     @log = DefaultLogger.logger
   end
 
   def determine_process_status(cmd, execution_result)
-    raise ProcessFailedError.new("Execution of command '#{cmd}' failed.") unless execution_result
+    raise(ProcessFailedError, "Execution of command '#{cmd}' failed.") unless execution_result
+  end
+
+  #
+  # Execute the command, returning the result of the Kernel.system call
+  #
+  def execute(cmd)
+    @log.info("Executing command '#{cmd}'...")
+    Kernel.system(cmd)
   end
 
   #
@@ -32,11 +36,20 @@ class ProcessRunner
   # @throws - ProcessFailedError if the command exits with a non-zero status
   #
   def execute!(cmd)
-    @log.info("Executing command '#{cmd}'...")
-    execution_result = Kernel.system(cmd)
+    execution_result = execute(cmd)
     determine_process_status(cmd, execution_result)
   end
 
-  private :determine_process_status
+  #
+  # Executes the given command, returning true if the command succeeded (i.e. returned a zero exit code), or false
+  # otherwise
+  #
+  def execute?(cmd)
+    execution_result = execute(cmd)
+    !execution_result.nil? && execution_result
+  end
+
+
+  private :determine_process_status, :execute
 
 end

--- a/_docker/lib/pull_request/clean_up/pull_request_cleaner.rb
+++ b/_docker/lib/pull_request/clean_up/pull_request_cleaner.rb
@@ -43,7 +43,12 @@ class PullRequestCleaner
     pull_requests.each do |pull_request|
       @log.info("Cleaning up Docker resources for pull request '#{pull_request}'...")
       @process_runner.execute!("cd #{@docker_environment_directory} && docker-compose -p rhdpr#{pull_request} down -v --remove-orphans --rmi local")
-      @process_runner.execute!("docker rmi $(docker images --format \"{{.Repository}}\" rhdpr#{pull_request}*)")
+
+      #
+      # This command cleans-up any remaining Docker images. It will fail if there are no images to be cleaned, so we
+      # use execute? to ignore that failure as it doesn't matter.
+      #
+      @process_runner.execute?("docker rmi $(docker images --format \"{{.Repository}}\" rhdpr#{pull_request}*)")
     end
   end
 

--- a/_docker/tests/pull_request/clean_up/test_pull_request_cleaner.rb
+++ b/_docker/tests/pull_request/clean_up/test_pull_request_cleaner.rb
@@ -20,9 +20,9 @@ class TestPullRequestCleaner < MiniTest::Test
     @pull_requests.expects(:list_closed).returns(%w(1 2))
 
     @process_runner.expects(:execute!).with("cd #{@docker_directory} && docker-compose -p rhdpr1 down -v --remove-orphans --rmi local")
-    @process_runner.expects(:execute!).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr1*)')
+    @process_runner.expects(:execute?).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr1*)')
     @process_runner.expects(:execute!).with("cd #{@docker_directory} && docker-compose -p rhdpr2 down -v --remove-orphans --rmi local")
-    @process_runner.expects(:execute!).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr2*)')
+    @process_runner.expects(:execute?).with('docker rmi $(docker images --format "{{.Repository}}" rhdpr2*)')
     @process_runner.expects(:execute!).with("rsync --partial --archive --checksum --compress --omit-dir-times --quiet --ignore-non-existing --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --delete #{@empty_dir}/ rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/1")
     @process_runner.expects(:execute!).with("rsync --partial --archive --checksum --compress --omit-dir-times --quiet --ignore-non-existing --chmod=Dg+sx,ug+rw,Do+rx,o+r --protocol=28 --delete #{@empty_dir}/ rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg/pr/2")
 

--- a/_docker/tests/test_process_runner.rb
+++ b/_docker/tests/test_process_runner.rb
@@ -4,22 +4,38 @@ require_relative 'test_helper'
 
 class TestProcessRunner < Minitest::Test
 
+  def setup
+    @process_runner = ProcessRunner.new
+  end
+
   def test_successful_execution
     Kernel.expects(:system).with('pwd').returns(true)
-    process_runner = ProcessRunner.new
-    process_runner.execute!('pwd')
+    @process_runner.execute!('pwd')
   end
 
   def test_failed_execution_raises_exception
 
     Kernel.expects(:system).with('pwd').returns(false)
-    process_runner = ProcessRunner.new
-
-
     assert_raises(ProcessRunner::ProcessFailedError) {
-      process_runner.execute!('pwd')
+      @process_runner.execute!('pwd')
     }
 
   end
+
+  def test_successful_execution_returns_true
+    Kernel.expects(:system).with('pwd').returns(true)
+    assert(@process_runner.execute?('pwd'))
+  end
+
+  def test_failed_execution_returns_false_when_exit_code_is_nil
+    Kernel.expects(:system).with('pwd').returns(nil)
+    refute(@process_runner.execute?('pwd'))
+  end
+
+  def test_failed_execution_returns_false
+    Kernel.expects(:system).with('pwd').returns(false)
+    refute(@process_runner.execute?('pwd'))
+  end
+
 
 end


### PR DESCRIPTION
The previous PR for this issue introduced a regression whereby the clean-up job now fails if there are no Docker images to be removed. This PR fixes that regression.

**For Reviewers:**

- Another code review please