### PR TITLE
DEVELOPER-4432 - Create 'Try it now' feature for EAP Kitchensink quickstart

### DIFF
--- a/_tests/unit/rhdp-tryitnow_spec.js
+++ b/_tests/unit/rhdp-tryitnow_spec.js
@@ -1,0 +1,42 @@
+"use strict";
+//rhdp-tryitnow component testing
+
+describe('Try-it now feature', function() {
+    var wc;
+    beforeEach(function() {
+        wc = document.createElement('rhdp-tryitnow');
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function() {
+        beforeEach(function() {
+            document.body.insertBefore(wc, document.body.firstChild);
+        });
+
+        it('should update all attributes', function() {
+            var title = "test title",
+            subtitle = "test subtitle",
+            buttonID = "test button id",
+            buttonText = "test button text",
+            buttonLink = "http://www.buttonlink.com",
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+            expect(wc.getAttribute('title')).toEqual(title);
+            expect(wc.getAttribute('subtitle')).toEqual(subtitle);
+            expect(wc.getAttribute('buttonID')).toEqual(buttonID);
+            expect(wc.getAttribute('buttonText')).toEqual(buttonText);
+            expect(wc.getAttribute('buttonLink')).toEqual(buttonLink);
+            expect(wc.getAttribute('icon')).toEqual(icon);
+        });
+    });
+
+});

--- a/_tests/unit/rhdp-tryitnow_spec.js
+++ b/_tests/unit/rhdp-tryitnow_spec.js
@@ -32,9 +32,9 @@ describe('Try-it now feature', function() {
             wc.icon = icon;
             expect(wc.getAttribute('title')).toEqual(title);
             expect(wc.getAttribute('subtitle')).toEqual(subtitle);
-            expect(wc.getAttribute('buttonID')).toEqual(buttonID);
-            expect(wc.getAttribute('buttonText')).toEqual(buttonText);
-            expect(wc.getAttribute('buttonLink')).toEqual(buttonLink);
+            expect(wc.getAttribute('button-id')).toEqual(buttonID);
+            expect(wc.getAttribute('button-text')).toEqual(buttonText);
+            expect(wc.getAttribute('button-link')).toEqual(buttonLink);
             expect(wc.getAttribute('icon')).toEqual(icon);
         });
     });
@@ -216,6 +216,34 @@ describe('Try-it now feature', function() {
             expect(wc.querySelector('a').id).toEqual(buttonID);
         });
 
+        describe('and dynamic value edits', function() {
+
+            it('should update the heading with appropriate text', function() {
+                wc.title = "Updated Title";
+                expect(wc.querySelector('h4').innerText).toEqual("Updated Title");
+            });
+
+            it('should update the subheading with appropriate text', function() {
+                expect(wc.querySelector('h5').innerText).toEqual(subtitle);
+            });
+
+            it('should update the button with appropriate text', function() {
+                expect(wc.querySelector('a.button').innerText).toEqual(buttonText);
+            });
+
+            it('should update the button with corresponding link', function() {
+                expect(wc.querySelector('a.button').href).toEqual(buttonLink);
+            });
+
+            it('should update the icon with a src link', function() {
+                expect(wc.querySelector('img').src).toEqual(icon);
+            });
+
+            it('should update the ID on the related button', function() {
+                expect(wc.querySelector('a').id).toEqual(buttonID);
+            });
+
+        });
     })
 
 });

