### PR TITLE
DEVELOPER-4243 JavaOne 2017 - Fixes width of tables

### DIFF
--- a/stylesheets/_javaone.scss
+++ b/stylesheets/_javaone.scss
@@ -163,6 +163,13 @@
       }
     }
   }
+  table {
+    th:nth-of-type(1) { width: 10%; }
+    th:nth-of-type(2) { width: 15%; }
+    th:nth-of-type(3) { width: 50%; }
+    th:nth-of-type(4) { width: 15%; }
+    th:nth-of-type(5) { width: 10%; }
+  }
 }
 
 #javaone-registration iframe {


### PR DESCRIPTION
Some tables were just added to the content of /events/javaone/2017. This CSS fixes the table's widths.