### PR TITLE
DEVELOPER-4243 JavaOne 2017 Fixes width of tables

### DIFF
--- a/stylesheets/_javaone.scss
+++ b/stylesheets/_javaone.scss
@@ -164,6 +164,7 @@
     }
   }
   table {
+    width: 100%;
     th:nth-of-type(1) { width: 10%; }
     th:nth-of-type(2) { width: 15%; }
     th:nth-of-type(3) { width: 50%; }


### PR DESCRIPTION
This minor fix makes the tables in [this page](https://developers-pr.stage.redhat.com/pr/2036/export/events/javaone/2017/) be full width.