### PR TITLE
DEVELOPER-4441 Style fix for adaptive placeholders

### DIFF
--- a/stylesheets/_adaptive-placeholder.scss
+++ b/stylesheets/_adaptive-placeholder.scss
@@ -31,6 +31,11 @@
       -webkit-box-shadow: 0 0 0px 1000px white inset;
     }
   }
+  input:-webkit-autofill ~ label {
+    bottom: 35px;
+    font-size: 12px;
+    color: #8c8f91;
+  }
 
   select {
     background-color: $white;


### PR DESCRIPTION
[DEVELOPER-4441 Odd text overlap in password field in Chrome browser](https://issues.jboss.org/browse/DEVELOPER-4441)

Fixes spacing between input and labels in adaptive placeholders. Libor has tested this CSS fix and says it works as it should, but needed it added to our app.css stylesheet.