### PR TITLE
Blinkr: Ignore quickstarts

### DIFF
--- a/_tests/blc/config/pr_blinkr.yaml
+++ b/_tests/blc/config/pr_blinkr.yaml
@@ -1,4 +1,8 @@
 verbose: true
+
+skips:
+ - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
+
 ignores:
   - code: 202
   - code: 203
@@ -12,11 +16,9 @@ ignores:
   - url: !ruby/regexp /https?:\/\/(www\.)?linkedin\.com\/.*/
   - url: !ruby/regexp /https?:\/\/(www\.)?linkedin\.com\/.*/
 
-environments:
+ environments:
   - http://developer-drupal.web.prod.ext.phx2.redhat.com
   - https://developer-drupal.web.prod.ext.phx2.redhat.com
-  - https://developers.redhat.com
-  - http://developers.redhat.com
 
 ignore_external: true
 
@@ -25,5 +27,5 @@ max_page_retys: 5
 max_retrys: 5
 browser: phantomjs
 ignore_fragments: true
-phantomjs_threads: 10
+phantomjs_threads: 8
 report: blinkr.html

--- a/_tests/blc/config/pr_blinkr.yaml
+++ b/_tests/blc/config/pr_blinkr.yaml
@@ -1,7 +1,7 @@
 verbose: true
 
 skips:
- - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
+  - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
 
 ignores:
   - code: 202
@@ -16,7 +16,7 @@ ignores:
   - url: !ruby/regexp /https?:\/\/(www\.)?linkedin\.com\/.*/
   - url: !ruby/regexp /https?:\/\/(www\.)?linkedin\.com\/.*/
 
- environments:
+environments:
   - http://developer-drupal.web.prod.ext.phx2.redhat.com
   - https://developer-drupal.web.prod.ext.phx2.redhat.com
 

--- a/_tests/blc/config/pr_blinkr.yaml
+++ b/_tests/blc/config/pr_blinkr.yaml
@@ -1,7 +1,7 @@
 verbose: true
 
 skips:
-  - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
+  - !ruby/regexp /^https:\/\/developers\-pr\.stage\.redhat\.com\/pr\/(.*)\/export\/quickstarts\.*\/.*/
 
 ignores:
   - code: 202

--- a/_tests/blc/config/prod_blinkr.yaml
+++ b/_tests/blc/config/prod_blinkr.yaml
@@ -35,15 +35,10 @@ skips:
   - !ruby/regexp /^http:\/\/vimeo\.com\/ericschabell\/bpmsuite\-fuse\-integraiton\-demo\-run$/
   - !ruby/regexp /^https:\/\/github\.com\/jboss\-dockerfiles\/hawkular\/blob\/master\/hawkular\-aio\/README.md$/
   - http://www.jboss.org/jdf/quickstarts/jboss-as-quickstart/guide/Introduction
-  - https://developers.redhat.com/quickstarts/datagrid
-  - https://developers.redhat.com/quickstarts/fuse
-  - https://developers.redhat.com/quickstarts/fuse/cxf
-  - https://developers.redhat.com/quickstarts/wfk
-  - https://developers.redhat.com/quickstarts/unifiedpush
-  - https://developers.redhat.com/quickstarts/unifiedpush/push-helloworld-android
   - http://vimeo.com/ericschabell/bpms-hr-employee-rewards-demo-run
   - https://pubs.vmware.com/workstation-12/index.jsp#com.vmware.ws.using.doc/GUID-0CE1AE01-7E79-41BB-9EA8-4F839BE40E1A.html
   - !ruby/regexp /^https:\/\/pubs\.vmware\.com\/workstation\-\d*\/.*/
+  - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
   
 ignores:
   - code: 202
@@ -61,5 +56,5 @@ max_page_retys: 5
 max_retrys: 5
 browser: phantomjs
 ignore_fragments: true
-phantomjs_threads: 10
+phantomjs_threads: 8
 report: blinkr.html

--- a/_tests/blc/config/stage_blinkr.yaml
+++ b/_tests/blc/config/stage_blinkr.yaml
@@ -2,6 +2,10 @@ base_url: https://developers.stage.redhat.com
 verbose: true
 ignore_external: true
 ignore_ssl: true
+
+skips:
+ - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
+
 ignores:
   - code: 202
   - code: 203
@@ -18,12 +22,10 @@ ignores:
 environments:
   - http://developer-drupal.web.prod.ext.phx2.redhat.com
   - https://developer-drupal.web.prod.ext.phx2.redhat.com
-  - https://developers.redhat.com
-  - http://developers.redhat.com
 
 max_page_retys: 5
 max_retrys: 5
 browser: phantomjs
 ignore_fragments: true
-phantomjs_threads: 10
+phantomjs_threads: 8
 report: blinkr.html

--- a/_tests/blc/config/stage_blinkr.yaml
+++ b/_tests/blc/config/stage_blinkr.yaml
@@ -4,7 +4,7 @@ ignore_external: true
 ignore_ssl: true
 
 skips:
- - !ruby/regexp /^https:\/\/developers\.redhat\.com\/quickstarts\.*\/.*/
+ - !ruby/regexp /^https:\/\/developers\.stage\.redhat\.com\/quickstarts\.*\/.*/
 
 ignores:
   - code: 202


### PR DESCRIPTION
We do not own those pages, therefore cannot fix broken links.  Also reduced phantomjs threads in an attempt to reduce random build timeouts.