### PR TITLE
Updated /middleware referrer alert link

### DIFF
--- a/javascripts/referrer.js
+++ b/javascripts/referrer.js
@@ -1,7 +1,7 @@
 (function() {
   $(function() { 
     var referrerHTML = $('<section id="referral-alert"><div class="row alert-box alert-xl"><div class="row"><div class="icon"></div><div class="alert-content"><h3>You have been redirected from JBoss.org to Red Hat Developers.</h3><p>It'+"'"+'s true — JBoss Developer and Red Hat Developers are one and the same, and you can find all the great stuff you were looking for right here on <a href="https://developers.redhat.com/">developers.redhat.com.</a></p><a class="close"></a></div></div></div></section>');
-    var jbdReferrerHTML = $('<section id="referral-alert"><div class="row alert-box alert-xl"><div class="row"><div class="icon"></div><div class="alert-content"><h3>Welcome jboss.org members!</h3><p>It'+"'"+'s true — JBoss Developer and Red Hat Developer Program are joining forces. You can find all the great Middleware information that you were looking for right here on developers.redhat.com.<a href="https://developers.redhat.com/blog"> Read more about this on our blog.</a></p></div></div></div></section>');
+    var jbdReferrerHTML = $('<section id="referral-alert"><div class="row alert-box alert-xl"><div class="row"><div class="icon"></div><div class="alert-content"><h3>Welcome jboss.org members!</h3><p>It'+"'"+'s true — JBoss Developer and Red Hat Developer Program are joining forces. You can find all the great Middleware information that you were looking for right here on developers.redhat.com.<a href="https://developer.jboss.org/blogs/mark.little/2017/08/31/we-are-moving?_sscc=t"> Read more about this on our blog.</a></p></div></div></div></section>');
     if(isReferrer('jbd')) {
       switch (getPrimaryCategory()) {
         case 'products': // before class .mobile.product-header


### PR DESCRIPTION
Per Mark Little's request, the link in the /middleware referrer alert link was updated to: https://developer.jboss.org/blogs/mark.little/2017/08/31/we-are-moving?_sscc=t


To review, go [here](https://developers-pr.stage.redhat.com/pr/2019/export/middleware/?referrer=jbd) and check that the link in the alert goes to the link above.