### PR TITLE
[DEVELOPER-4373] Fixed addition of double trailing slash to access.redhat.com doc links

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -184,7 +184,8 @@ class ExportHtmlPostProcessor
         # Only perform processing on the link if it doesn't already link to a .html file
         #
         unless uri.path.to_s.end_with?('.html')
-          uri.path = "#{uri.path.to_s}/index.html"
+          new_path = uri.path.end_with?('/') ? "#{uri.path}index.html" : "#{uri.path}/index.html"
+          uri.path = new_path
           new_href = uri.to_s
           @log.info("\tModifying documentation link #{link.attributes['href'].to_s} to #{new_href}")
           link.attributes['href'].value = new_href

--- a/_docker/tests/export/test_export_form_rewrite/index/index.html
+++ b/_docker/tests/export/test_export_form_rewrite/index/index.html
@@ -26,6 +26,7 @@
 <a id="angular-link" ng-href="{{blah.test[0]}}">Testing Angular Link</a>
 
 <a id="documentation" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide">Red Hat Software Collections</a>
+<a id="documentation-trailing-slash" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/">Red Hat Software Collections</a>
 <a id="documentation-with-html" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/mypage.html"></a>
 <a id="documentation-with-anchor" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide#foobar"></a>
 <a id="not-documentation" href="https://access.redhat.com/security">Security</a>

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -60,6 +60,7 @@ class TestExportHtmlPostProcessor < MiniTest::Test
 
     index_html = get_html_document("#{@export_directory}/index.html")
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html',get_link_href(index_html, 'documentation'))
+    assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html',get_link_href(index_html, 'documentation-trailing-slash'))
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html#foobar',get_link_href(index_html, 'documentation-with-anchor'))
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/mypage.html', get_link_href(index_html, 'documentation-with-html'))
     assert_equal('https://access.redhat.com/security', get_link_href(index_html, 'not-documentation'))


### PR DESCRIPTION
This PR fixes an issue added in #2002 that was merged too early. The previous version of the code added a double trailing slash to the access.redhat.com documentation links resulting in blinkr reporting broken links.

This attempts to rectify this.

**For reviewers**

- Check the blinkr report for 404 on access.redhat.com doc links
- Verify if any of them are being caused by missing the trailing `index.html` suffix