### PR TITLE
DEVELOPER-4245 Added loading image in search results

### DIFF
--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -523,6 +523,7 @@ var RHDPSearchApp = (function (_super) {
             this.results.more = e.detail.results;
         }
         this.count.count = e.detail.results.hits.total;
+        this.results.classList.remove('loading');
     };
     RHDPSearchApp.prototype.toggleModal = function (e) {
         this.querySelector('rhdp-search-app')['modal'].toggle = e.detail.toggle;
@@ -1289,6 +1290,11 @@ var RHDPSearchQuery = (function (_super) {
     RHDPSearchQuery.prototype.search = function (term) {
         var _this = this;
         this.term = term;
+        var searchResults = document.getElementsByTagName('rhdp-search-results')[0];
+        while (searchResults.firstChild && this.from === 0) {
+            searchResults.removeChild(searchResults.firstChild);
+        }
+        searchResults.setAttribute('class', 'loading');
         fetch((_a = ["", "", "", "", "", "", "", "", ""], _a.raw = ["", "", "", "", "", "", "", "", ""], this.urlTemplate(_a, this.url, this.term, this.from, this.limit, this.sort, this.productString, this.tagString, this.sysTypeString)))
             .then(function (resp) { return resp.json(); })
             .then(function (data) {

--- a/stylesheets/_searchapp.scss
+++ b/stylesheets/_searchapp.scss
@@ -8,6 +8,10 @@ rhdp-search-app {
 
     h2 { margin-top: 30px; }
 
+    .loading {
+        background:url("https://developers.redhat.com/images/icons/ajax-loader.gif") center 80px no-repeat;
+        min-height:250px;
+    }
 }
 
 rhdp-search-box {

--- a/typescript/rhdp-search/rhdp-search-app.ts
+++ b/typescript/rhdp-search/rhdp-search-app.ts
@@ -176,6 +176,7 @@ class RHDPSearchApp extends HTMLElement {
         }
         
         this.count.count = e.detail.results.hits.total;
+        this.results.classList.remove('loading');
     }
 
     toggleModal(e) {

--- a/typescript/rhdp-search/rhdp-search-query.ts
+++ b/typescript/rhdp-search/rhdp-search-query.ts
@@ -187,6 +187,14 @@ class RHDPSearchQuery extends HTMLElement {
 
     search(term) {
         this.term = term;
+
+        var searchResults = document.getElementsByTagName( 'rhdp-search-results' )[0];
+
+        while(searchResults.firstChild && this.from === 0){
+            searchResults.removeChild(searchResults.firstChild);
+        }
+
+        searchResults.setAttribute( 'class', 'loading' );
         
         fetch(this.urlTemplate`${this.url}${this.term}${this.from}${this.limit}${this.sort}${this.productString}${this.tagString}${this.sysTypeString}`)
         .then((resp) => resp.json())


### PR DESCRIPTION
[DEVELOPER-4245 - Add loading image while waiting for results](https://issues.jboss.org/browse/DEVELOPER-4245)

Requirements:
The amount of time to return search results can be multiple seconds. There should be an image showing that loading is happening so users do not get confused.

To test:

1.  Search for 'eap'
2. Loading gif should show while results load
3. Click on the 'books' filter (this one takes the longest so you see the gif for a bit