### PR TITLE
[DO NOT MERGE] [DEVELOPER-4373] Fix access.redhat.com documentation links in export

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -109,8 +109,9 @@ class ExportHtmlPostProcessor
 
       hide_drupal = remove_drupal_host_identifying_markup?(html_doc)
       rewrite_forms = rewrite_form_target_urls?(drupal_host, html_doc, html_file)
+      rewrite_access_links = rewrite_access_redhat_com_links(html_doc, html_file)
 
-      if hide_drupal || rewrite_forms
+      if hide_drupal || rewrite_forms || rewrite_access_links
         @log.info("DOM in file '#{html_file}' has been modified, writing new file to disk.")
         File.open(html_file,'w') do | file |
           file.write(html_doc.to_html)
@@ -165,6 +166,27 @@ class ExportHtmlPostProcessor
     forms_to_modify.size > 0
 
   end
+
+  #
+  # access.redhat.com links are broken when we strip off the trailing "/index.html" to fix the site export structure.
+  # This fixes that.
+  #
+  def rewrite_access_redhat_com_links(html_doc, html_file_name)
+    links_to_modify = html_doc.css("body a[href*=\"access.redhat.com\"]")
+    modified = false
+    links_to_modify.each do | link |
+      if link.attributes['href'].value.include?('documentation')
+        new_href = "#{link.attributes['href']}/index.html"
+        @log.info("\tModifying documentation link #{link.attributes['href'].to_s} to #{new_href}")
+        link.attributes['href'].value = new_href
+        modified = true
+      end
+    end
+
+    modified
+
+  end
+
 
   private :final_base_url_location, :locate_index_link_href, :rewrite_links_for_trailing_slash_url_structure, :rewrite_form_target_urls?, :relocate_index_html, :remove_drupal_host_identifying_markup?, :post_process_html_dom
 

--- a/_docker/tests/export/test_export_form_rewrite/index/index.html
+++ b/_docker/tests/export/test_export_form_rewrite/index/index.html
@@ -25,5 +25,8 @@
 
 <a id="angular-link" ng-href="{{blah.test[0]}}">Testing Angular Link</a>
 
+<a id="documentation" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide">Red Hat Software Collections</a>
+<a id="not-documentation" href="https://access.redhat.com/security">Security</a>
+
 </body>
 </html>

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -55,6 +55,14 @@ class TestExportHtmlPostProcessor < MiniTest::Test
     assert(File.exist?("#{@export_directory}/nested/nested-file.txt"))
   end
 
+  def test_should_rewrite_access_redhat_com_documentation_links
+    @export_post_processor.post_process_html_export('docker', @export_directory)
+
+    index_html = get_html_document("#{@export_directory}/index.html")
+    assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html',get_link_href(index_html, 'documentation'))
+    assert_equal('https://access.redhat.com/security', get_link_href(index_html, 'not-documentation'))
+  end
+
 
   def test_should_rewrite_index_html_link
 


### PR DESCRIPTION
This PR updates the export process to re-add '/index.html' to any access.redhat.com links containing the word 'documentation'. The current incarnation of the export process strips away the '/index.html' from these links, resulting in a 404.

**For Reviewers**

* See the following spreadsheet: https://docs.google.com/spreadsheets/d/1JD0X_12JI3uikscSd6hKDiZYyyzjFekzbVbqjUcxCNU/edit?ts=59946a34#gid=0
* Check all access.redhat.com links that were previously 404'ing, now work as expected.