### PR TITLE
[DO NOT MERGE] [DEVELOPER-4008] Migrate to new host for Jenkins slaves

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -102,7 +102,7 @@ profiles:
 
   drupal_pull_request:
     <<: *docker
-    base_url: http://stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>/
+    base_url: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>/
     dcp_base_url: https://dcp.stage.jboss.org/
     dcp_base_protocol_relative_url: https://dcp.stage.jboss.org/
     push_to_searchisko: false

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - github_status_api_token
       - github_status_context=drupal-site
       - github_status_repo=redhat-developer/developers.redhat.com
-      - github_status_target_url=http://stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}
+      - github_status_target_url=http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}
       - github_status_sha1=${ghprbActualCommit}
       - ghprbPullId
       - google_api_key
@@ -81,7 +81,7 @@ services:
    volumes:
     - ../../../:/home/jenkins_developer/developer.redhat.com
     - ../../awestruct/overlay/ssh-key:/home/jenkins_developer/.ssh
-   entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'ruby _docker/lib/export/export.rb stumpjumper.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}'"
+   entrypoint: "ruby _docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb 'ruby _docker/lib/export/export.rb rhdp-jenkins-slave.lab4.eng.bos.redhat.com:${DRUPAL_HOST_PORT}'"
    network_mode: "host"
    environment:
     - github_status_enabled=true

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -6,7 +6,7 @@ keycloak:
   accountUrl: 'https://developers.stage.redhat.com/auth/realms/rhd/account/'
   authUrl: 'https://developers.stage.redhat.com/auth/'
 drupal:
-  host: stumpjumper.lab4.eng.bos.redhat.com
+  host: rhdp-jenkins-slave.lab4.eng.bos.redhat.com
   port: "<%=ENV['DRUPAL_HOST_PORT']%>"
 searchisko:
   protocol: 'https'
@@ -20,7 +20,7 @@ database:
   password: 'drupal'
   name: 'drupal'
 dtm_code: 'https://dpal-it-marketing.int.open.paas.redhat.com/developers'
-rhd_base_url: "stumpjumper.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>"
+rhd_base_url: "rhdp-jenkins-slave.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>"
 rhd_final_base_url: "developers-pr.stage.redhat.com/pr/<%= ENV['ghprbPullId'] %>/export"
 sentry_track: true
 sentry_script: 'https://cdn.ravenjs.com/3.17.0/raven.min.js'


### PR DESCRIPTION
This PR updates the requisite configuration files to ensure that we can migrate to the new host running the Jenkins slaves.