### PR TITLE
No longer pushing any get started items to drupal

### DIFF
--- a/_layouts/get-started-item.html.slim
+++ b/_layouts/get-started-item.html.slim
@@ -2,7 +2,7 @@
 layout: base
 status: green
 issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
-
+ignore_export: true
 ---
 - if page.metadata
   - page.title = page.metadata[:title]


### PR DESCRIPTION
I don't see the point in doing this any longer, things don't change, and if we're going to fix broken links, I'd rather do it in Drupal and not worry about things being overwritten.