### PR TITLE
Upgrade Ruby for builds to pass

### DIFF
--- a/_docker/awestruct/Dockerfile
+++ b/_docker/awestruct/Dockerfile
@@ -1,4 +1,4 @@
-FROM developer.redhat.com/ruby:2.0.0
+FROM developer.redhat.com/ruby:2.3.0
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -233,7 +233,7 @@ def build_base_docker_images(environment, system_exec)
 
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/base:2.0.0).concat(build_args).concat(%w(./base)))
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/java:3.0.0).concat(build_args).concat(%w(./java)))
-  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/ruby:2.0.0).concat(build_args).concat(%w(./ruby)))
+  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/ruby:2.3.0).concat(build_args).concat(%w(./ruby)))
 end
 
 #

--- a/_docker/ruby/Dockerfile
+++ b/_docker/ruby/Dockerfile
@@ -32,20 +32,20 @@ RUN yum install -y  \
 WORKDIR /tmp
 
 # Install ruby and rubygems
-RUN wget http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz \
-    && tar -xzf /tmp/ruby-2.1.2.tar.gz \
-    && cd ruby-2.1.2/ \
+RUN wget https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.gz \
+    && tar -xzf /tmp/ruby-2.3.4.tar.gz \
+    && cd ruby-2.3.4/ \
     && ./configure --disable-install-doc \
     && make \
     && make install \
     && rm -rf /tmp/*
 
-RUN wget http://production.cf.rubygems.org/rubygems/rubygems-2.4.1.tgz \
-    && tar -zxf /tmp/rubygems-2.4.1.tgz \
-    && cd /tmp/rubygems-2.4.1 \
+RUN wget https://rubygems.org/rubygems/rubygems-2.6.13.tgz \
+    && tar -zxf /tmp/rubygems-2.6.13.tgz \
+    && cd /tmp/rubygems-2.6.13 \
     && ruby setup.rb \
     && rm -rf /tmp/* \
     && echo "gem: --no-ri --no-rdoc" > ~/.gemrc
 
-RUN gem install bundler --version 1.11.2 --no-rdoc --no-ri
+RUN gem install bundler --version 1.15.4 --no-rdoc --no-ri
 

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -266,7 +266,7 @@ class TestControl < Minitest::Test
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 ./base))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 ./java))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.0.0 ./ruby))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.3.0 ./ruby))
 
     build_base_docker_images(environment, system_exec)
 
@@ -284,7 +284,7 @@ class TestControl < Minitest::Test
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./base))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./java))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./ruby))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.3.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./ruby))
 
     build_base_docker_images(environment, system_exec)
 


### PR DESCRIPTION
The version of Ruby we're using is old enough that some of the gems we use will no longer install, as you can see in our build environments with tests failing.
I'm bumping the version of Ruby here to allow those gems to install.
Using the latest version of Ruby 2.3 and rubygems. This should better mirror our other environments as well.