--- a/_tests/unit/rhdp-tryitnow_spec.js
+++ b/_tests/unit/rhdp-tryitnow_spec.js
@@ -224,23 +224,28 @@ describe('Try-it now feature', function() {
             });
 
             it('should update the subheading with appropriate text', function() {
-                expect(wc.querySelector('h5').innerText).toEqual(subtitle);
+                wc.subtitle = "Updated subtitle";
+                expect(wc.querySelector('h5').innerText).toEqual("Updated subtitle");
             });
 
             it('should update the button with appropriate text', function() {
-                expect(wc.querySelector('a.button').innerText).toEqual(buttonText);
+                wc.buttonText = "Updated button text";
+                expect(wc.querySelector('a').innerText).toEqual("Updated button text");
             });
 
             it('should update the button with corresponding link', function() {
-                expect(wc.querySelector('a.button').href).toEqual(buttonLink);
+                wc.buttonLink = "http://www.newbuttonlink.com/";
+                expect(wc.querySelector('a.button').href).toEqual("http://www.newbuttonlink.com/");
             });
 
             it('should update the icon with a src link', function() {
-                expect(wc.querySelector('img').src).toEqual(icon);
+                wc.icon = "http://www.newiconlink.com/";
+                expect(wc.querySelector('img').src).toEqual("http://www.newiconlink.com/");
             });
 
-            it('should update the ID on the related button', function() {
-                expect(wc.querySelector('a').id).toEqual(buttonID);
+            it('should update the button ID on the related button', function() {
+                wc.buttonID = "new button id";
+                expect(wc.querySelector('a').id).toEqual("new button id");
             });
 
         });

--- a/_tests/unit/rhdp-tryitnow_spec.js
+++ b/_tests/unit/rhdp-tryitnow_spec.js
@@ -39,4 +39,183 @@ describe('Try-it now feature', function() {
         });
     });
 
