### PR TITLE
DEVELOPER-4216 Search - Added notification for end of results

### DIFF
--- a/_tests/e2e/features/search/search.feature
+++ b/_tests/e2e/features/search/search.feature
@@ -170,3 +170,15 @@ Feature: Search Page
     When I search for "Java"
     Then the results should be updated and contain "Java"
 
+  Scenario: User sees the end of the returned search results
+    Given I am on the "Search" page
+    When I search for "qwert"
+    And there are 10 or less results available
+    Then I should not see a Load More link
+    And I should see some text that says "- End of Results -"
+
+  Scenario: User gets to the end of the returned resultset, but there are more results
+    Given I am on the "Search" page
+    And I search for "Containers"
+    Then I should see a Load More link
+    And I should not see some text that says "- End of Results -"

--- a/_tests/e2e/features/step_definitions/search_steps.js
+++ b/_tests/e2e/features/step_definitions/search_steps.js
@@ -77,6 +77,15 @@ module.exports = function () {
         }
     });
 
+    this.Then(/^I (should|should not) see some text that says "- End of Results -"$/, function (negate) {
+        searchPage.waitForResultsLoaded();
+        if (negate === 'should') {
+            expect(searchPage.endOfResults().isVisible(), 'End of Results text was not visible').to.be.true;
+        } else {
+            expect(searchPage.endOfResults().isVisible(), 'End of Results text was visible').to.be.false;
+        }
+    });
+
     this.Then(/^I should see a message "([^"]*)"$/, function (resultMsg) {
         let resultMessage = searchPage.resultCount();
         expect(resultMessage, `${resultMsg} was not displayed`).to.equal(resultMsg)

--- a/_tests/e2e/support/pages/search.page.js
+++ b/_tests/e2e/support/pages/search.page.js
@@ -41,6 +41,8 @@ class SearchPage extends mixin(BasePage, NavigationBar) {
 
     loadMoreButton () { return $('.moreBtn'); }
 
+    endOfResults () { return $('.end-of-results'); }
+
     searchResults () { return $$('.result'); }
 
     searchResult (i) { return $(`//rhdp-search-result[${i}]/div`); }

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -1798,6 +1798,7 @@ var RHDPSearchResults = (function (_super) {
         var _this = _super.call(this) || this;
         _this._last = 0;
         _this.loadMore = document.createElement('a');
+        _this.endOfResults = document.createElement('p');
         return _this;
     }
     Object.defineProperty(RHDPSearchResults.prototype, "results", {
@@ -1841,6 +1842,8 @@ var RHDPSearchResults = (function (_super) {
     });
     RHDPSearchResults.prototype.connectedCallback = function () {
         var _this = this;
+        this.endOfResults.className = 'end-of-results';
+        this.endOfResults.innerText = '- End of Results -';
         this.loadMore.className = 'moreBtn hide';
         this.loadMore.innerText = 'Load More';
         this.loadMore.addEventListener('click', function (e) {
@@ -1887,6 +1890,9 @@ var RHDPSearchResults = (function (_super) {
                 this.addResult(hits[i]);
             }
             this.last = this.last + l;
+            if (this.last >= results.hits.total) {
+                this.appendChild(this.endOfResults);
+            }
             if (l > 0 && this.last < results.hits.total) {
                 this.appendChild(this.loadMore);
             }

--- a/stylesheets/_searchapp.scss
+++ b/stylesheets/_searchapp.scss
@@ -428,6 +428,10 @@ rhdp-search-results {
             color: $white;
         }
     }
+    .end-of-results {
+        text-align: center;
+        color: $grey-5;
+    }
 
     @media only screen and (max-width: 768px) {
         display: block;

--- a/typescript/rhdp-search/rhdp-search-results.ts
+++ b/typescript/rhdp-search/rhdp-search-results.ts
@@ -33,12 +33,15 @@ class RHDPSearchResults extends HTMLElement {
     }
 
     loadMore = document.createElement('a');
+    endOfResults = document.createElement('p');
 
     constructor() {
         super();
     }
 
     connectedCallback() {
+        this.endOfResults.className = 'end-of-results';
+        this.endOfResults.innerText = '- End of Results -';
         this.loadMore.className = 'moreBtn hide';
         this.loadMore.innerText = 'Load More';
 
@@ -86,6 +89,9 @@ class RHDPSearchResults extends HTMLElement {
                 this.addResult(hits[i]);
             }
             this.last = this.last + l;
+            if (this.last >= results.hits.total) {
+                this.appendChild(this.endOfResults);
+            }
             if (l > 0 && this.last < results.hits.total) {
                 this.appendChild(this.loadMore);
             } else if (this.querySelector('.moreBtn')) {


### PR DESCRIPTION
[DEVELOPER-4216 - Notification for end of results](https://issues.jboss.org/browse/DEVELOPER-4216)

**Requirements**
As a user, I should be able to see some sort of notification when I reach the end of the results. Currently, the LOAD MORE disappears which should still occur in addition to the notification message.

**Review Process**
1. Go to: /search/?q=faq
2. Filter by CONTENT TYPE of "Article" - You should see about 12 as the results found number
3. Click LOAD MORE
4. Verify a notification message displays at the end of the results to indicate there are no more results.