### PR TITLE
DEVELOPER-3587 - Improve the performance of /downloads

### DIFF
--- a/_docker/lib/export/static/rhdp-apps/downloads/products.json
+++ b/_docker/lib/export/static/rhdp-apps/downloads/products.json
@@ -1,0 +1,187 @@
+{
+  "products" : [
+    {
+      "productName": "Red Hat JBoss Data Grid",
+      "groupHeading" : "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+      "productCode": "datagrid",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "An in-memory data grid to accelerate performance that is fast, distributed, scalable, and independent from the data tier.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/datagrid/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss Enterprise Application Platform",
+      "groupHeading" : "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+      "productCode": "eap",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "An innovative, modular, cloud-ready application platform that addresses management, automation and developer productivity.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/eap/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss Web Server",
+      "groupHeading" : "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+      "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+      "description" : "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/webserver/overview/"
+    },
+    {
+      "productName": "Red Hat Application Migration Toolkit",
+      "groupHeading" : "DEVELOPER TOOLS",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads",
+      "downloadLink": "https://access.redhat.com/downloads",
+      "description" : "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/rhamt/overview/"
+    },
+    {
+      "productName": "Red Hat Container Development Kit",
+      "groupHeading" : "DEVELOPER TOOLS",
+      "productCode": "cdk",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads/content/293/",
+      "downloadLink": "",
+      "description" : "For container development, includes RHEL and OpenShift 3.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/cdk/overview/"
+    },
+    {
+      "productName": "Red Hat Development Suite",
+      "groupHeading" : "DEVELOPER TOOLS",
+      "productCode": "devsuite",
+      "featured" : true,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads",
+      "downloadLink": "",
+      "description" : "A fully integrated development environment for modern enterprise development.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/devsuite/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss Developer Studio",
+      "groupHeading" : "DEVELOPER TOOLS",
+      "productCode": "devstudio",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jbossdeveloperstudio&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "An Eclipse-based IDE to create apps for web, mobile, transactional enterprise, and SOA-based integration apps/services.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/devstudio/overview/"
+    },
+    {
+      "productName": "Red Hat Enterprise Linux",
+      "groupHeading" : "INFRASTRUCTURE",
+      "productCode": "rhel",
+      "featured" : true,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads/content/69/",
+      "downloadLink": "",
+      "description" : "For traditional development, includes Software Collections and Developer Toolset.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/rhel/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss AMQ",
+      "groupHeading" : "INTEGRATION AND AUTOMATION",
+      "productCode": "amq",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "A small-footprint, performant, robust messaging platform that enables real-time app, device, and service integration.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/amq/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss BRMS",
+      "groupHeading" : "INTEGRATION AND AUTOMATION",
+      "productCode": "brms",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=brms&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "A programming platform to easily capture and maintain rules for business changes, without impacting static applications.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/brms/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss BPM Suite",
+      "groupHeading" : "INTEGRATION AND AUTOMATION",
+      "productCode": "bpmsuite",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=bpm.suite&productChanged=yes",
+      "downloadLink": "",
+      "description" : "A platform that combines business rules and process management (BPM), and complex event processing.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/bpmsuite/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss Data Virtualization",
+      "groupHeading" : "INTEGRATION AND AUTOMATION",
+      "productCode": "datavirt",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/datavirt/overview/"
+    },
+    {
+      "productName": "Red Hat JBoss Fuse",
+      "groupHeading" : "INTEGRATION AND AUTOMATION",
+      "productCode": "fuse",
+      "featured" : true,
+      "dataFallbackUrl" : "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.fuse&downloadType=distributions",
+      "downloadLink": "",
+      "description" : "A small-footprint enterprise service bus (ESB) that lets you build, deploy and integrate applications and services.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/fuse/overview/"
+    },
+    {
+      "productName": "Red Hat Mobile Application Platform",
+      "groupHeading" : "MOBILE",
+      "featured" : true,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads/content/316/",
+      "downloadLink": "https://access.redhat.com/downloads/content/316/",
+      "description" : "Develop and deploy mobile apps in an agile and flexible manner.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/mobileplatform/overview/"
+    },
+    {
+      "productName": "Red Hat OpenShift Container Platform",
+      "groupHeading" : "CLOUD",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads/content/290/",
+      "downloadLink": "https://access.redhat.com/downloads/content/290/",
+      "description" : "An open, hybrid Platform-as-a-Service (PaaS) to quickly develop, host, scale, and deliver apps in the cloud.",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/openshift/overview/"
+    },
+    {
+      "productName": "OpenJDK",
+      "groupHeading" : "RUNTIMES",
+      "productCode": "openjdk",
+      "featured" : false,
+      "dataFallbackUrl" : "https://developers.redhat.com/products/openjdk/overview/",
+      "downloadLink": "",
+      "description" : "A Tried, Tested and Trusted open source implementation of the Java platform",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/openjdk/overview/"
+    },
+    {
+      "productName": ".NET Core for Red Hat Enterprise Linux",
+      "groupHeading" : "RUNTIMES",
+      "productCode": "dotnet",
+      "featured" : false,
+      "dataFallbackUrl" : "https://access.redhat.com/downloads",
+      "downloadLink": "",
+      "description" : "Build and run cross-platform .NET applications on the world’s number one Enterprise-ready Linux Distribution, Red Hat Enterprise Linux",
+      "version" : "",
+      "learnMoreLink" : "https://developers.redhat.com/products/dotnet/overview/"
+    }
+  ]
+}

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-all-item_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-all-item_spec.js
@@ -1,0 +1,91 @@
+"use strict";
+// Test rhdp-downloads-all component
+
+describe('Downloads All Product Items', function () {
+    var wc;
+
+    beforeEach(function () {
+        wc = document.createElement('rhdp-downloads-all-item');
+        wc.name = 'Test Product';
+        wc.productId = 'testproduct';
+        wc.dataFallbackUrl = 'http://www.testproduct.com';
+        wc.downloadUrl = 'http://www.downloadtestproduct.com';
+        wc.description = 'This is a description for a solid test product';
+        wc.learnMore = 'http://www.testproduct.com/learnmore';
+        wc.version = '1.0.0';
+
+        document.body.insertBefore(wc, document.body.firstChild);
+
+    });
+
+    afterEach(function () {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function () {
+
+        it('should update the name property', function () {
+            expect(wc.name).toEqual('Test Product');
+
+
+        });
+        it('should update the productId property', function () {
+            expect(wc.productId).toEqual('testproduct');
+
+
+        });
+        it('should update the dataFallbackUrl property', function () {
+            expect(wc.dataFallbackUrl).toEqual('http://www.testproduct.com');
+
+
+        });
+        it('should update the downloadUrl property', function () {
+            expect(wc.downloadUrl).toEqual('http://www.downloadtestproduct.com');
+
+
+        });
+        it('should update the description property', function () {
+            expect(wc.description).toEqual('This is a description for a solid test product');
+
+
+        });
+        it('should update the learnMore property', function () {
+            expect(wc.learnMore).toEqual('http://www.testproduct.com/learnmore');
+
+
+        });
+        it('should update the version property', function () {
+            expect(wc.version).toEqual('1.0.0');
+
+
+        });
+
+    });
+    describe('with valid data', function () {
+
+
+        it('should update the heading', function () {
+            expect(wc.querySelector('.row .large-24.column').innerText.trim()).toEqual('Test Product');
+        });
+        it('should update the description with the appropriate text', function () {
+            expect(wc.querySelector('.large-10.columns .paragraph p').innerText.trim()).toEqual('This is a description for a solid test product');
+        });
+        it('should update the href the appropriate learnmore link', function () {
+            expect(wc.querySelector('.large-10.columns .paragraph p').innerText.trim()).toEqual('This is a description for a solid test product');
+        });
+        it('should update the datafallback with the appropriate url', function () {
+            expect(wc.querySelector('.large-5.columns a').getAttribute('data-fallback-url')).toEqual('http://www.testproduct.com');
+        });
+        it('should update the downloadURL with the appropriate text', function () {
+            expect(wc.querySelector('.large-5.columns a').href).toEqual('http://www.downloadtestproduct.com/');
+        });
+        it('should update the productID with the appropriate text', function () {
+            expect(wc.querySelector('.large-5.columns a').getAttribute('data-download-id')).toEqual('testproduct');
+        });
+        it('should update the version with the appropriate text', function () {
+            expect(wc.querySelector('.large-9.center.columns p').innerText.trim()).toEqual('Version: 1.0.0');
+        });
+
+    });
+
+});

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-all_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-all_spec.js
@@ -6,14 +6,15 @@ describe('Downloads All Products', function () {
     var products;
     var mockProduct = {
         "products": [{
-            "productName": "Red Hat JBoss Data Virtualization",
-            "groupHeading": "INTEGRATION AND AUTOMATION",
-            "productCode": "datavirt",
-            "featured": false,
-            "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
-            "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+            "productName": "Test Product",
+            "groupHeading": "Test Group Heading",
+            "productCode": "testid",
+            "featured": true,
+            "dataFallbackUrl": "http://www.testdatafallbackurl.com",
+            "downloadLink": "http://www.testdownloadlink.com/",
+            "description": "This is a test of popular products",
             "version": "6.3.0",
-            "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+            "learnMoreLink": "http://www.testlearningmore.com"
         }]
     };
 
@@ -73,6 +74,55 @@ describe('Downloads All Products', function () {
         it('should update the id with the appropriate text', function () {
             expect(wc.querySelector('.large-24.category-label').id).toEqual('test');
         });
+
+        describe('and product category headings', function () {
+
+
+            beforeEach(function () {
+                wc.id = 'test';
+                wc.heading = 'Test Group Heading';
+                wc.products = products;
+                document.body.insertBefore(wc, document.body.firstChild);
+
+            });
+            it('should have a download list class to append children to', function () {
+                expect(wc.querySelector('.download-list').innerText.length).toBeGreaterThan(0);
+
+            });
+            it('should have a rhdp-downloads-all-item child appended', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item').innerText.length).toBeGreaterThan(0);
+
+            });
+            it('should have a rhdp-downloads-all-item child appended with a heading', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row .large-24.column h5').innerText.trim()).toEqual("Test Product");
+
+            });
+            it('should have a rhdp-downloads-all-item child appended with a description', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row .paragraph p').innerText.trim()).toEqual("This is a test of popular products");
+
+            });
+            it('should have a rhdp-downloads-all-item child appended with a learn more link', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row .large-10.columns a').href).toEqual("http://www.testlearningmore.com/");
+
+            });
+            it('should have a rhdp-downloads-all-item child appended with a data-download-id-version', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row .large-9.center.columns p').getAttribute('data-download-id-version')).toEqual("testid");
+
+            });
+            it('should have a rhdp-downloads-all-item child appended with a version', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row .large-9.center.columns p').innerText.trim()).toEqual("Version: 6.3.0");
+
+            });
+            it('should have a rhdp-downloads-all-item child appended medium-cta blue with appropriate data', function () {
+                expect(wc.querySelector('rhdp-downloads-all-item .row a.button.medium-cta.blue').getAttribute('data-download-id')).toEqual("testid");
+                expect(wc.querySelector('rhdp-downloads-all-item .row a.button.medium-cta.blue').getAttribute('data-fallback-url')).toEqual("http://www.testdatafallbackurl.com");
+                expect(wc.querySelector('rhdp-downloads-all-item .row a.button.medium-cta.blue').href).toEqual("http://www.testdownloadlink.com/");
+
+            });
+
+        });
+
+
 
     });
 

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-all_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-all_spec.js
@@ -1,0 +1,79 @@
+"use strict";
+// Test rhdp-downloads-all component
+
+describe('Downloads All Products', function () {
+    var wc;
+    var products;
+    var mockProduct = {
+        "products": [{
+            "productName": "Red Hat JBoss Data Virtualization",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "datavirt",
+            "featured": false,
+            "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+            "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+            "version": "6.3.0",
+            "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+        }]
+    };
+
+
+    beforeEach(function () {
+        wc = document.createElement('rhdp-downloads-all');
+        products = new RHDPDownloadsProducts();
+        products.products = mockProduct;
+
+    });
+
+    afterEach(function () {
+        document.body.removeChild(document.body.firstChild);
+        products = null;
+    });
+
+    describe('properties', function () {
+
+
+        beforeEach(function () {
+            wc.id = 'test';
+            wc.heading = 'test heading';
+            wc.products = products;
+            document.body.insertBefore(wc, document.body.firstChild);
+
+        });
+        it('should update the id property', function () {
+            expect(wc.id).toEqual('test');
+
+
+        });
+        it('should update the heading property', function () {
+            expect(wc.heading).toEqual('test heading');
+
+
+        });
+        it('should update productList property', function () {
+            expect(wc.products).toEqual(products);
+
+
+        });
+
+    });
+    describe('with valid data', function () {
+
+
+        beforeEach(function () {
+            wc.id = 'test';
+            wc.heading = 'test heading';
+            wc.products = products;
+            document.body.insertBefore(wc, document.body.firstChild);
+        });
+
+        it('should have a heading with the appropriate text', function () {
+            expect(wc.querySelector('h4').innerText).toEqual('test heading');
+        });
+        it('should update the id with the appropriate text', function () {
+            expect(wc.querySelector('.large-24.category-label').id).toEqual('test');
+        });
+
+    });
+
+});

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-app_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-app_spec.js
@@ -1,0 +1,21 @@
+"use strict";
+/* global RHDPDownloadsApp */
+// Test rhdp-downloads-app component
+
+describe('Given Downloads Application', function() {
+    var wc;
+
+    beforeEach(function() {
+        document.body.insertBefore(document.createElement('rhdp-downloads-app'), document.body.firstChild);
+        wc = document.body.firstChild;
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    it('should be true', function() {
+        expect(wc.innerText.length).toBeGreaterThan(0);
+
+    });
+});

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-popular-product_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-popular-product_spec.js
@@ -1,0 +1,69 @@
+"use strict";
+// Test rhdp-downloads-popular-product component
+
+describe('Downloads Popular Product Item', function() {
+    var wc;
+    beforeEach(function() {
+        wc = document.createElement('rhdp-downloads-popular-product');
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function() {
+
+
+        beforeEach(function() {
+            wc.name = "Test Name";
+            wc.productId = "testproduct";
+            wc.dataFallbackUrl = "http://www.testproduct.com";
+            wc.downloadUrl = "http://www.downloadtestproduct.com";
+
+            document.body.insertBefore(wc, document.body.firstChild);
+
+        });
+
+        it('should update productList and productList attributes', function() {
+            expect(wc.name).toEqual("Test Name");
+        });
+        it('should update productList and productList attributes', function() {
+            expect(wc.productId).toEqual("testproduct");
+        });
+        it('should update productList and productList attributes', function() {
+            expect(wc.dataFallbackUrl).toEqual("http://www.testproduct.com");
+        });
+        it('should update productList and productList attributes', function() {
+            expect(wc.downloadUrl).toEqual('http://www.downloadtestproduct.com');
+        });
+
+    });
+    describe('with valid data', function() {
+
+
+        beforeEach(function() {
+            wc.name = "Test Name";
+            wc.productId = "testproduct";
+            wc.dataFallbackUrl = "http://www.testproduct.com";
+            wc.downloadUrl = "http://www.downloadtestproduct.com";
+
+            document.body.insertBefore(wc, document.body.firstChild);
+
+        });
+
+        it('should update the heading with the appropriate name', function() {
+            expect(wc.querySelector('.popular-download-box h4').innerText.trim()).toEqual('Test Name');
+        });
+        it('should update the data-download-id attribute with the appropriate id', function() {
+            expect(wc.querySelector('.popular-download-box a').getAttribute('data-download-id')).toEqual("testproduct");
+        });
+        it('should update the data-fallback-url attribute with the appropriate url', function() {
+            expect(wc.querySelector('.popular-download-box a').getAttribute('data-fallback-url')).toEqual("http://www.testproduct.com");
+        });
+        it('should update the href attribute with the proper download url', function() {
+            expect(wc.querySelector('.popular-download-box a').href).toEqual('http://www.downloadtestproduct.com/');
+        });
+
+    });
+
+});

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-popular-products_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-popular-products_spec.js
@@ -1,0 +1,46 @@
+"use strict";
+// Test rhdp-downloads-popular-products component
+
+describe('Downloads Popular Products', function() {
+    var wc;
+    beforeEach(function() {
+        wc = document.createElement('rhdp-downloads-popular-products');
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function() {
+
+        var product;
+
+        beforeEach(function() {
+            document.body.insertBefore(wc, document.body.firstChild);
+
+        });
+        afterEach(function() {
+            product = null;
+
+        });
+
+        it('should update productList and productList attributes', function() {
+            var products = {
+                "products": [{
+                    "productName": "Red Hat JBoss Data Virtualization",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "datavirt",
+                    "featured": false,
+                    "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+                    "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+                    "version": "6.3.0",
+                    "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+                }]
+            };
+            wc.products = products;
+            expect(wc.products).toEqual(products);
+        });
+
+    });
+
+});

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-popular-products_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-popular-products_spec.js
@@ -3,8 +3,25 @@
 
 describe('Downloads Popular Products', function() {
     var wc;
+
+    var products = {
+        "products": [{
+            "productName": "Test Product",
+            "groupHeading": "Test Group Heading",
+            "productCode": "testid",
+            "featured": true,
+            "dataFallbackUrl": "http://www.testdatafallbackurl.com",
+            "downloadLink": "http://www.testdownloadlink.com/",
+            "description": "This is a test of popular products",
+            "version": "6.3.0",
+            "learnMoreLink": "http://www.testlearningmore.com"
+        }]
+    };
+
     beforeEach(function() {
         wc = document.createElement('rhdp-downloads-popular-products');
+        wc.productList = products;
+
     });
 
     afterEach(function() {
@@ -13,32 +30,32 @@ describe('Downloads Popular Products', function() {
 
     describe('properties', function() {
 
-        var product;
+        beforeEach(function() {
+            document.body.insertBefore(wc, document.body.firstChild);
+
+        });
+
+        it('should update productList variable', function() {
+            expect(wc.productList).toEqual(products);
+        });
+
+    });
+
+    describe('with valid data', function() {
 
         beforeEach(function() {
             document.body.insertBefore(wc, document.body.firstChild);
 
         });
-        afterEach(function() {
-            product = null;
 
+        it('should display a child node with the appropriate heading', function() {
+            expect(wc.querySelector('.large-6.column h4').innerText.trim()).toEqual("Test Product");
         });
-
-        it('should update productList and productList attributes', function() {
-            var products = {
-                "products": [{
-                    "productName": "Red Hat JBoss Data Virtualization",
-                    "groupHeading": "INTEGRATION AND AUTOMATION",
-                    "productCode": "datavirt",
-                    "featured": false,
-                    "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
-                    "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
-                    "version": "6.3.0",
-                    "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
-                }]
-            };
-            wc.products = products;
-            expect(wc.products).toEqual(products);
+        it('should display a child node with the appropriate data-download-id', function() {
+            expect(wc.querySelector('.large-6.column a').getAttribute('data-fallback-url')).toEqual("http://www.testdatafallbackurl.com");
+        });
+        it('should display a child node with the appropriate href', function() {
+            expect(wc.querySelector('.large-6.column a').href).toEqual("http://www.testdownloadlink.com/");
         });
 
     });

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-products_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-products_spec.js
@@ -26,16 +26,16 @@ describe('Download Products', function() {
             var data =
                 [
                     {
-                        "name": "Data Virtualization",
-                        "productCode": "datavirt",
+                        "name": "Test Product",
+                        "productCode": "testprod",
                         "featuredArtifact": {
-                            "url": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+                            "url": "http://www.testproduct.com",
                             "description": "Installer",
                             "label": "Installer",
                             "fileSize": 1001265730,
-                            "tcModel": "JBoss/Red Hat Developer Subscription",
-                            "sha256": "b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949",
-                            "md5": "f88f9106745f913c9e2e158cd28eebf7",
+                            "tcModel": "Test subscription model",
+                            "sha256": "ShaTestKey",
+                            "md5": "md5TestKey",
                             "versionName": "6.3.0",
                             "releaseDate": 1470801600000,
                             "type": "file"
@@ -50,14 +50,15 @@ describe('Download Products', function() {
         it('should update products attribute', function() {
             var products = {
                 "products": [{
-                    "productName": "Red Hat JBoss Data Virtualization",
-                    "groupHeading": "INTEGRATION AND AUTOMATION",
-                    "productCode": "datavirt",
-                    "featured": false,
-                    "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
-                    "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+                    "productName": "Test Product",
+                    "groupHeading": "Test Group Heading",
+                    "productCode": "testid",
+                    "featured": true,
+                    "dataFallbackUrl": "http://www.testdatafallbackurl.com",
+                    "downloadLink": "http://www.testdownloadlink.com/",
+                    "description": "This is a test of popular products",
                     "version": "6.3.0",
-                    "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+                    "learnMoreLink": "http://www.testlearningmore.com"
                 }]
             };
             wc.products = products;
@@ -70,23 +71,42 @@ describe('Download Products', function() {
         var mockData;
         var products = {
             "products": [{
-                "productName": "Red Hat JBoss Data Virtualization",
-                "groupHeading": "INTEGRATION AND AUTOMATION",
-                "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
-                "productCode": "datavirt",
-                "featured": false,
-                "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
-                "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
-                "version": "6.3.0",
-                "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+                "productName": "Test Product",
+                "groupHeading": "Test Group Heading",
+                "productCode": "testid",
+                "featured": true,
+                "dataFallbackUrl": "http://www.testdatafallbackurl.com",
+                "downloadLink": "",
+                "description": "This is a test of popular products",
+                "version": "",
+                "learnMoreLink": "http://www.testlearningmore.com"
             }]
         };
 
         beforeEach(function() {
-            mockData = [{"name":"Data Virtualization","productCode":"datavirt","featuredArtifact":{"url":"https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar","description":"Installer","label":"Installer","fileSize":1001265730,"tcModel":"JBoss/Red Hat Developer Subscription","sha256":"b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949","md5":"f88f9106745f913c9e2e158cd28eebf7","versionName":"6.3.0","releaseDate":1470801600000,"type":"file"},"productVersions":[]}];
+            mockData =                 [
+                {
+                    "name": "Test Product",
+                    "productCode": "testid",
+                    "featuredArtifact": {
+                        "url": "http://www.testdownloadlink.com/",
+                        "description": "Installer",
+                        "label": "Installer",
+                        "fileSize": 1001265730,
+                        "tcModel": "Test subscription model",
+                        "sha256": "ShaTestKey",
+                        "md5": "md5TestKey",
+                        "versionName": "6.3.0",
+                        "releaseDate": 1470801600000,
+                        "type": "file"
+                    },
+                    "productVersions": []
+                }
+            ];
             wc = document.createElement('rhdp-downloads-products');
             wc.products = products;
             document.body.insertBefore(wc, document.body.firstChild);
+
         });
 
         afterEach(function() {
@@ -95,7 +115,7 @@ describe('Download Products', function() {
 
         it('should set the products when data is added', function() {
             wc.data = mockData;
-            expect(wc.products).toEqual({"products":[{"productName":"Red Hat JBoss Data Virtualization","groupHeading":"INTEGRATION AND AUTOMATION","productCode":"datavirt","featured":false,"dataFallbackUrl":"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions","downloadLink":"https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar","description":"A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.","version":"6.3.0","learnMoreLink":"https://developers.redhat.com/products/datavirt/overview/"}]});
+            expect(wc.products).toEqual({"products":[{"productName":"Test Product","groupHeading":"Test Group Heading","productCode":"testid","featured":true,"dataFallbackUrl":"http://www.testdatafallbackurl.com","downloadLink":"http://www.testdownloadlink.com/","description":"This is a test of popular products","version":"6.3.0","learnMoreLink":"http://www.testlearningmore.com"}]});
         });
 
 

--- a/_tests/unit/rhdp-downloads/rhdp-downloads-products_spec.js
+++ b/_tests/unit/rhdp-downloads/rhdp-downloads-products_spec.js
@@ -1,0 +1,104 @@
+"use strict";
+// Test rhdp-downloads-products component
+
+describe('Download Products', function() {
+    var wc;
+    beforeEach(function() {
+        wc = document.createElement('rhdp-downloads-products');
+        wc.mock = true;
+    });
+
+    afterEach(function() {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function() {
+        beforeEach(function() {
+            document.body.insertBefore(wc, document.body.firstChild);
+        });
+
+        it('should update categoryHeading attribute', function() {
+            var category = 'Test Product';
+            wc.category = category;
+            expect(wc.getAttribute('category')).toEqual(category);
+        });
+        it('should update data attribute', function() {
+            var data =
+                [
+                    {
+                        "name": "Data Virtualization",
+                        "productCode": "datavirt",
+                        "featuredArtifact": {
+                            "url": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+                            "description": "Installer",
+                            "label": "Installer",
+                            "fileSize": 1001265730,
+                            "tcModel": "JBoss/Red Hat Developer Subscription",
+                            "sha256": "b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949",
+                            "md5": "f88f9106745f913c9e2e158cd28eebf7",
+                            "versionName": "6.3.0",
+                            "releaseDate": 1470801600000,
+                            "type": "file"
+                        },
+                        "productVersions": []
+                    }
+                ]
+            ;
+            wc.data = data;
+            expect(wc.data).toEqual(data);
+        });
+        it('should update products attribute', function() {
+            var products = {
+                "products": [{
+                    "productName": "Red Hat JBoss Data Virtualization",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "datavirt",
+                    "featured": false,
+                    "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+                    "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+                    "version": "6.3.0",
+                    "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+                }]
+            };
+            wc.products = products;
+            expect(wc.products).toEqual(products);
+        });
+
+    });
+
+    describe('with valid data', function() {
+        var mockData;
+        var products = {
+            "products": [{
+                "productName": "Red Hat JBoss Data Virtualization",
+                "groupHeading": "INTEGRATION AND AUTOMATION",
+                "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
+                "productCode": "datavirt",
+                "featured": false,
+                "downloadLink": "https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar",
+                "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+                "version": "6.3.0",
+                "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+            }]
+        };
+
+        beforeEach(function() {
+            mockData = [{"name":"Data Virtualization","productCode":"datavirt","featuredArtifact":{"url":"https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar","description":"Installer","label":"Installer","fileSize":1001265730,"tcModel":"JBoss/Red Hat Developer Subscription","sha256":"b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949","md5":"f88f9106745f913c9e2e158cd28eebf7","versionName":"6.3.0","releaseDate":1470801600000,"type":"file"},"productVersions":[]}];
+            wc = document.createElement('rhdp-downloads-products');
+            wc.products = products;
+            document.body.insertBefore(wc, document.body.firstChild);
+        });
+
+        afterEach(function() {
+            document.body.removeChild(document.body.firstChild);
+        });
+
+        it('should set the products when data is added', function() {
+            wc.data = mockData;
+            expect(wc.products).toEqual({"products":[{"productName":"Red Hat JBoss Data Virtualization","groupHeading":"INTEGRATION AND AUTOMATION","productCode":"datavirt","featured":false,"dataFallbackUrl":"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions","downloadLink":"https://developers.stage.redhat.com/download-manager/content/origin/files/sha256/b4/b466affbcc1740bf2c7c73b60bb6ffa7e1ec844fc08447224ab15aa3bcee3949/jboss-dv-6.3.0-1-installer.jar","description":"A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.","version":"6.3.0","learnMoreLink":"https://developers.redhat.com/products/datavirt/overview/"}]});
+        });
+
+
+    })
+
+});

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -676,6 +676,633 @@ var DevNationLiveApp = (function (_super) {
 window.addEventListener('WebComponentsReady', function () {
     customElements.define('devnation-live-app', DevNationLiveApp);
 });
+var RHDPDownloadsAllItem = (function (_super) {
+    __extends(RHDPDownloadsAllItem, _super);
+    function RHDPDownloadsAllItem() {
+        var _this = _super.call(this) || this;
+        _this.template = function (strings, name, productId, dataFallbackUrl, downloadUrl, learnMore, description, version) {
+            return "\n            <div class=\"row\">\n                <hr>\n                <div class=\"large-24 column\">\n                    <h5>" + name + "</h5>\n                </div>\n            \n                <div class=\"large-10 columns\">\n                    <p></p>\n            \n                    <div class=\"paragraph\">\n                        <p>" + description + "</p>\n                    </div>\n                    <a href=\"" + learnMore + "\">Learn More</a></div>\n            \n                <div class=\"large-9 center columns\">\n                \n                  " + (version ? "<p data-download-id-version=\"" + productId + "\">Version: " + version + "</p>" : "<p data-download-id-version=\"" + productId + "\">&nbsp;</p>") + "  \n                </div>\n            \n                <div class=\"large-5 columns\"><a class=\"button medium-cta blue\" data-download-id=\"" + productId + "\"\n                                                data-fallback-url=\"" + dataFallbackUrl + "\"\n                                                href=\"" + downloadUrl + "\">Download</a></div>\n            </div>\n";
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "name", {
+        get: function () {
+            return this._name;
+        },
+        set: function (value) {
+            if (this._name === value)
+                return;
+            this._name = value;
+            this.setAttribute('name', this.name);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "productId", {
+        get: function () {
+            return this._productId;
+        },
+        set: function (value) {
+            if (this.productId === value)
+                return;
+            this._productId = value;
+            this.setAttribute('productid', this._productId);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "dataFallbackUrl", {
+        get: function () {
+            return this._dataFallbackUrl;
+        },
+        set: function (value) {
+            if (this.dataFallbackUrl === value)
+                return;
+            this._dataFallbackUrl = value;
+            this.setAttribute('datafallbackurl', this._dataFallbackUrl);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "downloadUrl", {
+        get: function () {
+            return this._downloadUrl;
+        },
+        set: function (value) {
+            if (this.downloadUrl === value)
+                return;
+            this._downloadUrl = value;
+            this.setAttribute('downloadurl', this._downloadUrl);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "description", {
+        get: function () {
+            return this._description;
+        },
+        set: function (value) {
+            this._description = value;
+            this.setAttribute('description', this._description);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "learnMore", {
+        get: function () {
+            return this._learnMore;
+        },
+        set: function (value) {
+            this._learnMore = value;
+            this.setAttribute('learnmore', this._learnMore);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAllItem.prototype, "version", {
+        get: function () {
+            return this._version;
+        },
+        set: function (value) {
+            this._version = value;
+            this.setAttribute('version', this._version);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsAllItem.prototype.connectedCallback = function () {
+        this.innerHTML = (_a = ["", "", "", "", "", "", "", ""], _a.raw = ["", "", "", "", "", "", "", ""], this.template(_a, this.name, this.productId, this.dataFallbackUrl, this.downloadUrl, this.learnMore, this.description, this.version));
+        var _a;
+    };
+    Object.defineProperty(RHDPDownloadsAllItem, "observedAttributes", {
+        get: function () {
+            return ['name'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsAllItem.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPDownloadsAllItem;
+}(HTMLElement));
+var RHDPDownloadsAll = (function (_super) {
+    __extends(RHDPDownloadsAll, _super);
+    function RHDPDownloadsAll() {
+        var _this = _super.call(this) || this;
+        _this.template = function (strings, id, heading) {
+            return "<div class=\"download-list\">\n                    <div class=\"large-24 category-label\" id=\"" + id + "\">\n                        <h4>" + heading + "</h4>\n                    </div>\n                </div>\n                ";
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPDownloadsAll.prototype, "id", {
+        get: function () {
+            return this._id;
+        },
+        set: function (value) {
+            if (this.id === value)
+                return;
+            this._id = value;
+            this.setAttribute('id', this._id);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAll.prototype, "heading", {
+        get: function () {
+            return this._heading;
+        },
+        set: function (value) {
+            if (this.heading === value)
+                return;
+            this._heading = value;
+            this.setAttribute('heading', this._heading);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsAll.prototype, "products", {
+        get: function () {
+            return this._products;
+        },
+        set: function (value) {
+            if (this.products === value)
+                return;
+            this._products = value;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsAll.prototype.connectedCallback = function () {
+        this.innerHTML = (_a = ["", "", ""], _a.raw = ["", "", ""], this.template(_a, this.id, this.heading));
+        this.getProductsWithTargetHeading(this.products);
+        var _a;
+    };
+    RHDPDownloadsAll.prototype.getProductsWithTargetHeading = function (productList) {
+        if (productList.products) {
+            var products = productList.products.products;
+            var len = products.length;
+            for (var i = 0; i < len; i++) {
+                if (products[i].groupHeading === this.heading) {
+                    var item = new RHDPDownloadsAllItem();
+                    item.name = products[i].productName;
+                    item.productId = products[i].productCode ? products[i].productCode : "";
+                    item.dataFallbackUrl = products[i].dataFallbackUrl ? products[i].dataFallbackUrl : "";
+                    item.downloadUrl = products[i].downloadLink ? products[i].downloadLink : "";
+                    item.description = products[i].description ? products[i].description : "";
+                    item.learnMore = products[i].learnMoreLink ? products[i].learnMoreLink : "";
+                    item.version = products[i].version ? products[i].version : "";
+                    this.querySelector('.download-list').appendChild(item);
+                }
+            }
+        }
+    };
+    Object.defineProperty(RHDPDownloadsAll, "observedAttributes", {
+        get: function () {
+            return ['id', 'heading'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsAll.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPDownloadsAll;
+}(HTMLElement));
+var RHDPDownloadsApp = (function (_super) {
+    __extends(RHDPDownloadsApp, _super);
+    function RHDPDownloadsApp() {
+        var _this = _super.call(this) || this;
+        _this.popularProduct = new RHDPDownloadsPopularProducts();
+        _this.products = new RHDPDownloadsProducts();
+        _this.template = "<div class=\"hero hero-wide hero-downloads\">\n                    <div class=\"row\">\n                        <div class=\"large-12 medium-24 columns\" id=\"downloads\">\n                            <h2>Downloads</h2>\n                        </div>\n                    </div>\n                </div>\n                <div class=\"most-popular-downloads\">\n                    <div class=\"row\">\n                        <div class=\"large-24 column\">\n                            <h3>Most Popular</h3>\n                        </div>\n                    </div>\n                \n                    <div class=\"row\">\n                    </div>\n                </div>\n                <div class=\"row\" id=\"downloads\">\n                    <div class=\"large-24 columns\">\n                        <h3 class=\"downloads-header\">All Downloads</h3>\n                    </div>\n                </div>";
+        return _this;
+    }
+    Object.defineProperty(RHDPDownloadsApp.prototype, "url", {
+        get: function () {
+            return this._url;
+        },
+        set: function (val) {
+            if (this._url === val)
+                return;
+            this._url = val;
+            this.setAttribute('url', this.url);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsApp.prototype.connectedCallback = function () {
+        this.innerHTML = this.template;
+        this.setProductsDownloadData(this.url);
+    };
+    RHDPDownloadsApp.prototype.addGroups = function (productList) {
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('accelerated_development_and_management', 'ACCELERATED DEVELOPMENT AND MANAGEMENT', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('developer_tools', 'DEVELOPER TOOLS', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('infrastructure', 'INFRASTRUCTURE', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('integration_and_automation', 'INTEGRATION AND AUTOMATION', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('mobile', 'MOBILE', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('cloud', 'CLOUD', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('runtimes', 'RUNTIMES', productList));
+    };
+    RHDPDownloadsApp.prototype.setPopularProducts = function (productList) {
+        this.popularProduct.productList = productList.products;
+        this.querySelector('.most-popular-downloads .row').appendChild(this.popularProduct);
+    };
+    RHDPDownloadsApp.prototype.downloadsAllFactory = function (id, heading, productList) {
+        var downloads = new RHDPDownloadsAll();
+        downloads.id = id;
+        downloads.heading = heading;
+        downloads.products = productList;
+        return downloads;
+    };
+    RHDPDownloadsApp.prototype.setProductsDownloadData = function (url) {
+        var _this = this;
+        fetch(url, { headers: 'application/json' })
+            .then(function (resp) { return resp.json(); })
+            .then(function (data) {
+            _this.products.data = data;
+            _this.setPopularProducts(_this.products);
+            _this.addGroups(_this.products);
+        });
+    };
+    Object.defineProperty(RHDPDownloadsApp, "observedAttributes", {
+        get: function () {
+            return ['url'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsApp.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPDownloadsApp;
+}(HTMLElement));
+var RHDPDownloadsPopularProduct = (function (_super) {
+    __extends(RHDPDownloadsPopularProduct, _super);
+    function RHDPDownloadsPopularProduct() {
+        var _this = _super.call(this) || this;
+        _this.template = function (strings, name, id, dataFallbackUrl, url) {
+            return "\n        <div class=\"large-6 column\">\n            <div class=\"popular-download-box\">\n                <h4>" + name + "</h4>\n                <a class=\"button heavy-cta\" data-download-id=\"" + id + "\" data-fallback-url=\"" + dataFallbackUrl + "\" href=\"" + url + "\"><i class=\"fa fa-download\"></i> Download</a>\n            </div>\n        </div>";
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPDownloadsPopularProduct.prototype, "name", {
+        get: function () {
+            return this._name;
+        },
+        set: function (value) {
+            if (this._name === value)
+                return;
+            this._name = value;
+            this.setAttribute('name', this.name);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsPopularProduct.prototype, "productId", {
+        get: function () {
+            return this._productId;
+        },
+        set: function (value) {
+            if (this.productId === value)
+                return;
+            this._productId = value;
+            this.setAttribute('productid', this.productId);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsPopularProduct.prototype, "dataFallbackUrl", {
+        get: function () {
+            return this._dataFallbackUrl;
+        },
+        set: function (value) {
+            if (this.dataFallbackUrl === value)
+                return;
+            this._dataFallbackUrl = value;
+            this.setAttribute('datafallbackurl', this.dataFallbackUrl);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsPopularProduct.prototype, "downloadUrl", {
+        get: function () {
+            return this._downloadUrl;
+        },
+        set: function (value) {
+            if (this.downloadUrl === value)
+                return;
+            this._downloadUrl = value;
+            this.setAttribute('downloadurl', this.downloadUrl);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsPopularProduct.prototype.connectedCallback = function () {
+        this.innerHTML = (_a = ["", "", "", "", ""], _a.raw = ["", "", "", "", ""], this.template(_a, this.name, this.productId, this.dataFallbackUrl, this.downloadUrl));
+        var _a;
+    };
+    Object.defineProperty(RHDPDownloadsPopularProduct, "observedAttributes", {
+        get: function () {
+            return ['name', 'productid', 'downloadurl', 'datafallbackurl'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsPopularProduct.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPDownloadsPopularProduct;
+}(HTMLElement));
+var RHDPDownloadsPopularProducts = (function (_super) {
+    __extends(RHDPDownloadsPopularProducts, _super);
+    function RHDPDownloadsPopularProducts() {
+        return _super.call(this) || this;
+    }
+    Object.defineProperty(RHDPDownloadsPopularProducts.prototype, "productList", {
+        get: function () {
+            return this._productList;
+        },
+        set: function (value) {
+            if (this._productList === value)
+                return;
+            this._productList = value;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsPopularProducts.prototype.addProduct = function (product) {
+        var productNode = new RHDPDownloadsPopularProduct();
+        productNode.name = product.productName;
+        productNode.productId = product.productCode;
+        productNode.dataFallbackUrl = product.dataFallbackUrl;
+        productNode.downloadUrl = product.downloadLink;
+        this.appendChild(productNode);
+    };
+    RHDPDownloadsPopularProducts.prototype.renderProductList = function () {
+        // Set instance variable productList to the overall productList returned from download-manager
+        // If the product is popular, append it, else: forget about it.
+        if (this.productList.products) {
+            var products = this.productList.products;
+            var len = products.length;
+            for (var i = 0; i < len; i++) {
+                if (products[i].featured) {
+                    this.addProduct(products[i]);
+                }
+            }
+        }
+    };
+    RHDPDownloadsPopularProducts.prototype.connectedCallback = function () {
+        this.renderProductList();
+    };
+    RHDPDownloadsPopularProducts.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    return RHDPDownloadsPopularProducts;
+}(HTMLElement));
+var RHDPDownloadsProducts = (function (_super) {
+    __extends(RHDPDownloadsProducts, _super);
+    function RHDPDownloadsProducts() {
+        var _this = _super.call(this) || this;
+        _this._products = {
+            "products": [{
+                    "productName": "Red Hat JBoss Data Grid",
+                    "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+                    "productCode": "datagrid",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "An in-memory data grid to accelerate performance that is fast, distributed, scalable, and independent from the data tier.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/datagrid/overview/"
+                }, {
+                    "productName": "Red Hat JBoss Enterprise Application Platform",
+                    "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+                    "productCode": "eap",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "An innovative, modular, cloud-ready application platform that addresses management, automation and developer productivity.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/eap/overview/"
+                }, {
+                    "productName": "Red Hat JBoss Web Server",
+                    "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+                    "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+                    "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
+                }, {
+                    "productName": "Red Hat Application Migration Toolkit",
+                    "groupHeading": "DEVELOPER TOOLS",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads",
+                    "downloadLink": "https://access.redhat.com/downloads",
+                    "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
+                }, {
+                    "productName": "Red Hat Container Development Kit",
+                    "groupHeading": "DEVELOPER TOOLS",
+                    "productCode": "cdk",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads/content/293/",
+                    "downloadLink": "",
+                    "description": "For container development, includes RHEL and OpenShift 3.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/cdk/overview/"
+                }, {
+                    "productName": "Red Hat Development Suite",
+                    "groupHeading": "DEVELOPER TOOLS",
+                    "productCode": "devsuite",
+                    "featured": true,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads",
+                    "downloadLink": "",
+                    "description": "A fully integrated development environment for modern enterprise development.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/devsuite/overview/"
+                }, {
+                    "productName": "Red Hat JBoss Developer Studio",
+                    "groupHeading": "DEVELOPER TOOLS",
+                    "productCode": "devstudio",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jbossdeveloperstudio&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "An Eclipse-based IDE to create apps for web, mobile, transactional enterprise, and SOA-based integration apps/services.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/devstudio/overview/"
+                }, {
+                    "productName": "Red Hat Enterprise Linux",
+                    "groupHeading": "INFRASTRUCTURE",
+                    "productCode": "rhel",
+                    "featured": true,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads/content/69/",
+                    "downloadLink": "",
+                    "description": "For traditional development, includes Software Collections and Developer Toolset.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/rhel/overview/"
+                }, {
+                    "productName": "Red Hat JBoss AMQ",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "amq",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "A small-footprint, performant, robust messaging platform that enables real-time app, device, and service integration.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/amq/overview/"
+                }, {
+                    "productName": "Red Hat JBoss BRMS",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "brms",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=brms&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "A programming platform to easily capture and maintain rules for business changes, without impacting static applications.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/brms/overview/"
+                }, {
+                    "productName": "Red Hat JBoss BPM Suite",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "bpmsuite",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=bpm.suite&productChanged=yes",
+                    "downloadLink": "",
+                    "description": "A platform that combines business rules and process management (BPM), and complex event processing.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/bpmsuite/overview/"
+                }, {
+                    "productName": "Red Hat JBoss Data Virtualization",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "datavirt",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+                }, {
+                    "productName": "Red Hat JBoss Fuse",
+                    "groupHeading": "INTEGRATION AND AUTOMATION",
+                    "productCode": "fuse",
+                    "featured": true,
+                    "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.fuse&downloadType=distributions",
+                    "downloadLink": "",
+                    "description": "A small-footprint enterprise service bus (ESB) that lets you build, deploy and integrate applications and services.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/fuse/overview/"
+                }, {
+                    "productName": "Red Hat Mobile Application Platform",
+                    "groupHeading": "MOBILE",
+                    "featured": true,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
+                    "downloadLink": "https://access.redhat.com/downloads/content/316/",
+                    "description": "Develop and deploy mobile apps in an agile and flexible manner.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"
+                }, {
+                    "productName": "Red Hat OpenShift Container Platform",
+                    "groupHeading": "CLOUD",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads/content/290/",
+                    "downloadLink": "https://access.redhat.com/downloads/content/290/",
+                    "description": "An open, hybrid Platform-as-a-Service (PaaS) to quickly develop, host, scale, and deliver apps in the cloud.",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/openshift/overview/"
+                }, {
+                    "productName": "OpenJDK",
+                    "groupHeading": "RUNTIMES",
+                    "productCode": "openjdk",
+                    "featured": false,
+                    "dataFallbackUrl": "https://developers.redhat.com/products/openjdk/overview/",
+                    "downloadLink": "",
+                    "description": "A Tried, Tested and Trusted open source implementation of the Java platform",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/openjdk/overview/"
+                }, {
+                    "productName": ".NET Core for Red Hat Enterprise Linux",
+                    "groupHeading": "RUNTIMES",
+                    "productCode": "dotnet",
+                    "featured": false,
+                    "dataFallbackUrl": "https://access.redhat.com/downloads",
+                    "downloadLink": "",
+                    "description": "Build and run cross-platform .NET applications on the world’s number one Enterprise-ready Linux Distribution, Red Hat Enterprise Linux",
+                    "version": "",
+                    "learnMoreLink": "https://developers.redhat.com/products/dotnet/overview/"
+                }]
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPDownloadsProducts.prototype, "category", {
+        get: function () {
+            return this._category;
+        },
+        set: function (value) {
+            if (this._category === value)
+                return;
+            this._category = value;
+            this.setAttribute('category', this._category);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsProducts.prototype, "products", {
+        get: function () {
+            return this._products;
+        },
+        set: function (value) {
+            if (this._products === value)
+                return;
+            this._products = value;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPDownloadsProducts.prototype, "data", {
+        get: function () {
+            return this._data;
+        },
+        set: function (value) {
+            if (this._data === value)
+                return;
+            this._data = value;
+            this.setAttribute('data', this._data);
+            this._createProductList();
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPDownloadsProducts.prototype._createProductList = function () {
+        var tempProductList = { "products": [] };
+        if (this._data) {
+            var productLen = this.products.products.length;
+            var dataLen = this.data.length;
+            for (var i = 0; i < productLen; i++) {
+                var product = this.products.products[i];
+                for (var j = 0; j < dataLen; j++) {
+                    var data = this.data[j];
+                    if (data['productCode'] == product['productCode']) {
+                        this.products.products[i]['downloadLink'] = data['featuredArtifact']['url'];
+                        this.products.products[i]['version'] = data['featuredArtifact']['versionName'];
+                    }
+                }
+                tempProductList['products'].push(product);
+            }
+        }
+        this.products = tempProductList;
+    };
+    return RHDPDownloadsProducts;
+}(HTMLElement));
+window.addEventListener('WebComponentsReady', function () {
+    customElements.define('rhdp-downloads-all-item', RHDPDownloadsAllItem);
+    customElements.define('rhdp-downloads-all', RHDPDownloadsAll);
+    customElements.define('rhdp-downloads-popular-product', RHDPDownloadsPopularProduct);
+    customElements.define('rhdp-downloads-popular-products', RHDPDownloadsPopularProducts);
+    customElements.define('rhdp-downloads-products', RHDPDownloadsProducts);
+    customElements.define('rhdp-downloads-app', RHDPDownloadsApp);
+});
 var RHDPSearchBox = (function (_super) {
     __extends(RHDPSearchBox, _super);
     function RHDPSearchBox() {

--- a/stylesheets/_downloads.scss
+++ b/stylesheets/_downloads.scss
@@ -50,7 +50,7 @@ h3.downloads-header {
     p {
       margin: 0;
     }
-    .category-label + .row hr {
+    .category-label + rhdp-downloads-all-item .row hr {
       display: none;
     }
     hr {

--- a/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
@@ -101,7 +101,7 @@ class RHDPDownloadsAllItem extends HTMLElement {
             
                 <div class="large-9 center columns">
                 
-                  ${version ? `<p data-download-id-version="${productId}">Version: ${version}</p>` : `<p data-download-id-version="${productId}"></p>`}  
+                  ${version ? `<p data-download-id-version="${productId}">Version: ${version}</p>` : `<p data-download-id-version="${productId}">&nbsp;</p>`}  
                 </div>
             
                 <div class="large-5 columns"><a class="button medium-cta blue" data-download-id="${productId}"

--- a/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
@@ -112,7 +112,7 @@ class RHDPDownloadsAllItem extends HTMLElement {
     };
 
     connectedCallback() {
-        this.innerHTML = this.template`${this.name}${this.productId}${this.dataFallbackUrl}${this.downloadUrl}${this.learnMore}${this.description}${this.version}`;
+        this.innerHTML =this.template`${this.name}${this.productId}${this.dataFallbackUrl}${this.downloadUrl}${this.learnMore}${this.description}${this.version}`;
     }
 
     static get observedAttributes() {

--- a/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
@@ -1,0 +1,126 @@
+class RHDPDownloadsAllItem extends HTMLElement {
+
+
+    private _name;
+    private _productId;
+    private _dataFallbackUrl;
+    private _downloadUrl;
+    private _description;
+    private _learnMore;
+    private _version;
+
+    constructor() {
+        super();
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    set name(value) {
+        if (this._name === value) return;
+        this._name = value;
+        this.setAttribute('name', this.name);
+    }
+
+    get productId() {
+
+        return this._productId;
+
+    }
+
+    set productId(value) {
+        if (this.productId === value) return;
+        this._productId = value;
+        this.setAttribute('productid', this._productId);
+
+    }
+
+    get dataFallbackUrl() {
+        return this._dataFallbackUrl;
+    }
+
+    set dataFallbackUrl(value) {
+        if (this.dataFallbackUrl === value) return;
+        this._dataFallbackUrl = value;
+        this.setAttribute('datafallbackurl', this._dataFallbackUrl);
+    }
+
+    get downloadUrl() {
+        return this._downloadUrl;
+    }
+
+    set downloadUrl(value) {
+        if (this.downloadUrl === value) return;
+        this._downloadUrl = value;
+        this.setAttribute('downloadurl', this._downloadUrl);
+    }
+
+    get description() {
+        return this._description;
+    }
+
+    set description(value) {
+        this._description = value;
+        this.setAttribute('description', this._description);
+    }
+
+    get learnMore() {
+        return this._learnMore;
+    }
+
+    set learnMore(value) {
+        this._learnMore = value;
+        this.setAttribute('learnmore', this._learnMore);
+    }
+
+    get version() {
+        return this._version;
+    }
+
+    set version(value) {
+        this._version = value;
+        this.setAttribute('version', this._version);
+    }
+
+    template = (strings, name, productId, dataFallbackUrl, downloadUrl, learnMore, description, version) => {
+        return `
+            <div class="row">
+                <hr>
+                <div class="large-24 column">
+                    <h5>${name}</h5>
+                </div>
+            
+                <div class="large-10 columns">
+                    <p></p>
+            
+                    <div class="paragraph">
+                        <p>${description}</p>
+                    </div>
+                    <a href="${learnMore}">Learn More</a></div>
+            
+                <div class="large-9 center columns">
+                
+                  ${version ? `<p data-download-id-version="${productId}">Version: ${version}</p>` : `<p data-download-id-version="${productId}"></p>`}  
+                </div>
+            
+                <div class="large-5 columns"><a class="button medium-cta blue" data-download-id="${productId}"
+                                                data-fallback-url="${dataFallbackUrl}"
+                                                href="${downloadUrl}">Download</a></div>
+            </div>
+`;
+    };
+
+    connectedCallback() {
+        this.innerHTML = this.template`${this.name}${this.productId}${this.dataFallbackUrl}${this.downloadUrl}${this.learnMore}${this.description}${this.version}`;
+    }
+
+    static get observedAttributes() {
+        return ['name'];
+    }
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads-all.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all.ts
@@ -1,0 +1,80 @@
+class RHDPDownloadsAll extends HTMLElement {
+
+
+    private _id;
+    private _heading;
+    private _products;
+
+    constructor() {
+        super();
+    }
+
+    get id() {
+        return this._id;
+    }
+
+    set id(value) {
+        this._id = value;
+        this.setAttribute('id', this._id);
+    }
+
+    get heading() {
+        return this._heading;
+    }
+
+    set heading(value) {
+        this._heading = value;
+        this.setAttribute('heading', this._heading);
+
+    }
+
+    get products() {
+        return this._products;
+    }
+
+    set products(value) {
+        this._products = value;
+    }
+
+    template = (strings, id, heading) => {
+        return `<div class="download-list">
+                    <div class="large-24 category-label" id="${id}">
+                        <h4>${heading}</h4>
+                    </div>
+                </div>
+                `; };
+
+    connectedCallback() {
+        this.innerHTML = this.template`${this.id}${this.heading}`;
+        this.getProductsWithTargetHeading(this.products)
+    }
+
+    getProductsWithTargetHeading(productList) {
+        if (productList.products) {
+            let products = productList.products.products;
+            let len = products.length;
+
+            for (let i = 0; i < len; i++) {
+                if (products[i].groupHeading === this.heading) {
+                    let item = new RHDPDownloadsAllItem();
+                    item.name = products[i].productName;
+                    item.productId = products[i].productCode ? products[i].productCode : "";
+                    item.dataFallbackUrl = products[i].dataFallbackUrl ? products[i].dataFallbackUrl : "";
+                    item.downloadUrl = products[i].downloadLink ? products[i].downloadLink : "";
+                    item.description = products[i].description ? products[i].description : "";
+                    item.learnMore = products[i].learnMoreLink ? products[i].learnMoreLink : "";
+                    item.version = products[i].version ? products[i].version : "";
+                    this.appendChild(item);
+                }
+            }
+        }
+    }
+    // static get observedAttributes() {
+    //     return ['id'];
+    // }
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads-all.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all.ts
@@ -64,7 +64,7 @@ class RHDPDownloadsAll extends HTMLElement {
                     item.description = products[i].description ? products[i].description : "";
                     item.learnMore = products[i].learnMoreLink ? products[i].learnMoreLink : "";
                     item.version = products[i].version ? products[i].version : "";
-                    this.appendChild(item);
+                    this.querySelector('.download-list').appendChild(item);
                 }
             }
         }

--- a/typescript/rhdp-downloads/rhdp-downloads-all.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all.ts
@@ -14,6 +14,7 @@ class RHDPDownloadsAll extends HTMLElement {
     }
 
     set id(value) {
+        if (this.id === value) return;
         this._id = value;
         this.setAttribute('id', this._id);
     }
@@ -23,6 +24,7 @@ class RHDPDownloadsAll extends HTMLElement {
     }
 
     set heading(value) {
+        if (this.heading === value) return;
         this._heading = value;
         this.setAttribute('heading', this._heading);
 
@@ -33,6 +35,7 @@ class RHDPDownloadsAll extends HTMLElement {
     }
 
     set products(value) {
+        if (this.products === value) return;
         this._products = value;
     }
 
@@ -69,9 +72,9 @@ class RHDPDownloadsAll extends HTMLElement {
             }
         }
     }
-    // static get observedAttributes() {
-    //     return ['id'];
-    // }
+    static get observedAttributes() {
+        return ['id', 'heading'];
+    }
 
     attributeChangedCallback(name, oldVal, newVal) {
         this[name] = newVal;

--- a/typescript/rhdp-downloads/rhdp-downloads-app.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-app.ts
@@ -3,8 +3,7 @@ class RHDPDownloadsApp extends HTMLElement {
         super();
     }
 
-    _url = 'https://developers.redhat.com/download-manager/rest/available/rhel,eap,devstudio,fuse,datagrid,eap,webserver,cdk,devsuite,amq,brms,bpmsuite,datavirt,mobileplatform,openshift,openjdk,dotnet?nv=1';
-    // _url;
+    _url;
 
     popularProduct = new RHDPDownloadsPopularProducts();
     products = new RHDPDownloadsProducts();
@@ -47,12 +46,11 @@ class RHDPDownloadsApp extends HTMLElement {
 
     connectedCallback() {
         this.innerHTML = this.template;
-        this.querySelector('.most-popular-downloads .row').appendChild(this.popularProduct);
         this.setProductsDownloadData(this.url);
 
     }
 
-    addGroupHeadings(productList){
+    addGroups(productList){
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('accelerated_development_and_management','ACCELERATED DEVELOPMENT AND MANAGEMENT', productList));
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('developer_tools','DEVELOPER TOOLS', productList));
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('infrastructure','INFRASTRUCTURE', productList));
@@ -60,6 +58,12 @@ class RHDPDownloadsApp extends HTMLElement {
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('mobile','MOBILE', productList));
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('cloud','CLOUD', productList));
         this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('runtimes','RUNTIMES', productList));
+
+    }
+
+    setPopularProducts(productList){
+        this.popularProduct.productList = productList.products;
+        this.querySelector('.most-popular-downloads .row').appendChild(this.popularProduct);
 
     }
 
@@ -77,12 +81,14 @@ class RHDPDownloadsApp extends HTMLElement {
             .then((resp) => resp.json())
             .then((data) => {
                 this.products.data = data;
-                this.addGroupHeadings(this.products);
+                this.setPopularProducts(this.products);
+                this.addGroups(this.products);
+
             });
     }
 
     static get observedAttributes() { 
-        return ['url', 'name']; 
+        return ['url'];
     }
 
     attributeChangedCallback(name, oldVal, newVal) {

--- a/typescript/rhdp-downloads/rhdp-downloads-app.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-app.ts
@@ -1,0 +1,92 @@
+class RHDPDownloadsApp extends HTMLElement {
+    constructor() {
+        super();
+    }
+
+    _url = 'https://developers.redhat.com/download-manager/rest/available/rhel,eap,devstudio,fuse,datagrid,eap,webserver,cdk,devsuite,amq,brms,bpmsuite,datavirt,mobileplatform,openshift,openjdk,dotnet?nv=1';
+    // _url;
+
+    popularProduct = new RHDPDownloadsPopularProducts();
+    products = new RHDPDownloadsProducts();
+
+    get url() {
+        return this._url;
+    }
+
+
+    set url(val) {
+        if (this._url === val) return;
+        this._url = val;
+        this.setAttribute('url', this.url);
+    }
+
+    template = `<div class="hero hero-wide hero-downloads">
+                    <div class="row">
+                        <div class="large-12 medium-24 columns" id="downloads">
+                            <h2>Downloads</h2>
+                        </div>
+                    </div>
+                </div>
+                <div class="most-popular-downloads">
+                    <div class="row">
+                        <div class="large-24 column">
+                            <h3>Most Popular</h3>
+                        </div>
+                    </div>
+                
+                    <div class="row">
+                    </div>
+                </div>
+                <div class="row" id="downloads">
+                    <div class="large-24 columns">
+                        <h3 class="downloads-header">All Downloads</h3>
+                    </div>
+                </div>`;
+
+
+
+    connectedCallback() {
+        this.innerHTML = this.template;
+        this.querySelector('.most-popular-downloads .row').appendChild(this.popularProduct);
+        this.setProductsDownloadData(this.url);
+
+    }
+
+    addGroupHeadings(productList){
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('accelerated_development_and_management','ACCELERATED DEVELOPMENT AND MANAGEMENT', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('developer_tools','DEVELOPER TOOLS', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('infrastructure','INFRASTRUCTURE', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('integration_and_automation','INTEGRATION AND AUTOMATION', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('mobile','MOBILE', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('cloud','CLOUD', productList));
+        this.querySelector('#downloads .large-24').appendChild(this.downloadsAllFactory('runtimes','RUNTIMES', productList));
+
+    }
+
+    downloadsAllFactory(id, heading, productList){
+        var downloads = new RHDPDownloadsAll();
+        downloads.id = id;
+        downloads.heading = heading;
+        downloads.products = productList;
+
+        return downloads;
+    }
+
+    setProductsDownloadData(url) {
+        fetch(url, {headers : 'application/json'})
+            .then((resp) => resp.json())
+            .then((data) => {
+                this.products.data = data;
+                this.addGroupHeadings(this.products);
+            });
+    }
+
+    static get observedAttributes() { 
+        return ['url', 'name']; 
+    }
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads-popular-product.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-popular-product.ts
@@ -1,0 +1,77 @@
+class RHDPDownloadsPopularProduct extends HTMLElement {
+
+    private _name;
+    private _productId;
+    private _dataFallbackUrl;
+    private _downloadUrl;
+
+    get name() {
+        return this._name;
+    }
+
+    set name(value) {
+        if (this._name === value) return;
+        this._name = value;
+        this.setAttribute('name', this.name)
+    }
+
+    get productId() {
+
+        return this._productId;
+
+    }
+
+    set productId(value) {
+        if (this.productId === value) return;
+        this._productId = value;
+        this.setAttribute('productid', this.productId)
+
+    }
+
+    get dataFallbackUrl() {
+        return this._dataFallbackUrl;
+    }
+
+    set dataFallbackUrl(value) {
+        if (this.dataFallbackUrl === value) return;
+        this._dataFallbackUrl = value;
+        this.setAttribute('datafallbackurl', this.dataFallbackUrl)
+    }
+
+    get downloadUrl() {
+        return this._downloadUrl;
+    }
+
+    set downloadUrl(value) {
+        if (this.downloadUrl === value) return;
+        this._downloadUrl = value;
+        this.setAttribute('downloadurl', this.downloadUrl)
+    }
+
+    constructor() {
+        super();
+    }
+
+    template = (strings, name, id, dataFallbackUrl, url) => {
+        return `
+        <div class="large-6 column">
+            <div class="popular-download-box">
+                <h4>${name}</h4>
+                <a class="button heavy-cta" data-download-id="${id}" data-fallback-url="${dataFallbackUrl}" href="${url}"><i class="fa fa-download"></i> Download</a>
+            </div>
+        </div>`;
+    };
+
+    connectedCallback() {
+        this.innerHTML = this.template`${this.name}${this.productId}${this.dataFallbackUrl}${this.downloadUrl}`;
+    }
+
+    static get observedAttributes() {
+        return ['name'];
+    }
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads-popular-product.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-popular-product.ts
@@ -16,9 +16,7 @@ class RHDPDownloadsPopularProduct extends HTMLElement {
     }
 
     get productId() {
-
         return this._productId;
-
     }
 
     set productId(value) {
@@ -67,7 +65,7 @@ class RHDPDownloadsPopularProduct extends HTMLElement {
     }
 
     static get observedAttributes() {
-        return ['name'];
+        return ['name','productid','downloadurl','datafallbackurl'];
     }
 
     attributeChangedCallback(name, oldVal, newVal) {

--- a/typescript/rhdp-downloads/rhdp-downloads-popular-products.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-popular-products.ts
@@ -13,7 +13,6 @@ class RHDPDownloadsPopularProducts extends HTMLElement {
     set productList(value) {
         if (this._productList === value) return;
         this._productList = value;
-        this.setAttribute('productlist', this.productList)
 
     }
 
@@ -22,15 +21,14 @@ class RHDPDownloadsPopularProducts extends HTMLElement {
 
         productNode.name = product.productName;
         productNode.productId = product.productCode;
-        productNode.dataFallbackUrl = product.dataFallbackURL;
+        productNode.dataFallbackUrl = product.dataFallbackUrl;
         productNode.downloadUrl = product.downloadLink;
         this.appendChild(productNode);
     }
 
-    renderProductList(productList){
+    renderProductList(){
         // Set instance variable productList to the overall productList returned from download-manager
         // If the product is popular, append it, else: forget about it.
-        this.productList = productList.products;
         if(this.productList.products){
             let products = this.productList.products;
             let len = products.length;
@@ -44,7 +42,7 @@ class RHDPDownloadsPopularProducts extends HTMLElement {
     }
 
     connectedCallback() {
-        this.renderProductList(new RHDPDownloadsProducts());
+        this.renderProductList();
 
     }
 

--- a/typescript/rhdp-downloads/rhdp-downloads-popular-products.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-popular-products.ts
@@ -1,0 +1,57 @@
+class RHDPDownloadsPopularProducts extends HTMLElement {
+
+    private _productList;
+
+    constructor() {
+        super();
+    }
+
+    get productList() {
+        return this._productList;
+    }
+
+    set productList(value) {
+        if (this._productList === value) return;
+        this._productList = value;
+        this.setAttribute('productlist', this.productList)
+
+    }
+
+    addProduct(product){
+        var productNode = new RHDPDownloadsPopularProduct();
+
+        productNode.name = product.productName;
+        productNode.productId = product.productCode;
+        productNode.dataFallbackUrl = product.dataFallbackURL;
+        productNode.downloadUrl = product.downloadLink;
+        this.appendChild(productNode);
+    }
+
+    renderProductList(productList){
+        // Set instance variable productList to the overall productList returned from download-manager
+        // If the product is popular, append it, else: forget about it.
+        this.productList = productList.products;
+        if(this.productList.products){
+            let products = this.productList.products;
+            let len = products.length;
+            for (let i = 0; i < len; i++){
+                if(products[i].featured){
+                    this.addProduct(products[i])
+                }
+            }
+        }
+
+    }
+
+    connectedCallback() {
+        this.renderProductList(new RHDPDownloadsProducts());
+
+    }
+
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads-products.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-products.ts
@@ -1,176 +1,176 @@
 class RHDPDownloadsProducts extends HTMLElement {
     private _category;
-    // _products = {
-    //     "products": [{
-    //         "productName": "Red Hat JBoss Data Grid",
-    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
-    //         "productCode": "datagrid",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "An in-memory data grid to accelerate performance that is fast, distributed, scalable, and independent from the data tier.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/datagrid/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss Enterprise Application Platform",
-    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
-    //         "productCode": "eap",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "An innovative, modular, cloud-ready application platform that addresses management, automation and developer productivity.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/eap/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss Web Server",
-    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
-    //         "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
-    //         "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
-    //     }, {
-    //         "productName": "Red Hat Application Migration Toolkit",
-    //         "groupHeading": "DEVELOPER TOOLS",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
-    //         "downloadLink": "https://access.redhat.com/downloads",
-    //         "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
-    //     }, {
-    //         "productName": "Red Hat Container Development Kit",
-    //         "groupHeading": "DEVELOPER TOOLS",
-    //         "productCode": "cdk",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/293/",
-    //         "downloadLink": "",
-    //         "description": "For container development, includes RHEL and OpenShift 3.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/cdk/overview/"
-    //     }, {
-    //         "productName": "Red Hat Development Suite",
-    //         "groupHeading": "DEVELOPER TOOLS",
-    //         "productCode": "devsuite",
-    //         "featured": true,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
-    //         "downloadLink": "",
-    //         "description": "A fully integrated development environment for modern enterprise development.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/devsuite/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss Developer Studio",
-    //         "groupHeading": "DEVELOPER TOOLS",
-    //         "productCode": "devstudio",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jbossdeveloperstudio&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "An Eclipse-based IDE to create apps for web, mobile, transactional enterprise, and SOA-based integration apps/services.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/devstudio/overview/"
-    //     }, {
-    //         "productName": "Red Hat Enterprise Linux",
-    //         "groupHeading": "INFRASTRUCTURE",
-    //         "productCode": "rhel",
-    //         "featured": true,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/69/",
-    //         "downloadLink": "",
-    //         "description": "For traditional development, includes Software Collections and Developer Toolset.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/rhel/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss AMQ",
-    //         "groupHeading": "INTEGRATION AND AUTOMATION",
-    //         "productCode": "amq",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "A small-footprint, performant, robust messaging platform that enables real-time app, device, and service integration.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/amq/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss BRMS",
-    //         "groupHeading": "INTEGRATION AND AUTOMATION",
-    //         "productCode": "brms",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=brms&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "A programming platform to easily capture and maintain rules for business changes, without impacting static applications.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/brms/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss BPM Suite",
-    //         "groupHeading": "INTEGRATION AND AUTOMATION",
-    //         "productCode": "bpmsuite",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=bpm.suite&productChanged=yes",
-    //         "downloadLink": "",
-    //         "description": "A platform that combines business rules and process management (BPM), and complex event processing.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/bpmsuite/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss Data Virtualization",
-    //         "groupHeading": "INTEGRATION AND AUTOMATION",
-    //         "productCode": "datavirt",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
-    //     }, {
-    //         "productName": "Red Hat JBoss Fuse",
-    //         "groupHeading": "INTEGRATION AND AUTOMATION",
-    //         "productCode": "fuse",
-    //         "featured": true,
-    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.fuse&downloadType=distributions",
-    //         "downloadLink": "",
-    //         "description": "A small-footprint enterprise service bus (ESB) that lets you build, deploy and integrate applications and services.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/fuse/overview/"
-    //     }, {
-    //         "productName": "Red Hat Mobile Application Platform",
-    //         "groupHeading": "MOBILE",
-    //         "featured": true,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
-    //         "downloadLink": "https://access.redhat.com/downloads/content/316/",
-    //         "description": "Develop and deploy mobile apps in an agile and flexible manner.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"
-    //     }, {
-    //         "productName": "Red Hat OpenShift Container Platform",
-    //         "groupHeading": "CLOUD",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/290/",
-    //         "downloadLink": "https://access.redhat.com/downloads/content/290/",
-    //         "description": "An open, hybrid Platform-as-a-Service (PaaS) to quickly develop, host, scale, and deliver apps in the cloud.",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/openshift/overview/"
-    //     }, {
-    //         "productName": "OpenJDK",
-    //         "groupHeading": "RUNTIMES",
-    //         "productCode": "openjdk",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://developers.redhat.com/products/openjdk/overview/",
-    //         "downloadLink": "",
-    //         "description": "A Tried, Tested and Trusted open source implementation of the Java platform",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/openjdk/overview/"
-    //     }, {
-    //         "productName": ".NET Core for Red Hat Enterprise Linux",
-    //         "groupHeading": "RUNTIMES",
-    //         "productCode": "dotnet",
-    //         "featured": false,
-    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
-    //         "downloadLink": "",
-    //         "description": "Build and run cross-platform .NET applications on the world’s number one Enterprise-ready Linux Distribution, Red Hat Enterprise Linux",
-    //         "version": "",
-    //         "learnMoreLink": "https://developers.redhat.com/products/dotnet/overview/"
-    //     }]
-    // };
+    _products = {
+        "products": [{
+            "productName": "Red Hat JBoss Data Grid",
+            "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+            "productCode": "datagrid",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions",
+            "downloadLink": "",
+            "description": "An in-memory data grid to accelerate performance that is fast, distributed, scalable, and independent from the data tier.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/datagrid/overview/"
+        }, {
+            "productName": "Red Hat JBoss Enterprise Application Platform",
+            "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+            "productCode": "eap",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions",
+            "downloadLink": "",
+            "description": "An innovative, modular, cloud-ready application platform that addresses management, automation and developer productivity.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/eap/overview/"
+        }, {
+            "productName": "Red Hat JBoss Web Server",
+            "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+            "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+            "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
+        }, {
+            "productName": "Red Hat Application Migration Toolkit",
+            "groupHeading": "DEVELOPER TOOLS",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/downloads",
+            "downloadLink": "https://access.redhat.com/downloads",
+            "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
+        }, {
+            "productName": "Red Hat Container Development Kit",
+            "groupHeading": "DEVELOPER TOOLS",
+            "productCode": "cdk",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/downloads/content/293/",
+            "downloadLink": "",
+            "description": "For container development, includes RHEL and OpenShift 3.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/cdk/overview/"
+        }, {
+            "productName": "Red Hat Development Suite",
+            "groupHeading": "DEVELOPER TOOLS",
+            "productCode": "devsuite",
+            "featured": true,
+            "dataFallbackUrl": "https://access.redhat.com/downloads",
+            "downloadLink": "",
+            "description": "A fully integrated development environment for modern enterprise development.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/devsuite/overview/"
+        }, {
+            "productName": "Red Hat JBoss Developer Studio",
+            "groupHeading": "DEVELOPER TOOLS",
+            "productCode": "devstudio",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jbossdeveloperstudio&downloadType=distributions",
+            "downloadLink": "",
+            "description": "An Eclipse-based IDE to create apps for web, mobile, transactional enterprise, and SOA-based integration apps/services.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/devstudio/overview/"
+        }, {
+            "productName": "Red Hat Enterprise Linux",
+            "groupHeading": "INFRASTRUCTURE",
+            "productCode": "rhel",
+            "featured": true,
+            "dataFallbackUrl": "https://access.redhat.com/downloads/content/69/",
+            "downloadLink": "",
+            "description": "For traditional development, includes Software Collections and Developer Toolset.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/rhel/overview/"
+        }, {
+            "productName": "Red Hat JBoss AMQ",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "amq",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq&downloadType=distributions",
+            "downloadLink": "",
+            "description": "A small-footprint, performant, robust messaging platform that enables real-time app, device, and service integration.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/amq/overview/"
+        }, {
+            "productName": "Red Hat JBoss BRMS",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "brms",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=brms&downloadType=distributions",
+            "downloadLink": "",
+            "description": "A programming platform to easily capture and maintain rules for business changes, without impacting static applications.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/brms/overview/"
+        }, {
+            "productName": "Red Hat JBoss BPM Suite",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "bpmsuite",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=bpm.suite&productChanged=yes",
+            "downloadLink": "",
+            "description": "A platform that combines business rules and process management (BPM), and complex event processing.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/bpmsuite/overview/"
+        }, {
+            "productName": "Red Hat JBoss Data Virtualization",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "datavirt",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
+            "downloadLink": "",
+            "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+        }, {
+            "productName": "Red Hat JBoss Fuse",
+            "groupHeading": "INTEGRATION AND AUTOMATION",
+            "productCode": "fuse",
+            "featured": true,
+            "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.fuse&downloadType=distributions",
+            "downloadLink": "",
+            "description": "A small-footprint enterprise service bus (ESB) that lets you build, deploy and integrate applications and services.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/fuse/overview/"
+        }, {
+            "productName": "Red Hat Mobile Application Platform",
+            "groupHeading": "MOBILE",
+            "featured": true,
+            "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
+            "downloadLink": "https://access.redhat.com/downloads/content/316/",
+            "description": "Develop and deploy mobile apps in an agile and flexible manner.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"
+        }, {
+            "productName": "Red Hat OpenShift Container Platform",
+            "groupHeading": "CLOUD",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/downloads/content/290/",
+            "downloadLink": "https://access.redhat.com/downloads/content/290/",
+            "description": "An open, hybrid Platform-as-a-Service (PaaS) to quickly develop, host, scale, and deliver apps in the cloud.",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/openshift/overview/"
+        }, {
+            "productName": "OpenJDK",
+            "groupHeading": "RUNTIMES",
+            "productCode": "openjdk",
+            "featured": false,
+            "dataFallbackUrl": "https://developers.redhat.com/products/openjdk/overview/",
+            "downloadLink": "",
+            "description": "A Tried, Tested and Trusted open source implementation of the Java platform",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/openjdk/overview/"
+        }, {
+            "productName": ".NET Core for Red Hat Enterprise Linux",
+            "groupHeading": "RUNTIMES",
+            "productCode": "dotnet",
+            "featured": false,
+            "dataFallbackUrl": "https://access.redhat.com/downloads",
+            "downloadLink": "",
+            "description": "Build and run cross-platform .NET applications on the world’s number one Enterprise-ready Linux Distribution, Red Hat Enterprise Linux",
+            "version": "",
+            "learnMoreLink": "https://developers.redhat.com/products/dotnet/overview/"
+        }]
+    };
 
-    _products = '../rhdp-apps/downloads/products.json';
+    // _products = '../rhdp-apps/downloads/products.json';
 
     private _data;
 

--- a/typescript/rhdp-downloads/rhdp-downloads-products.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-products.ts
@@ -1,0 +1,236 @@
+class RHDPDownloadsProducts extends HTMLElement {
+    private _category;
+    // _products = {
+    //     "products": [{
+    //         "productName": "Red Hat JBoss Data Grid",
+    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+    //         "productCode": "datagrid",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.grid&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "An in-memory data grid to accelerate performance that is fast, distributed, scalable, and independent from the data tier.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/datagrid/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss Enterprise Application Platform",
+    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+    //         "productCode": "eap",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "An innovative, modular, cloud-ready application platform that addresses management, automation and developer productivity.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/eap/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss Web Server",
+    //         "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+    //         "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+    //         "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
+    //     }, {
+    //         "productName": "Red Hat Application Migration Toolkit",
+    //         "groupHeading": "DEVELOPER TOOLS",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
+    //         "downloadLink": "https://access.redhat.com/downloads",
+    //         "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
+    //     }, {
+    //         "productName": "Red Hat Container Development Kit",
+    //         "groupHeading": "DEVELOPER TOOLS",
+    //         "productCode": "cdk",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/293/",
+    //         "downloadLink": "",
+    //         "description": "For container development, includes RHEL and OpenShift 3.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/cdk/overview/"
+    //     }, {
+    //         "productName": "Red Hat Development Suite",
+    //         "groupHeading": "DEVELOPER TOOLS",
+    //         "productCode": "devsuite",
+    //         "featured": true,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
+    //         "downloadLink": "",
+    //         "description": "A fully integrated development environment for modern enterprise development.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/devsuite/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss Developer Studio",
+    //         "groupHeading": "DEVELOPER TOOLS",
+    //         "productCode": "devstudio",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jbossdeveloperstudio&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "An Eclipse-based IDE to create apps for web, mobile, transactional enterprise, and SOA-based integration apps/services.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/devstudio/overview/"
+    //     }, {
+    //         "productName": "Red Hat Enterprise Linux",
+    //         "groupHeading": "INFRASTRUCTURE",
+    //         "productCode": "rhel",
+    //         "featured": true,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/69/",
+    //         "downloadLink": "",
+    //         "description": "For traditional development, includes Software Collections and Developer Toolset.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/rhel/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss AMQ",
+    //         "groupHeading": "INTEGRATION AND AUTOMATION",
+    //         "productCode": "amq",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "A small-footprint, performant, robust messaging platform that enables real-time app, device, and service integration.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/amq/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss BRMS",
+    //         "groupHeading": "INTEGRATION AND AUTOMATION",
+    //         "productCode": "brms",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=brms&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "A programming platform to easily capture and maintain rules for business changes, without impacting static applications.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/brms/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss BPM Suite",
+    //         "groupHeading": "INTEGRATION AND AUTOMATION",
+    //         "productCode": "bpmsuite",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=bpm.suite&productChanged=yes",
+    //         "downloadLink": "",
+    //         "description": "A platform that combines business rules and process management (BPM), and complex event processing.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/bpmsuite/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss Data Virtualization",
+    //         "groupHeading": "INTEGRATION AND AUTOMATION",
+    //         "productCode": "datavirt",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=data.services.platform&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "A tool that brings operational and analytical insight from data dispersed in various business units, apps, and technologies.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/datavirt/overview/"
+    //     }, {
+    //         "productName": "Red Hat JBoss Fuse",
+    //         "groupHeading": "INTEGRATION AND AUTOMATION",
+    //         "productCode": "fuse",
+    //         "featured": true,
+    //         "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.fuse&downloadType=distributions",
+    //         "downloadLink": "",
+    //         "description": "A small-footprint enterprise service bus (ESB) that lets you build, deploy and integrate applications and services.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/fuse/overview/"
+    //     }, {
+    //         "productName": "Red Hat Mobile Application Platform",
+    //         "groupHeading": "MOBILE",
+    //         "featured": true,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
+    //         "downloadLink": "https://access.redhat.com/downloads/content/316/",
+    //         "description": "Develop and deploy mobile apps in an agile and flexible manner.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"
+    //     }, {
+    //         "productName": "Red Hat OpenShift Container Platform",
+    //         "groupHeading": "CLOUD",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads/content/290/",
+    //         "downloadLink": "https://access.redhat.com/downloads/content/290/",
+    //         "description": "An open, hybrid Platform-as-a-Service (PaaS) to quickly develop, host, scale, and deliver apps in the cloud.",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/openshift/overview/"
+    //     }, {
+    //         "productName": "OpenJDK",
+    //         "groupHeading": "RUNTIMES",
+    //         "productCode": "openjdk",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://developers.redhat.com/products/openjdk/overview/",
+    //         "downloadLink": "",
+    //         "description": "A Tried, Tested and Trusted open source implementation of the Java platform",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/openjdk/overview/"
+    //     }, {
+    //         "productName": ".NET Core for Red Hat Enterprise Linux",
+    //         "groupHeading": "RUNTIMES",
+    //         "productCode": "dotnet",
+    //         "featured": false,
+    //         "dataFallbackUrl": "https://access.redhat.com/downloads",
+    //         "downloadLink": "",
+    //         "description": "Build and run cross-platform .NET applications on the world’s number one Enterprise-ready Linux Distribution, Red Hat Enterprise Linux",
+    //         "version": "",
+    //         "learnMoreLink": "https://developers.redhat.com/products/dotnet/overview/"
+    //     }]
+    // };
+
+    _products = '../rhdp-apps/downloads/products.json';
+
+    private _data;
+
+    constructor() {
+        super();
+    }
+
+    get category() {
+        return this._category;
+    }
+
+    set category(value) {
+        if (this._category === value) return;
+        this._category = value;
+        this.setAttribute('category', this._category);
+
+    }
+
+    get products() {
+        return this._products;
+    }
+
+    set products(value) {
+        if(this._products === value) return;
+        this._products = value;
+    }
+
+    get data() {
+        return this._data;
+    }
+
+    set data(value) {
+        if (this._data === value) return;
+        this._data = value;
+        this.setAttribute('data', this._data);
+        this._createProductList();
+    }
+
+
+    _createProductList() {
+        let tempProductList = {"products" :[]};
+        if (this._data){
+            let productLen = this.products.products.length
+            let dataLen = this.data.length;
+            for (var i = 0; i < productLen; i++){
+                let product = this.products.products[i];
+                for (var j = 0; j < dataLen; j++){
+                    let data = this.data[j];
+                    if (data['productCode'] == product['productCode']){
+                        this.products.products[i]['downloadLink'] = data['featuredArtifact']['url'];
+                        this.products.products[i]['version'] = data['featuredArtifact']['versionName'];
+
+                    }
+                }
+                tempProductList['products'].push(product);
+            }
+        }
+        this.products = tempProductList;
+    }
+
+
+
+}

--- a/typescript/rhdp-downloads/rhdp-downloads.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads.ts
@@ -1,0 +1,8 @@
+window.addEventListener('WebComponentsReady', function() {
+    customElements.define('rhdp-downloads-all-item', RHDPDownloadsAllItem);
+    customElements.define('rhdp-downloads-all', RHDPDownloadsAll);
+    customElements.define('rhdp-downloads-popular-product', RHDPDownloadsPopularProduct);
+    customElements.define('rhdp-downloads-popular-products', RHDPDownloadsPopularProducts);
+    customElements.define('rhdp-downloads-products', RHDPDownloadsProducts);
+    customElements.define('rhdp-downloads-app', RHDPDownloadsApp);
+});


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3587

Currently, we have the download button show "fetching" while it is iterating through the api products and fetching them one by one. With the new download functionality, there is no need for that since it does a one-time bulk fetch.

Some thoughts though:

1.) What do we want displayed when download-manager is down? I know that we have an alert that shows outages; however, if nothing is displayed, it will just show "Popular Downloads" and "All Downloads"

![image](https://user-images.githubusercontent.com/938664/31640303-7c73076c-b292-11e7-973a-72f12ac657fe.png)

2.) Once this does get merged in, will the products.json be exported similar to onebox.json?