### PR TITLE
[URGENT] DEVELOPER-4477 Disabled pdf-links.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,8 +83,7 @@ var globs = {
         'javascripts/build.js',
         'javascripts/middleware-blog.js',
         'javascripts/scroll-to-top.js',
-        'javascripts/footer.js',
-        'javascripts/pdf-links.js'
+        'javascripts/footer.js'
     ],
     "styles": ['stylesheets/*.scss']
 };


### PR DESCRIPTION
Opening all links with extension '.pdf' in a new tab broke downloads for pdfs in DM. This PR disables the script that was forcing the new tab. 

New pr coming soon with an exclusion to DM links within pdf-links.js