### PR TITLE
[DEVELOPER-4515] Ensure export does not re-write .pdf and .epub documentation links

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -24,6 +24,7 @@ class ExportHtmlPostProcessor
     @log = DefaultLogger.logger
     @process_runner = process_runner
     @static_file_directory = static_file_directory
+    @documentation_link_suffixes = %w(.html .pdf .epub)
   end
 
   #
@@ -181,9 +182,11 @@ class ExportHtmlPostProcessor
         uri = URI(link.attributes['href'].value)
 
         #
-        # Only perform processing on the link if it doesn't already link to a .html file
+        # Only perform processing on the link if it doesn't already link to an allowed
+        # documentation suffix e.g. .html, .pdf or .epub
         #
-        unless uri.path.to_s.end_with?('.html')
+        allowed_link_suffix = @documentation_link_suffixes.any? { | suffix | uri.path.to_s.end_with?(suffix)}
+        unless allowed_link_suffix
           new_path = uri.path.end_with?('/') ? "#{uri.path}index.html" : "#{uri.path}/index.html"
           uri.path = new_path
           new_href = uri.to_s

--- a/_docker/tests/export/test_export_form_rewrite/index/index.html
+++ b/_docker/tests/export/test_export_form_rewrite/index/index.html
@@ -29,6 +29,8 @@
 <a id="documentation-trailing-slash" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/">Red Hat Software Collections</a>
 <a id="documentation-with-html" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/mypage.html"></a>
 <a id="documentation-with-anchor" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide#foobar"></a>
+<a id="documentation-with-pdf" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/my.pdf"></a>
+<a id="documentation-with-epub" href="https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/my.epub"></a>
 <a id="not-documentation" href="https://access.redhat.com/security">Security</a>
 
 </body>

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -63,6 +63,8 @@ class TestExportHtmlPostProcessor < MiniTest::Test
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html',get_link_href(index_html, 'documentation-trailing-slash'))
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/index.html#foobar',get_link_href(index_html, 'documentation-with-anchor'))
     assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/mypage.html', get_link_href(index_html, 'documentation-with-html'))
+    assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/my.epub', get_link_href(index_html, 'documentation-with-epub'))
+    assert_equal('https://access.redhat.com/documentation/en-US/Red_Hat_Developer_Toolset/1/html/Software_Collections_Guide/my.pdf', get_link_href(index_html, 'documentation-with-pdf'))
     assert_equal('https://access.redhat.com/security', get_link_href(index_html, 'not-documentation'))
   end
 


### PR DESCRIPTION
The export process adds `/index.html` to access.redhat.com documentation links if the URL does not end with `/index.html`. Unfortunately this logic was being applied if the link ended with a `.pdf` or `.epub` resource as well.

This PR ensures that `.pdf` and `.epub` linked resources remain untouched by the export process.

**For reviewers:**

Ensure that all epub and pdf documentation links on the `/products/devstudio/docs-and-apis` page of the export do not have a `/index.html` suffix.

