### PR TITLE
DEVELOPER-4259 - Incorrect date for cheat sheets in search results

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
@@ -565,9 +565,9 @@ display:
           click_sort_column: value
           type: timestamp
           settings:
-            date_format: medium
-            custom_date_format: ''
-            timezone: ''
+            date_format: custom
+            custom_date_format: Y-m-d
+            timezone: UTC
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -736,7 +736,7 @@ display:
               raw_output: true
             created:
               alias: ''
-              raw_output: true
+              raw_output: false
             path:
               alias: ''
               raw_output: false


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4259

To review: Visit http://stumpjumper.lab4.eng.bos.redhat.com:36978/drupal/cheat-sheets and notice that "created" now shows the appropriate date.

DCP will pick up the and display it as yyyy-mm-dd.