### PR TITLE
DEVELOPER-3793 Updates hyperlink behavior in "Link to PDF"

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,7 +83,8 @@ var globs = {
         'javascripts/build.js',
         'javascripts/middleware-blog.js',
         'javascripts/scroll-to-top.js',
-        'javascripts/footer.js'
+        'javascripts/footer.js',
+        'javascripts/pdf-links.js'
     ],
     "styles": ['stylesheets/*.scss']
 };

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/promotion-page/node--promotion-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/promotion-page/node--promotion-page.html.twig
@@ -79,7 +79,7 @@ other methods (such as node.delete) will result in an exception.
       </h3>
     </div>
     <div class="medium-6 small-11 columns">
-      <a href="{{ content.field_call_to_action_link[0]['#url'] }}">
+      <a href="{{ content.field_call_to_action_link[0]['#url'] }}" class="img-link">
           {% if content.field_promotion_page_left_image|render|striptags|trim is not empty %}
               {{ content.field_promotion_page_left_image }}
           {% else %}

--- a/_layouts/ticket-monster.html.slim
+++ b/_layouts/ticket-monster.html.slim
@@ -28,7 +28,7 @@ layout: base
 
     .large-14.columns
       br
-      a.right.button.medium-cta.blue(href="http://docs.jboss.org/jbossdeveloper/2.7/ticket-monster-2.7.0.Final.pdf" target="_blank" rel="noopener noreferrer") Download the Instructions
+      a.right.button.medium-cta.blue(class="pdf" href="http://docs.jboss.org/jbossdeveloper/2.7/ticket-monster-2.7.0.Final.pdf" target="_blank" rel="noopener noreferrer") Download the Instructions
       h3#follow-along Follow along with video
       br
       .flex-video.large.24

--- a/javascripts/pdf-links.js
+++ b/javascripts/pdf-links.js
@@ -1,0 +1,5 @@
+// Opens in a new tab all links ending in .pdf extension
+$('a[href$=".pdf"]').click( function() {
+  window.open( $(this).attr('href') );
+  return false;
+});

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -173,6 +173,11 @@ a {
     font-family: FontAwesome;
     margin-left: 4px;
   }
+
+  &.img-link {
+    &[href$=".pdf"]:after,
+    &.pdf:after { display: none; }
+  }
 }
 
 p a:hover {
@@ -293,6 +298,11 @@ button, .button {
     display: none;
   }
 }
+
+a.heavy-cta[href$=".pdf"]:after,
+a.medium-cta[href$=".pdf"]:after,
+.heavy-cta a[href$=".pdf"]:after,
+.madium-cta a[href$=".pdf"]:after{ display: none; }
 
 a.light-cta{
   color: $link;


### PR DESCRIPTION
- JS to open all links with .pdf extension in new tab
- Added CSS to prevent pdf icon from displaying if pdf link has img child,
- Added CSS to prevent pdf icon from displaying if pdf link is a heavy or medium CTA