### PR TITLE
[HOLD] DEVELOPER-4477 Excludes DM links in pdf-links.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,7 +83,8 @@ var globs = {
         'javascripts/build.js',
         'javascripts/middleware-blog.js',
         'javascripts/scroll-to-top.js',
-        'javascripts/footer.js'
+        'javascripts/footer.js',
+        'javascripts/pdf-links.js'
     ],
     "styles": ['stylesheets/*.scss']
 };

--- a/javascripts/pdf-links.js
+++ b/javascripts/pdf-links.js
@@ -1,5 +1,17 @@
-// Opens in a new tab all links ending in .pdf extension
-$('a[href$=".pdf"]').click( function() {
-  window.open( $(this).attr('href') );
-  return false;
+// Opens in a new tab all (except Download Manager) links ending in .pdf extension
+$(document).ready(function() {
+  $("a[href$='.pdf'").each(function() {
+    
+    // Ignore DM links
+    var ignoredDomains = ['developers.redhat.com/download-manager/','jboss.org/download-manager/'];
+
+    for (i=0; i<ignoredDomains.length; i++) {
+      if (this.href.indexOf(ignoredDomains[i]) != -1) { return true; }
+    }
+    if (this.href.indexOf(location.hostname) == -1) {
+      $(this).click(function() { return true; });
+      $(this).attr({ target: "_blank" });
+      $(this).click();
+    }
+  })
 });


### PR DESCRIPTION
[DEVELOPER-4477 - "Bad Request" when attempting to download PDFs from the download manager](https://issues.jboss.org/browse/DEVELOPER-4477)

The script pdf-links.js should force all PDF links, except Download Manager links, to open in a new tab.

This PR excludes DM links to prevent the download flow from breaking.