+    describe('with incomplete properties', function() {
+        var title,
+            subtitle,
+            buttonID,
+            buttonText,
+            buttonLink,
+            icon;
+
+        beforeEach(function() {
+            title = "";
+            subtitle = "";
+            buttonID = "";
+            buttonText = "";
+            buttonLink = "";
+            icon = "";
+        });
+
+        it('should be blank with no values', function() {
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+
+        it('should not be blank with only buttonID missing', function() {
+            title = "test title";
+            subtitle = "test subtitle";
+            buttonText = "test button text";
+            buttonLink = "http://www.buttonlink.com";
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toBeGreaterThan(0);
+        });
+
+        it('should be blank with title missing', function() {
+            subtitle = "test subtitle";
+            buttonText = "test button text";
+            buttonLink = "http://www.buttonlink.com";
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+        it('should be blank with subtitle missing', function() {
+            title = "test title";
+            buttonText = "test button text";
+            buttonLink = "http://www.buttonlink.com";
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+        it('should be blank with buttonText missing', function() {
+            title = "test title";
+            subtitle = "test subtitle";
+            buttonLink = "http://www.buttonlink.com";
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+        it('should be blank with buttonLink missing', function() {
+            title = "test title";
+            subtitle = "test subtitle";
+            buttonText = "test button text";
+            icon = "http://www.imageicon.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+        it('should be blank with icon missing', function() {
+            title = "test title";
+            subtitle = "test subtitle";
+            buttonText = "test button text";
+            buttonLink = "http://www.buttonlink.com";
+
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.innerHTML.length).toEqual(0);
+        });
+
+    })
+
+    describe('with valid data', function() {
+        var title = "test title",
+            subtitle = "test subtitle",
+            buttonID = "test button id",
+            buttonText = "test button text",
+            buttonLink = "http://www.buttonlink.com/",
+            icon = "http://www.imageicon.com/";
+
+        beforeEach(function() {
+            wc.title = title;
+            wc.subtitle = subtitle;
+            wc.buttonID = buttonID;
+            wc.buttonText = buttonText;
+            wc.buttonLink = buttonLink;
+            wc.icon = icon;
+
+            document.body.insertBefore(wc, document.body.firstChild);
+        });
+
+        it('should not be blank', function() {
+            expect(wc.innerHTML.length).toBeGreaterThan(0);
+        });
+
+        it('should have a heading with appropriate text', function() {
+            expect(wc.querySelector('h4').innerText).toEqual(title);
+        });
+
+        it('should have a subheading with appropriate text', function() {
+            expect(wc.querySelector('h5').innerText).toEqual(subtitle);
+        });
+
+        it('should have button with appropriate text', function() {
+            expect(wc.querySelector('a.button').innerText).toEqual(buttonText);
+        });
+
+        it('should have a button with corresponding link', function() {
+            expect(wc.querySelector('a.button').href).toEqual(buttonLink);
+        });
+
+        it('should have an icon with a src link', function() {
+            expect(wc.querySelector('img').src).toEqual(icon);
+        });
+
+        it('should have an ID on the related button', function() {
+            expect(wc.querySelector('a').id).toEqual(buttonID);
+        });
+
+    })
+
 });

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -12,6 +12,12 @@ var RHDPTryItNow = (function (_super) {
     __extends(RHDPTryItNow, _super);
     function RHDPTryItNow() {
         var _this = _super.call(this) || this;
+        _this._title = '';
+        _this._subtitle = '';
+        _this._buttonID = '';
+        _this._buttonText = '';
+        _this._buttonLink = '';
+        _this._icon = '';
         _this.template = function (strings, title, subtitle, buttonLink, icon, buttonText, buttonID) {
             return "<section> <div class=\"row\"> <img src=\"" + icon + "\"> <span> <h4>" + title + "</h4> <h5>" + subtitle + "</h5> </span> <a " + (buttonID ? "id=\"" + buttonID + "\" " : '') + " href=\"" + buttonLink + "\" class=\"button medium-cta white\">" + buttonText + "</a> </div></section>";
         };
@@ -26,6 +32,7 @@ var RHDPTryItNow = (function (_super) {
                 return;
             this._title = value;
             this.setAttribute('title', this._title);
+            this.querySelector('h4') ? this.querySelector('h4').innerText = this._title : '';
         },
         enumerable: true,
         configurable: true
@@ -39,6 +46,7 @@ var RHDPTryItNow = (function (_super) {
                 return;
             this._subtitle = value;
             this.setAttribute('subtitle', this._subtitle);
+            this.querySelector('h5') ? this.querySelector('h5').innerText = this._subtitle : '';
         },
         enumerable: true,
         configurable: true
@@ -51,7 +59,8 @@ var RHDPTryItNow = (function (_super) {
             if (this._buttonID === value)
                 return;
             this._buttonID = value;
-            this.setAttribute('buttonID', this._buttonID);
+            this.setAttribute('button-id', this._buttonID);
+            this.querySelector('a') ? this.querySelector('a').id = this._buttonID : '';
         },
         enumerable: true,
         configurable: true
@@ -64,7 +73,8 @@ var RHDPTryItNow = (function (_super) {
             if (this._buttonLink === value)
                 return;
             this._buttonLink = value;
-            this.setAttribute('buttonLink', this._buttonLink);
+            this.setAttribute('button-link', this._buttonLink);
+            this.querySelector('a') ? this.querySelector('a').href = this._buttonLink : '';
         },
         enumerable: true,
         configurable: true
@@ -78,6 +88,7 @@ var RHDPTryItNow = (function (_super) {
                 return;
             this._icon = value;
             this.setAttribute('icon', this._icon);
+            this.querySelector('img') ? this.querySelector('img').src = this._buttonLink : '';
         },
         enumerable: true,
         configurable: true
@@ -90,7 +101,8 @@ var RHDPTryItNow = (function (_super) {
             if (this._buttonText === value)
                 return;
             this._buttonText = value;
-            this.setAttribute('buttonText', this._buttonText);
+            this.setAttribute('button-text', this._buttonText);
+            this.querySelector('a') ? this.querySelector('a').innerText = this._buttonLink : '';
         },
         enumerable: true,
         configurable: true

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -88,7 +88,7 @@ var RHDPTryItNow = (function (_super) {
                 return;
             this._icon = value;
             this.setAttribute('icon', this._icon);
-            this.querySelector('img') ? this.querySelector('img').src = this._buttonLink : '';
+            this.querySelector('img') ? this.querySelector('img').src = this._icon : '';
         },
         enumerable: true,
         configurable: true
@@ -102,7 +102,7 @@ var RHDPTryItNow = (function (_super) {
                 return;
             this._buttonText = value;
             this.setAttribute('button-text', this._buttonText);
-            this.querySelector('a') ? this.querySelector('a').innerText = this._buttonLink : '';
+            this.querySelector('a') ? this.querySelector('a').innerText = this._buttonText : '';
         },
         enumerable: true,
         configurable: true

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -13,7 +13,7 @@ var RHDPTryItNow = (function (_super) {
     function RHDPTryItNow() {
         var _this = _super.call(this) || this;
         _this.template = function (strings, title, subtitle, buttonLink, icon, buttonText, buttonID) {
-            return " <div class=\"row\"> <img src=\"" + icon + "\"> <h4>" + title + "</h4> <h5>" + subtitle + "</h5> <a " + (buttonID ? "id=\"" + buttonID + "\"" : '') + "href=\"" + buttonLink + "\" class=\"button medium-cta white\">" + buttonText + "</a> </div>";
+            return "<section> <div class=\"row\"> <img src=\"" + icon + "\"> <span> <h4>" + title + "</h4> <h5>" + subtitle + "</h5> </span> <a " + (buttonID ? "id=\"" + buttonID + "\" " : '') + " href=\"" + buttonLink + "\" class=\"button medium-cta white\">" + buttonText + "</a> </div></section>";
         };
         return _this;
     }

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -1,3 +1,120 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var RHDPTryItNow = (function (_super) {
+    __extends(RHDPTryItNow, _super);
+    function RHDPTryItNow() {
+        var _this = _super.call(this) || this;
+        _this.template = function (strings, title, subtitle, buttonLink, icon, buttonText, buttonID) {
+            return " <div class=\"row\"> <img src=\"" + icon + "\"> <h4>" + title + "</h4> <h5>" + subtitle + "</h5> <a " + (buttonID ? "id=\"" + buttonID + "\"" : '') + "href=\"" + buttonLink + "\" class=\"button medium-cta white\">" + buttonText + "</a> </div>";
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPTryItNow.prototype, "title", {
+        get: function () {
+            return this._title;
+        },
+        set: function (value) {
+            if (this._title === value)
+                return;
+            this._title = value;
+            this.setAttribute('title', this._title);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPTryItNow.prototype, "subtitle", {
+        get: function () {
+            return this._subtitle;
+        },
+        set: function (value) {
+            if (this._subtitle === value)
+                return;
+            this._subtitle = value;
+            this.setAttribute('subtitle', this._subtitle);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPTryItNow.prototype, "buttonID", {
+        get: function () {
+            return this._buttonID;
+        },
+        set: function (value) {
+            if (this._buttonID === value)
+                return;
+            this._buttonID = value;
+            this.setAttribute('buttonID', this._buttonID);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPTryItNow.prototype, "buttonLink", {
+        get: function () {
+            return this._buttonLink;
+        },
+        set: function (value) {
+            if (this._buttonLink === value)
+                return;
+            this._buttonLink = value;
+            this.setAttribute('buttonLink', this._buttonLink);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPTryItNow.prototype, "icon", {
+        get: function () {
+            return this._icon;
+        },
+        set: function (value) {
+            if (this._icon === value)
+                return;
+            this._icon = value;
+            this.setAttribute('icon', this._icon);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPTryItNow.prototype, "buttonText", {
+        get: function () {
+            return this._buttonText;
+        },
+        set: function (value) {
+            if (this._buttonText === value)
+                return;
+            this._buttonText = value;
+            this.setAttribute('buttonText', this._buttonText);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPTryItNow.prototype.connectedCallback = function () {
+        this.innerHTML = (_a = ["", "", "", "", "", "", ""], _a.raw = ["", "", "", "", "", "", ""], this.template(_a, this.title, this.subtitle, this.buttonLink, this.icon, this.buttonText, this.buttonID));
+        var _a;
+    };
+    ;
+    Object.defineProperty(RHDPTryItNow, "observedAttributes", {
+        get: function () {
+            return ['buttonText', 'icon', 'buttonLink', 'buttonID', 'subtitle', 'title'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPTryItNow.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPTryItNow;
+}(HTMLElement));
+window.addEventListener('WebComponentsReady', function () {
+    customElements.define('rhdp-tryitnow', RHDPTryItNow);
+});
 var DevNationLiveSession = (function () {
     function DevNationLiveSession(obj) {
         var _this = this;
@@ -147,16 +264,6 @@ var DevNationLiveSession = (function () {
     });
     return DevNationLiveSession;
 }());
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 var DevNationLiveApp = (function (_super) {
     __extends(DevNationLiveApp, _super);
     function DevNationLiveApp() {

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -96,7 +96,9 @@ var RHDPTryItNow = (function (_super) {
         configurable: true
     });
     RHDPTryItNow.prototype.connectedCallback = function () {
-        this.innerHTML = (_a = ["", "", "", "", "", "", ""], _a.raw = ["", "", "", "", "", "", ""], this.template(_a, this.title, this.subtitle, this.buttonLink, this.icon, this.buttonText, this.buttonID));
+        if (this.title && this.subtitle && this.buttonLink && this.icon && this.buttonText) {
+            this.innerHTML = (_a = ["", "", "", "", "", "", ""], _a.raw = ["", "", "", "", "", "", ""], this.template(_a, this.title, this.subtitle, this.buttonLink, this.icon, this.buttonText, this.buttonID));
+        }
         var _a;
     };
     ;

--- a/stylesheets/_products.scss
+++ b/stylesheets/_products.scss
@@ -650,3 +650,47 @@ ul.product-langs {
   }
 }
 
+rhdp-tryitnow {
+  section {
+    background-color: $green;
+    height: auto;
+    min-height: 150px;
+  }
+  .row {
+    padding: 30px 1em;
+    img {
+      height: 90px;
+      width: 90px;
+      float: left;
+    }
+    span {
+      width: calc(100% - 335px);
+      float: left;
+      padding: 0 1em;
+
+      h4, h5 { color: $white;}
+      h4 { margin: 0; }
+      h5 {
+        padding-top: 15px;
+        margin-top: 0;
+      }
+    }
+    a.button.medium-cta.white {
+      margin-top: 30px;
+      &:hover, &:focus { color: #656565; }
+    }
+  }
+  @media only screen and (max-width: 1170px) {
+    section {
+      margin-left: -15px;
+      margin-right: -15px;    
+    }
+  }
+  @include tablet-portrait-and-down {
+    .row span { width: calc(100% - 90px); }
+    a.button.medium-cta.white { left: 107px; }
+  }
+  @include mobile-landscape-and-down {
+    section { margin-top: -10px; }
+  }
+}

--- a/typescript/rhdp-tryitnow.ts
+++ b/typescript/rhdp-tryitnow.ts
@@ -1,0 +1,98 @@
+class RHDPTryItNow extends HTMLElement {
+
+    private _title;
+    private _subtitle;
+    private _buttonID;
+    private _buttonText;
+    private _buttonLink;
+    private _icon;
+
+    get title() {
+        return this._title;
+    }
+
+    set title(value) {
+        if(this._title === value) return;
+        this._title = value;
+        this.setAttribute('title', this._title);
+    }
+
+    get subtitle() {
+        return this._subtitle;
+    }
+
+    set subtitle(value) {
+        if(this._subtitle === value) return;
+        this._subtitle = value;
+        this.setAttribute('subtitle', this._subtitle);
+    }
+
+
+    get buttonID() {
+        return this._buttonID;
+    }
+
+    set buttonID(value) {
+        if(this._buttonID === value) return;
+        this._buttonID = value;
+        this.setAttribute('buttonID', this._buttonID);
+    }
+
+    get buttonLink() {
+        return this._buttonLink;
+    }
+
+    set buttonLink(value) {
+        if(this._buttonLink === value) return;
+        this._buttonLink = value;
+        this.setAttribute('buttonLink', this._buttonLink);
+    }
+
+    get icon() {
+        return this._icon;
+    }
+
+    set icon(value) {
+        if(this._icon === value) return;
+        this._icon = value;
+        this.setAttribute('icon', this._icon);
+    }
+
+
+    get buttonText() {
+        return this._buttonText;
+    }
+
+    set buttonText(value) {
+        if(this._buttonText === value) return;
+        this._buttonText = value;
+        this.setAttribute('buttonText', this._buttonText);
+    }
+
+    constructor() {
+        super();
+    }
+
+    template = (strings, title, subtitle, buttonLink, icon, buttonText, buttonID) => {
+        return ` <div class="row"> <img src="${icon}"> <h4>${title}</h4> <h5>${subtitle}</h5> <a ${buttonID ? `id="${buttonID}"` : ''}href="${buttonLink}" class="button medium-cta white">${buttonText}</a> </div>`;
+    };
+
+    connectedCallback() {
+        this.innerHTML = this.template`${this.title}${this.subtitle}${this.buttonLink}${this.icon}${this.buttonText}${this.buttonID}`;
+    };
+
+    static get observedAttributes() {
+        return ['buttonText', 'icon', 'buttonLink', 'buttonID', 'subtitle', 'title'];
+    }
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+
+
+}
+
+window.addEventListener('WebComponentsReady', function() {
+    customElements.define('rhdp-tryitnow', RHDPTryItNow);
+});

--- a/typescript/rhdp-tryitnow.ts
+++ b/typescript/rhdp-tryitnow.ts
@@ -74,7 +74,7 @@ class RHDPTryItNow extends HTMLElement {
     }
 
     template = (strings, title, subtitle, buttonLink, icon, buttonText, buttonID) => {
-        return ` <div class="row"> <img src="${icon}"> <h4>${title}</h4> <h5>${subtitle}</h5> <a ${buttonID ? `id="${buttonID}"` : ''}href="${buttonLink}" class="button medium-cta white">${buttonText}</a> </div>`;
+        return `<section> <div class="row"> <img src="${icon}"> <span> <h4>${title}</h4> <h5>${subtitle}</h5> </span> <a ${buttonID ? `id="${buttonID}" ` :''} href="${buttonLink}" class="button medium-cta white">${buttonText}</a> </div></section>`;
     };
 
     connectedCallback() {

--- a/typescript/rhdp-tryitnow.ts
+++ b/typescript/rhdp-tryitnow.ts
@@ -1,11 +1,11 @@
 class RHDPTryItNow extends HTMLElement {
 
-    private _title;
-    private _subtitle;
-    private _buttonID;
-    private _buttonText;
-    private _buttonLink;
-    private _icon;
+    private _title = '';
+    private _subtitle = '';
+    private _buttonID = '';
+    private _buttonText = '';
+    private _buttonLink = '';
+    private _icon = '';
 
     get title() {
         return this._title;
@@ -15,6 +15,7 @@ class RHDPTryItNow extends HTMLElement {
         if(this._title === value) return;
         this._title = value;
         this.setAttribute('title', this._title);
+        this.querySelector('h4') ? this.querySelector('h4').innerText = this._title : '';
     }
 
     get subtitle() {
@@ -25,8 +26,9 @@ class RHDPTryItNow extends HTMLElement {
         if(this._subtitle === value) return;
         this._subtitle = value;
         this.setAttribute('subtitle', this._subtitle);
-    }
+        this.querySelector('h5') ? this.querySelector('h5').innerText = this._subtitle : '';
 
+    }
 
     get buttonID() {
         return this._buttonID;
@@ -35,7 +37,8 @@ class RHDPTryItNow extends HTMLElement {
     set buttonID(value) {
         if(this._buttonID === value) return;
         this._buttonID = value;
-        this.setAttribute('buttonID', this._buttonID);
+        this.setAttribute('button-id', this._buttonID);
+        this.querySelector('a') ? this.querySelector('a').id = this._buttonID : '';
     }
 
     get buttonLink() {
@@ -45,7 +48,9 @@ class RHDPTryItNow extends HTMLElement {
     set buttonLink(value) {
         if(this._buttonLink === value) return;
         this._buttonLink = value;
-        this.setAttribute('buttonLink', this._buttonLink);
+        this.setAttribute('button-link', this._buttonLink);
+        this.querySelector('a') ? this.querySelector('a').href = this._buttonLink : '';
+
     }
 
     get icon() {
@@ -56,6 +61,8 @@ class RHDPTryItNow extends HTMLElement {
         if(this._icon === value) return;
         this._icon = value;
         this.setAttribute('icon', this._icon);
+        this.querySelector('img') ? this.querySelector('img').src = this._buttonLink : '';
+
     }
 
 
@@ -66,7 +73,8 @@ class RHDPTryItNow extends HTMLElement {
     set buttonText(value) {
         if(this._buttonText === value) return;
         this._buttonText = value;
-        this.setAttribute('buttonText', this._buttonText);
+        this.setAttribute('button-text', this._buttonText);
+        this.querySelector('a') ? this.querySelector('a').innerText = this._buttonLink : '';
     }
 
     constructor() {

--- a/typescript/rhdp-tryitnow.ts
+++ b/typescript/rhdp-tryitnow.ts
@@ -61,7 +61,7 @@ class RHDPTryItNow extends HTMLElement {
         if(this._icon === value) return;
         this._icon = value;
         this.setAttribute('icon', this._icon);
-        this.querySelector('img') ? this.querySelector('img').src = this._buttonLink : '';
+        this.querySelector('img') ? this.querySelector('img').src = this._icon : '';
 
     }
 
@@ -74,7 +74,7 @@ class RHDPTryItNow extends HTMLElement {
         if(this._buttonText === value) return;
         this._buttonText = value;
         this.setAttribute('button-text', this._buttonText);
-        this.querySelector('a') ? this.querySelector('a').innerText = this._buttonLink : '';
+        this.querySelector('a') ? this.querySelector('a').innerText = this._buttonText : '';
     }
 
     constructor() {

--- a/typescript/rhdp-tryitnow.ts
+++ b/typescript/rhdp-tryitnow.ts
@@ -78,7 +78,9 @@ class RHDPTryItNow extends HTMLElement {
     };
 
     connectedCallback() {
-        this.innerHTML = this.template`${this.title}${this.subtitle}${this.buttonLink}${this.icon}${this.buttonText}${this.buttonID}`;
+        if(this.title && this.subtitle && this.buttonLink && this.icon && this.buttonText){
+            this.innerHTML = this.template`${this.title}${this.subtitle}${this.buttonLink}${this.icon}${this.buttonText}${this.buttonID}`;
+        }
     };
 
     static get observedAttributes() {


### PR DESCRIPTION
This is a PR to work off of for the try it now feature.
https://issues.jboss.org/browse/DEVELOPER-4432

Test see what it looks like, I've been running this in the chrome console:

sel = document.querySelector('#block-rhd-content > article > section.product-graphics.application-development');
sel.removeChild(sel.firstElementChild);
var title = "Try EAP 7 right now in the cloud.<br/>No download, installation or configuration needed.",
subtitle = "Within seconds, you could be using a browser based IDE to evaluate EAP 7.",
buttonID = "test button id",
buttonText = "Launch EAP 7 Now",
buttonLink = "http://www.google.com",
icon = "https://static.jboss.org/rhd/images/icons/rocket.png";

wc = document.createElement('rhdp-tryitnow');
wc.title = title;
wc.subtitle = subtitle;
wc.buttonID = buttonID;
wc.buttonText = buttonText;
wc.buttonLink = buttonLink;
wc.icon = icon;
sel.insertBefore(wc, sel.firstChild);
