### PR TITLE
DEVELOPER-4351 - Add RHAMT to Stack Overflow Dropdown

### DIFF
--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -127,7 +127,8 @@ app.products = {
   "rhel": {"upstream": ["fedora"],"stackoverflow": ["rhel","rhel5","rhel6","rhel7"], "buzz_tags": ["rhel","rhel7"]},
   "softwarecollections": {"upstream": null,"stackoverflow": ["rhel","rhel5","rhel6","rhel7"], "buzz_tags": ["software collections"]},
   "webserver": {"upstream": ["tomcat","httpd","mod_cluster"],"stackoverflow": ["jboss-web"], "buzz_tags": ["webserver"]},
-  "rhmap": {"upstream": ["feedhenry"],"stackoverflow": ["redhat-rhamt"],"buzz_tags": ["mobileplatform","mobile"]}
+  "rhmap": {"upstream": ["feedhenry"],"stackoverflow": ["redhat-rhamt"],"buzz_tags": ["mobileplatform","mobile"]},
+  "rhamt": {"upstream": [""],"stackoverflow": ["rhamt"],"buzz_tags": [""]}
 };
 
 /*

--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -128,7 +128,7 @@ app.products = {
   "softwarecollections": {"upstream": null,"stackoverflow": ["rhel","rhel5","rhel6","rhel7"], "buzz_tags": ["software collections"]},
   "webserver": {"upstream": ["tomcat","httpd","mod_cluster"],"stackoverflow": ["jboss-web"], "buzz_tags": ["webserver"]},
   "rhmap": {"upstream": ["feedhenry"],"stackoverflow": ["redhat-rhamt"],"buzz_tags": ["mobileplatform","mobile"]},
-  "rhamt": {"upstream": [""],"stackoverflow": ["rhamt"],"buzz_tags": [""]}
+  "rhamt": {"upstream": null,"stackoverflow": ["rhamt"],"buzz_tags": ["windup","rhamt"]}
 };
 
 /*

--- a/products/rhamt/_common/product.yml
+++ b/products/rhamt/_common/product.yml
@@ -5,3 +5,5 @@ ignore_forums: true
 index:
   desc: |
     Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.
+stackoverflow_tags:
+  - rhamt

--- a/stack-overflow.html.slim
+++ b/stack-overflow.html.slim
@@ -46,6 +46,7 @@ div(ng-app="search")
                   option(value="cdk") Red Hat Developer Container Kit
                   option(value="devstudio") Red Hat JBoss Developer Studio
                   option(value="rhmap") Red Hat Mobile Application Platform
+                  option(value="rhamt") Red Hat Application Migration Toolkit
             .large-10.columns
               .sorting.so-sorting
                 p(ng-if="totalCount > 10")


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4351

To test: Visit http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:36996/stack-overflow#!q=rhamt and make sure that the stackoverflow data populates.

Also, you will need to check the help page: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:36996/products/rhamt/help (this will only work on the Drupal site--not the export) I had to update the product field in Drupal in order for the help page to pull in the SO data. We will likely need to do this in production as well. From what I can tell, this shouldn't cause any problems since there is no forum page.



