### PR TITLE
DEVELOPER-4410 - Cheat sheets showing up as both WEBPAGE and CHEAT SHEET in results

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.cheat_sheet.field_cheat_sheet_download_url
     - field.field.node.cheat_sheet.field_cheat_sheet_excerpt
     - field.field.node.cheat_sheet.field_cheat_sheet_tags
+    - field.field.node.cheat_sheet.field_exclude_from_search
     - node.type.cheat_sheet
   module:
     - link
@@ -68,6 +69,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_exclude_from_search:
+    weight: 122
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   path:
     type: path

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.cheat_sheet.field_cheat_sheet_download_url
     - field.field.node.cheat_sheet.field_cheat_sheet_excerpt
     - field.field.node.cheat_sheet.field_cheat_sheet_tags
+    - field.field.node.cheat_sheet.field_exclude_from_search
     - node.type.cheat_sheet
   module:
     - link
@@ -61,6 +62,16 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_exclude_from_search:
+    weight: 7
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   links:
     weight: 6

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.cheat_sheet.field_exclude_from_search.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.cheat_sheet.field_exclude_from_search.yml
@@ -1,0 +1,23 @@
+uuid: 0015097b-c35f-4f64-bfea-51ab0c99c690
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_search
+    - node.type.cheat_sheet
+id: node.cheat_sheet.field_exclude_from_search
+field_name: field_exclude_from_search
+entity_type: node
+bundle: cheat_sheet
+label: 'Exclude from search'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--cheat-sheet.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/node--cheat-sheet.html.twig
@@ -65,6 +65,13 @@ other methods (such as node.delete) will result in an exception.
 * @ingroup themeable
 */
 #}
+{% if node.field_exclude_from_search.value == '1' %}
+  <noscript>
+    <meta name="DCP:WebpageSearchExclude" content="true">
+  </noscript>
+{% endif %}
+
+
 <div{{ attributes.addClass(["row", "content"]).setAttribute("id", "rhd-cheat-sheet") }}>
   <div class="row">
     <div class="large-24 medium-24 columns">


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4410

To Test: Visit /admin/content?title=git+cheat+sheet&type=All&langcode=All&moderation_state= and edit the Git Cheatsheet.

* Check the box for "Exclude from search" at the bottom.
* Visit the page and notice that: 
```javascript
<noscript>
    &lt;meta name="DCP:WebpageSearchExclude" content="true"&gt;
  </noscript> 
```
Will appear in the body.

This will force DCP to skip the "WEBPAGE" indexing.
