### PR TITLE
DEVELOPER-4341 - Remove links to non-existent mobile download

### DIFF
--- a/downloads.html.slim
+++ b/downloads.html.slim
@@ -2,6 +2,7 @@
 layout: base
 title: Downloads | Red Hat Developers
 description: Discover the product downloads available from Red Hat, and locate the upstream projects they are based on.
+ignore_export: true
 ---
 
 .hero.hero-wide.hero-downloads


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4341

Stops the Downloads page from being Awestruct-built. Content update will happen once this is in production.