### PR TITLE
DEVELOPER-4348 Added exclude from search option to promotion content type

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - entity_browser.browser.media_browser
     - field.field.node.promotion_page.body
     - field.field.node.promotion_page.field_call_to_action_link
+    - field.field.node.promotion_page.field_exclude_from_search
     - field.field.node.promotion_page.field_mail_to_link
     - field.field.node.promotion_page.field_media_asset
     - field.field.node.promotion_page.field_promotion_page_left_image
@@ -45,6 +46,13 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_exclude_from_search:
+    weight: 26
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_mail_to_link:
     weight: 10

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.promotion_page.body
     - field.field.node.promotion_page.field_call_to_action_link
+    - field.field.node.promotion_page.field_exclude_from_search
     - field.field.node.promotion_page.field_mail_to_link
     - field.field.node.promotion_page.field_media_asset
     - field.field.node.promotion_page.field_promotion_page_left_image
@@ -37,6 +38,16 @@ content:
       target: '0'
     third_party_settings: {  }
     type: link
+    region: content
+  field_exclude_from_search:
+    weight: 106
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_mail_to_link:
     weight: 104

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.promotion_page.field_exclude_from_search.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.promotion_page.field_exclude_from_search.yml
@@ -1,0 +1,23 @@
+uuid: e34e5bcc-ca35-4375-af83-9246f5739fb2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_search
+    - node.type.promotion_page
+id: node.promotion_page.field_exclude_from_search
+field_name: field_exclude_from_search
+entity_type: node
+bundle: promotion_page
+label: 'Exclude from search'
+description: 'Select to exclude this page from the Search page results.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'True'
+  off_label: 'False'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_exclude_from_search.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_exclude_from_search.yml
@@ -1,0 +1,18 @@
+uuid: 8b852816-f238-4957-ae06-859657d3d677
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_exclude_from_search
+field_name: field_exclude_from_search
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/promotion-page/node--promotion-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/promotion-page/node--promotion-page.html.twig
@@ -65,6 +65,12 @@ other methods (such as node.delete) will result in an exception.
 * @ingroup themeable
 */
 #}
+{% if node.field_exclude_from_search.value == '1' %}
+  <noscript>
+    <meta name="DCP:WebpageSearchExclude" content="true">
+  </noscript>
+{% endif %}
+
 <article{{ attributes.addClass('microsite-tmpl') }}>
   <div{{ content_attributes.addClass(['row', 'promotion-header']) }}>
     <div class="small-24 columns show-for-small-only">


### PR DESCRIPTION
[DEVELOPER-4348 Exclude the Cheat Sheet promotion pages from on-site search](https://issues.jboss.org/browse/DEVELOPER-4348)

Added a checkbox to Promotions content type to exclude a page from the search page results.

If the checkbox is checked, a meta tag `<meta name="DCP:WebpageSearchExclude" content="true">` is added to the page, which the dcp indexer picks up and adds a flag to exclude that page from the search results.

To review: 

1. Go to edit the following page (or any of the promotion pages): /promotions/docker-cheatsheet/
2. Check the 'Exclude from search' checkbox at the bottom and save the changes
3. In the saved page, look at the source code and do a quick search for _DCP:WebpageSearchExclude_
If the checkbox was checked, you should be able to find the meta tag in the source code, if it was not checked the meta tag should not be there.

Once this PR is merged I'll check the checkboxes in the pages that need to be excluded, and after the dcp indexer runs, those pages should no longer show in the search page results.