### PR TITLE
DEVELOPER-4346 Forums page - Added read-only notice to all products

### DIFF
--- a/forums.html.slim
+++ b/forums.html.slim
@@ -37,10 +37,15 @@ title: Forums | Red Hat Developers
                     a(href="/articles/how-to-post-tag-question-stack-overflow/") relevant tags
                     | .
                 - else
-                  h4
+                  h4.read-only
                     a(id="#{product.id}" href="#{forum_url}" target="_blank" rel="noopener noreferrer")
                       = product.forum_title || product.name
                       i.fa.fa-comments-o
+                  p
+                    | PLEASE NOTE: This forum will become read-only on September 1st, 2017. You can now post your #{product.name} developer questions to StackOverflow using the 
+                    a(href="/articles/how-to-post-tag-question-stack-overflow/") relevant tags
+                    | .
+                    a(href="#{site.base_url}/forumstostackoverflow/" target="_blank")  Why are we doing this?
               .large-12.columns
                 - forum_desc = product.forum_desc ? "<div class=\"paragraph\"><p>#{product.forum_desc}</p></div>" : null
                 = forum_desc || product['index'].desc


### PR DESCRIPTION
[DEVELOPER-4346 - Forums - Add read-only notice to all products](https://issues.jboss.org/browse/DEVELOPER-4346)

All of the product forums (except "cdk","developertoolset","devstudio") listed in /forums/ should have the following message under the product name:

> “PLEASE NOTE: This forum will become read-only on September 1st, 2017. You can now post your Red Hat <product> developer questions to StackOverflow using the <relevant tags link>. Why are we doing this? <link to artcile>.”
