### PR TITLE
DEVELOPER-3915 - Add to books REST API product definition

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.storage.node.field_published_date
     - field.storage.node.field_publisher
     - field.storage.node.field_pull_from_google
+    - field.storage.node.field_related_product
     - field.storage.node.field_thumbnail_url
     - field.storage.node.field_web_reader_url
     - node.type.books
@@ -976,6 +977,69 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_related_product:
+          id: field_related_product
+          table: node__field_related_product
+          field: field_related_product
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         status:
           value: '1'
@@ -1077,6 +1141,7 @@ display:
         - 'config:field.storage.node.field_published_date'
         - 'config:field.storage.node.field_publisher'
         - 'config:field.storage.node.field_pull_from_google'
+        - 'config:field.storage.node.field_related_product'
         - 'config:field.storage.node.field_thumbnail_url'
         - 'config:field.storage.node.field_web_reader_url'
   rest_export_1:
@@ -1143,6 +1208,9 @@ display:
             field_web_reader_url:
               alias: ''
               raw_output: true
+            field_related_product:
+              alias: ''
+              raw_output: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -1162,5 +1230,6 @@ display:
         - 'config:field.storage.node.field_published_date'
         - 'config:field.storage.node.field_publisher'
         - 'config:field.storage.node.field_pull_from_google'
+        - 'config:field.storage.node.field_related_product'
         - 'config:field.storage.node.field_thumbnail_url'
         - 'config:field.storage.node.field_web_reader_url'


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-3915

To review: 

* Add a "Related product" to a book and save (make sure book is published).
* Navigate to <base_pr_url>/drupal/books and notice that the related product should now be displayed in string format.

There is a separate pull request on DCP (https://github.com/searchisko/configuration/pull/102) that will pull the product in and display it as "sys_project" in search queries.
