### PR TITLE
DEVELOPER-3793 Added PDF icon to PDF links

### DIFF
--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -167,6 +167,12 @@ a {
     outline-width: 1px;
     outline-color: color($link);
   }
+  &[href$=".pdf"]:after,
+  &.pdf:after {
+    content: "\f1c1";
+    font-family: FontAwesome;
+    margin-left: 4px;
+  }
 }
 
 p a:hover {


### PR DESCRIPTION
Added PDF icon to be automatically displayed after any PDF links that have the .pdf extension. [Example screenshot](https://www.dropbox.com/s/2zydvni8n4zdclo/Screenshot%202017-10-10%2010.34.15.png?dl=0)

For any PDF links that do not have the .pdf extension, I added the css class ".pdf" that can be manually added to the anchor tag to display the PDF icon.