### PR TITLE
DEVELOPER-4415 - Add support for OS detection for the pervasive red DOWNLOAD buttons

### DIFF
--- a/_tests/unit/rhdp-os-download_spec.js
+++ b/_tests/unit/rhdp-os-download_spec.js
@@ -1,16 +1,27 @@
 "use strict";
 
 describe('OS detection component', function () {
-    var wc,
-        productCode,
-        platformType,
-        downloadURL,
-        url;
+    var productCode,
+    productName,
+    platformType,
+    downloadURL,
+    url,
+    rhelURL,
+    macURL,
+    winURL,
+    version,
+    displayOS,
+    wc;
 
     beforeEach(function () {
         wc = document.createElement('rhdp-os-download');
+        productName = "Test product";
+        rhelURL = "http://www.rhel-url-download.com/";
+        macURL = "http://www.mac-url-download.com/";
+        winURL ="http://www.win-url-download.com/";
+        version = "7.0.0";
+        displayOS = "true";
         url = 'https://testdownload.com/products/testproduct/download/';
-        platformType = 'MacOS';
         downloadURL = 'https://testdownload.com/products/testproduct/download/';
         productCode = 'testproduct';
 
@@ -23,20 +34,32 @@ describe('OS detection component', function () {
     describe('properties', function () {
 
         beforeEach(function () {
-            wc.url = url;
             wc.productCode = productCode;
-            wc.platformType = platformType;
+            wc.productName = productName;
             wc.downloadURL = downloadURL;
+            wc.url = url;
+            wc.rhelURL = rhelURL;
+            wc.macURL = macURL;
+            wc.winURL = winURL;
+            wc.version = version;
+            wc.displayOS = displayOS;
 
         });
 
-        it('should update url, productcode, platform-type and downloadurl', function () {
+        it('should update all properties with appropriate values', function () {
+
             expect(wc.getAttribute('url')).toEqual(url);
             expect(wc.getAttribute('product-code')).toEqual(productCode);
-            expect(wc.getAttribute('platform-type')).toEqual(platformType);
             expect(wc.getAttribute('download-url')).toEqual(downloadURL);
+            expect(wc.getAttribute('rhel-download')).toEqual(rhelURL);
+            expect(wc.getAttribute('mac-download')).toEqual(macURL);
+            expect(wc.getAttribute('windows-download')).toEqual(winURL);
+            expect(wc.getAttribute('name')).toEqual(productName);
+            expect(wc.getAttribute('version')).toEqual(version);
+            expect(wc.getAttribute('display-os')).toEqual(displayOS);
         });
     });
+
     describe('logic methods', function () {
 
         beforeEach(function () {
@@ -44,16 +67,12 @@ describe('OS detection component', function () {
             wc.productCode = productCode;
             wc.platformType = platformType;
             wc.downloadURL = downloadURL;
-            document.body.insertBefore(wc, document.body.firstChild);
 
 
         });
 
-        it('should extract productCode from getProductFromURL', function () {
-            var testValue = wc.getProductFromURL();
-            expect(testValue).toEqual(productCode);
-        });
         it('should set platformType based on User-Agent', function () {
+            document.body.insertBefore(wc, document.body.firstChild);
             var OSName = "Windows";
             if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
             if (navigator.appVersion.indexOf("Linux")!=-1) OSName="RHEL";
@@ -61,23 +80,51 @@ describe('OS detection component', function () {
             expect(wc.platformType).toEqual(OSName);
 
         });
+        it('should set platformType based on User-Agent', function () {
+            document.body.insertBefore(wc, document.body.firstChild);
+            var OSName = "Windows";
+            if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+            if (navigator.appVersion.indexOf("Linux")!=-1) OSName="RHEL";
+
+            expect(wc.platformType).toEqual(OSName);
+
+        });
+
+
     });
     describe('with valid data', function () {
 
         beforeEach(function () {
-            wc.url = url;
             wc.productCode = productCode;
-            wc.platformType = platformType;
+            wc.productName = productName;
             wc.downloadURL = downloadURL;
+            wc.url = url;
+            wc.rhelURL = rhelURL;
+            wc.macURL = macURL;
+            wc.winURL = winURL;
+            wc.version = version;
+            wc.displayOS = false;
+
+        });
+
+        it('should update the link with the appropriate download url', function () {
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.querySelector('.button.heavy-cta').href).toEqual(wc.downloadURL);
+        });
+        it('should display the full name with version and platform', function () {
+            document.body.insertBefore(wc, document.body.firstChild);
+            expect(wc.querySelector('.version-name').innerText).toEqual(productName + ' ' + version +' for ' + wc.platformType);
+        });
+        it('should NOT display the platform when platform urls do not exist', function () {
+            wc.rhelURL = "";
+            wc.macURL = "";
+            wc.winURL = "";
             document.body.insertBefore(wc, document.body.firstChild);
 
-
-        });
-
-        it('should update url, productcode, platform-type and downloadurl', function () {
-            expect(wc.getAttribute('product-code')).toEqual(productCode);
+            expect(wc.querySelector('.version-name').innerText).toEqual(productName + ' ' + version);
         });
     });
+
 
 });
 

--- a/_tests/unit/rhdp-os-download_spec.js
+++ b/_tests/unit/rhdp-os-download_spec.js
@@ -1,0 +1,84 @@
+"use strict";
+
+describe('OS detection component', function () {
+    var wc,
+        productCode,
+        platformType,
+        downloadURL,
+        url;
+
+    beforeEach(function () {
+        wc = document.createElement('rhdp-os-download');
+        url = 'https://testdownload.com/products/testproduct/download/';
+        platformType = 'MacOS';
+        downloadURL = 'https://testdownload.com/products/testproduct/download/';
+        productCode = 'testproduct';
+
+    });
+
+    afterEach(function () {
+        document.body.removeChild(document.body.firstChild);
+    });
+
+    describe('properties', function () {
+
+        beforeEach(function () {
+            wc.url = url;
+            wc.productCode = productCode;
+            wc.platformType = platformType;
+            wc.downloadURL = downloadURL;
+
+        });
+
+        it('should update url, productcode, platform-type and downloadurl', function () {
+            expect(wc.getAttribute('url')).toEqual(url);
+            expect(wc.getAttribute('product-code')).toEqual(productCode);
+            expect(wc.getAttribute('platform-type')).toEqual(platformType);
+            expect(wc.getAttribute('download-url')).toEqual(downloadURL);
+        });
+    });
+    describe('logic methods', function () {
+
+        beforeEach(function () {
+            wc.url = url;
+            wc.productCode = productCode;
+            wc.platformType = platformType;
+            wc.downloadURL = downloadURL;
+            document.body.insertBefore(wc, document.body.firstChild);
+
+
+        });
+
+        it('should extract productCode from getProductFromURL', function () {
+            var testValue = wc.getProductFromURL();
+            expect(testValue).toEqual(productCode);
+        });
+        it('should set platformType based on User-Agent', function () {
+            var OSName = "Windows";
+            if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+            if (navigator.appVersion.indexOf("Linux")!=-1) OSName="RHEL";
+
+            expect(wc.platformType).toEqual(OSName);
+
+        });
+    });
+    describe('with valid data', function () {
+
+        beforeEach(function () {
+            wc.url = url;
+            wc.productCode = productCode;
+            wc.platformType = platformType;
+            wc.downloadURL = downloadURL;
+            document.body.insertBefore(wc, document.body.firstChild);
+
+
+        });
+
+        it('should update url, productcode, platform-type and downloadurl', function () {
+            expect(wc.getAttribute('product-code')).toEqual(productCode);
+        });
+    });
+
+});
+
+

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -107,6 +107,200 @@ var RHDPAlert = (function (_super) {
 window.addEventListener('WebComponentsReady', function () {
     customElements.define('rhdp-alert', RHDPAlert);
 });
+var RHDPOSDownload = (function (_super) {
+    __extends(RHDPOSDownload, _super);
+    function RHDPOSDownload() {
+        var _this = _super.call(this) || this;
+        _this.template = function (strings, product, downloadUrl, platform, version) {
+            return "<div class=\"large-8 columns download-link\">\n                    <a class=\"button heavy-cta\" href=\"" + downloadUrl + "\">\n                        <i class=\"fa fa-download\"></i> Download</a>\n                    <div class=\"version-name\">" + product + " " + version + " " + (_this.displayOS ? "for " + platform : '') + "</div>\n                </div>\n                ";
+        };
+        return _this;
+    }
+    Object.defineProperty(RHDPOSDownload.prototype, "url", {
+        get: function () {
+            return this._url;
+        },
+        set: function (value) {
+            if (this._url === value)
+                return;
+            this._url = value;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "productCode", {
+        get: function () {
+            return this._productCode;
+        },
+        set: function (value) {
+            if (this._productCode === value)
+                return;
+            this._productCode = value;
+            this.setAttribute('product-code', this._productCode);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "platformType", {
+        get: function () {
+            return this._platformType;
+        },
+        set: function (value) {
+            if (this._platformType === value)
+                return;
+            this._platformType = value;
+            this.setAttribute('platform-type', this._platformType);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "downloadURL", {
+        get: function () {
+            return this._downloadURL;
+        },
+        set: function (value) {
+            if (this._downloadURL === value)
+                return;
+            this._downloadURL = value;
+            this.setAttribute('download-url', this._downloadURL);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "rhelURL", {
+        get: function () {
+            return this._rhelURL;
+        },
+        set: function (value) {
+            if (this._rhelURL === value)
+                return;
+            this._rhelURL = value;
+            this.setAttribute('rhel-download', this._rhelURL);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "macURL", {
+        get: function () {
+            return this._macURL;
+        },
+        set: function (value) {
+            if (this._macURL === value)
+                return;
+            this._macURL = value;
+            this.setAttribute('mac-download', this._macURL);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "winURL", {
+        get: function () {
+            return this._winURL;
+        },
+        set: function (value) {
+            if (this._winURL === value)
+                return;
+            this._winURL = value;
+            this.setAttribute('windows-download', this._winURL);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "productName", {
+        get: function () {
+            return this._productName;
+        },
+        set: function (value) {
+            if (this._productName === value)
+                return;
+            this._productName = value;
+            this.setAttribute('name', this._productName);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "version", {
+        get: function () {
+            return this._version;
+        },
+        set: function (value) {
+            if (this._version === value)
+                return;
+            this._version = value;
+            this.setAttribute('version', this._version);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(RHDPOSDownload.prototype, "displayOS", {
+        get: function () {
+            return this._displayOS;
+        },
+        set: function (value) {
+            if (this._displayOS === value)
+                return;
+            this._displayOS = value;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPOSDownload.prototype.connectedCallback = function () {
+        this.platformType = this.getUserAgent();
+        this.setDownloadURLByPlatform();
+        this.innerHTML = (_a = ["", "", "", "", ""], _a.raw = ["", "", "", "", ""], this.template(_a, this.productName, this.downloadURL, this.platformType, this.version));
+        var _a;
+    };
+    Object.defineProperty(RHDPOSDownload, "observedAttributes", {
+        get: function () {
+            return ['product-code', 'platform-type', 'download-url', 'name'];
+        },
+        enumerable: true,
+        configurable: true
+    });
+    RHDPOSDownload.prototype.attributeChangedCallback = function (name, oldVal, newVal) {
+        this[name] = newVal;
+    };
+    // getProductFromURL(){
+    //     // returns the target product that will be used for the JSON reference
+    //     this.url = this.url ? this.url : window.location.href;
+    //     var regex = new RegExp("[^/.]+(?=\/download)"),
+    //         results = regex.exec(this.url);
+    //     if (!results) return null;
+    //     return results[0];
+    //
+    // }
+    RHDPOSDownload.prototype.getUserAgent = function () {
+        var OSName = "Windows";
+        if (navigator.appVersion.indexOf("Mac") != -1)
+            OSName = "MacOS";
+        if (navigator.appVersion.indexOf("Linux") != -1)
+            OSName = "RHEL";
+        return OSName;
+    };
+    RHDPOSDownload.prototype.setDownloadURLByPlatform = function () {
+        if (this.winURL.length <= 0 || this.macURL.length <= 0 || this.rhelURL.length <= 0) {
+            return;
+        }
+        this.displayOS = true;
+        switch (this.platformType) {
+            case "Windows":
+                this.downloadURL = this.winURL;
+                break;
+            case "MacOS":
+                this.downloadURL = this.macURL;
+                break;
+            case "RHEL":
+                this.downloadURL = this.rhelURL;
+                break;
+            default:
+                this.downloadURL = this.winURL;
+        }
+    };
+    return RHDPOSDownload;
+}(HTMLElement));
+window.addEventListener('WebComponentsReady', function () {
+    customElements.define('rhdp-os-download', RHDPOSDownload);
+});
 var RHDPThankyou = (function (_super) {
     __extends(RHDPThankyou, _super);
     function RHDPThankyou() {

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -111,6 +111,9 @@ var RHDPOSDownload = (function (_super) {
     __extends(RHDPOSDownload, _super);
     function RHDPOSDownload() {
         var _this = _super.call(this) || this;
+        _this._rhelURL = "";
+        _this._macURL = "";
+        _this._winURL = "";
         _this.template = function (strings, product, downloadUrl, platform, version) {
             return "<div class=\"large-8 columns download-link\">\n                    <a class=\"button heavy-cta\" href=\"" + downloadUrl + "\">\n                        <i class=\"fa fa-download\"></i> Download</a>\n                    <div class=\"version-name\">" + product + " " + version + " " + (_this.displayOS ? "for " + platform : '') + "</div>\n                </div>\n                ";
         };
@@ -124,6 +127,7 @@ var RHDPOSDownload = (function (_super) {
             if (this._url === value)
                 return;
             this._url = value;
+            this.setAttribute('url', this._url);
         },
         enumerable: true,
         configurable: true
@@ -240,6 +244,7 @@ var RHDPOSDownload = (function (_super) {
             if (this._displayOS === value)
                 return;
             this._displayOS = value;
+            this.setAttribute('display-os', this._displayOS);
         },
         enumerable: true,
         configurable: true

--- a/javascripts/downloads.js
+++ b/javascripts/downloads.js
@@ -84,15 +84,37 @@ app.downloads.createDownloadLink = function(data) {
   if (data[0].productCode === "rhoar") {
     return "";
   }
-  if(!data[0].featuredArtifact) {
+  else if (data[0].productCode === "devsuite") {
+    data[0].featuredWindowsArtifact = app.products.downloads.devsuite.windowsUrl;
+    data[0].featuredMacArtifact = app.products.downloads.devsuite.macUrl;
+    data[0].featuredRhelArtifact = app.products.downloads.devsuite.rhelUrl;
+  }
+  else if (data[0].productCode === "cdk") {
+    data[0].featuredWindowsArtifact = app.products.downloads.cdk.windowsUrl;
+    data[0].featuredMacArtifact = app.products.downloads.cdk.macUrl;
+    data[0].featuredRhelArtifact = app.products.downloads.cdk.rhelUrl;
+ }
+
+  else if(!data[0].featuredArtifact) {
     return "";
   }
+
+  else {
+      data[0].featuredWindowsArtifact = "";
+      data[0].featuredMacArtifact = "";
+      data[0].featuredRhelArtifact = "";
+
+  }
+  var $downloadLink = new RHDPOSDownload();
+      $downloadLink.productCode  = data[0].productCode;
+      $downloadLink.downloadURL  = data[0].featuredArtifact.url;
+      $downloadLink.winURL       = data[0].featuredWindowsArtifact;
+      $downloadLink.macURL       = data[0].featuredMacArtifact;
+      $downloadLink.rhelURL      = data[0].featuredRhelArtifact;
+      $downloadLink.productName  = data[0].name;
+      $downloadLink.version      = data[0].featuredArtifact.versionName;
+
   // Pull the first one from the sorted array
-  var icn = '<i class="fa fa-download"></i>',
-      lnk = '<a class="button heavy-cta" href="'+data[0].featuredArtifact.url+'">'+icn+' Download</a>',
-      ver = '<div class="version-name">'+data[0].name + ' ' + data[0].featuredArtifact.versionName+'</div>',
-      $downloadLink = $('<div class="large-8 columns download-link">'+lnk+ver+'</div>');
-      
   return $downloadLink;
 }
 

--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -132,6 +132,11 @@ app.products = {
   "migrationtoolkit": {"upstream": null,"stackoverflow": ["rhamt"],"buzz_tags": ["windup","rhamt"]}
 };
 
+app.products.downloads = {
+    "devsuite" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"},
+    "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/cdk/hello-world/#fndtn-rhel"}
+};
+
 /*
  * Marketing ops
  */

--- a/typescript/rhdp-os-download.ts
+++ b/typescript/rhdp-os-download.ts
@@ -1,0 +1,191 @@
+class RHDPOSDownload extends HTMLElement {
+
+    private _productCode;
+    private _productName;
+    private _platformType;
+    private _downloadURL;
+    private _url;
+    private _rhelURL;
+    private _macURL;
+    private _winURL;
+    private _version;
+    private _displayOS;
+
+
+    get url() {
+        return this._url;
+    }
+
+    set url(value) {
+        if (this._url === value) return;
+        this._url = value;
+    }
+
+    get productCode() {
+        return this._productCode;
+    }
+
+    set productCode(value) {
+        if (this._productCode === value) return;
+        this._productCode = value;
+        this.setAttribute('product-code', this._productCode);
+    }
+
+    get platformType() {
+        return this._platformType;
+    }
+
+    set platformType(value) {
+        if (this._platformType === value) return;
+        this._platformType = value;
+        this.setAttribute('platform-type', this._platformType)
+    }
+
+    get downloadURL() {
+        return this._downloadURL;
+    }
+
+    set downloadURL(value) {
+        if (this._downloadURL === value) return;
+        this._downloadURL = value;
+        this.setAttribute('download-url', this._downloadURL)
+
+    }
+
+    get rhelURL() {
+        return this._rhelURL;
+    }
+
+    set rhelURL(value) {
+        if (this._rhelURL === value) return;
+        this._rhelURL = value;
+        this.setAttribute('rhel-download', this._rhelURL)
+    }
+
+    get macURL() {
+        return this._macURL;
+    }
+
+    set macURL(value) {
+        if (this._macURL === value) return;
+        this._macURL = value;
+        this.setAttribute('mac-download', this._macURL)
+    }
+
+    get winURL() {
+        return this._winURL;
+    }
+
+    set winURL(value) {
+        if (this._winURL === value) return;
+        this._winURL = value;
+        this.setAttribute('windows-download', this._winURL)
+
+
+    }
+
+    get productName() {
+        return this._productName;
+    }
+
+    set productName(value) {
+        if (this._productName === value) return;
+        this._productName = value;
+        this.setAttribute('name', this._productName)
+
+    }
+
+    get version() {
+        return this._version;
+    }
+
+    set version(value) {
+        if (this._version === value) return;
+        this._version = value;
+        this.setAttribute('version', this._version)
+
+    }
+
+    get displayOS() {
+        return this._displayOS;
+    }
+
+    set displayOS(value) {
+        if (this._displayOS === value) return;
+        this._displayOS = value;
+    }
+
+    constructor() {
+        super();
+    }
+
+    template = (strings, product, downloadUrl, platform, version) => {
+        return `<div class="large-8 columns download-link">
+                    <a class="button heavy-cta" href="${downloadUrl}">
+                        <i class="fa fa-download"></i> Download</a>
+                    <div class="version-name">${product} ${version} ${this.displayOS ? `for ${platform}` : ''}</div>
+                </div>
+                `;
+    };
+
+    connectedCallback() {
+        this.platformType = this.getUserAgent();
+        this.setDownloadURLByPlatform();
+        this.innerHTML = this.template`${this.productName}${this.downloadURL}${this.platformType}${this.version}`;
+
+    }
+
+    static get observedAttributes() {
+        return ['product-code','platform-type', 'download-url', 'name'];
+    }
+
+
+    attributeChangedCallback(name, oldVal, newVal) {
+        this[name] = newVal;
+    }
+
+    // getProductFromURL(){
+    //     // returns the target product that will be used for the JSON reference
+    //     this.url = this.url ? this.url : window.location.href;
+    //     var regex = new RegExp("[^/.]+(?=\/download)"),
+    //         results = regex.exec(this.url);
+    //     if (!results) return null;
+    //     return results[0];
+    //
+    // }
+    getUserAgent(){
+        let OSName = "Windows";
+        if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";
+        if (navigator.appVersion.indexOf("Linux")!=-1) OSName="RHEL";
+
+        return OSName;
+
+    }
+    setDownloadURLByPlatform(){
+        if (this.winURL.length <=0 || this.macURL.length <=0 || this.rhelURL.length <=0){
+            return;
+        }
+        this.displayOS = true;
+        switch(this.platformType) {
+            case "Windows":
+                this.downloadURL = this.winURL;
+                break;
+            case "MacOS":
+                this.downloadURL = this.macURL;
+                break;
+            case "RHEL":
+                this.downloadURL = this.rhelURL;
+                break;
+            default:
+                this.downloadURL = this.winURL
+        }
+    }
+
+
+
+}
+
+window.addEventListener('WebComponentsReady', function() {
+    customElements.define('rhdp-os-download', RHDPOSDownload);
+});
+

--- a/typescript/rhdp-os-download.ts
+++ b/typescript/rhdp-os-download.ts
@@ -5,12 +5,11 @@ class RHDPOSDownload extends HTMLElement {
     private _platformType;
     private _downloadURL;
     private _url;
-    private _rhelURL;
-    private _macURL;
-    private _winURL;
+    private _rhelURL = "";
+    private _macURL = "";
+    private _winURL = "";
     private _version;
     private _displayOS;
-
 
     get url() {
         return this._url;
@@ -19,6 +18,8 @@ class RHDPOSDownload extends HTMLElement {
     set url(value) {
         if (this._url === value) return;
         this._url = value;
+        this.setAttribute('url', this._url);
+
     }
 
     get productCode() {
@@ -113,6 +114,7 @@ class RHDPOSDownload extends HTMLElement {
     set displayOS(value) {
         if (this._displayOS === value) return;
         this._displayOS = value;
+        this.setAttribute('display-os', this._displayOS);
     }
 
     constructor() {
@@ -144,15 +146,6 @@ class RHDPOSDownload extends HTMLElement {
         this[name] = newVal;
     }
 
-    // getProductFromURL(){
-    //     // returns the target product that will be used for the JSON reference
-    //     this.url = this.url ? this.url : window.location.href;
-    //     var regex = new RegExp("[^/.]+(?=\/download)"),
-    //         results = regex.exec(this.url);
-    //     if (!results) return null;
-    //     return results[0];
-    //
-    // }
     getUserAgent(){
         let OSName = "Windows";
         if (navigator.appVersion.indexOf("Mac")!=-1) OSName="MacOS";


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4415

To test: Visit the download page of each of the products and confirm that they still refer to the correct download.

Special cases:
DevSuite and CDK should now detect the platform that you are running (RHEL, MacOS or Windows). These should point to the downloads listed on https://docs.google.com/document/d/1m1WljXUSM8EonxaFKtDTmysxrWUnssH1PiShKZ6Mz1o/edit?ts=59c0d31b#

The e2e test failures are unrelated to this component