### PR TITLE
DEVELOPER-4504 Fixes display for 'book' search results

### DIFF
--- a/_tests/unit/rhdp-search/rhdp-search-result_spec.js
+++ b/_tests/unit/rhdp-search/rhdp-search-result_spec.js
@@ -74,21 +74,35 @@ describe('Search Result', function() {
     });
 
     describe('Description', function() {
+        var tempDiv = document.createElement("div");
+
         it('should match highlights.sys_description if present', function() {
             wc.result = testResult;
-            expect(wc.description).toEqual(testResult.highlight.sys_description[0]);
+
+            tempDiv.innerHTML = testResult.highlight.sys_description[0];
+            var sanitizedDescription = tempDiv.innerText;
+
+            expect(wc.description).toEqual(sanitizedDescription);
         });
 
         it('should match highlights.sys_plaintext if present without h.sys_description', function() {
             delete testResult.highlight.sys_description;
             wc.result = testResult;
-            expect(wc.description).toEqual(testResult.highlight.sys_content_plaintext[0]);
+
+            tempDiv.innerHTML = testResult.highlight.sys_content_plaintext[0];
+            var sanitizedDescription = tempDiv.innerText;
+
+            expect(wc.description).toEqual(sanitizedDescription);
         });
 
         it('should match fields.sys_description by default', function() {
             delete testResult.highlight.sys_content_plaintext;
             wc.result = testResult;
-            expect(wc.description).toEqual(testResult.fields.sys_description[0]);
+
+            tempDiv.innerHTML = testResult.fields.sys_description[0];
+            var sanitizedDescription = tempDiv.innerText;
+
+            expect(wc.description).toEqual(sanitizedDescription);
         });
     });
 

--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -2906,6 +2906,10 @@ var RHDPSearchResult = (function (_super) {
         else {
             description = result.fields.sys_content_plaintext[0];
         }
+        // Removes all HTML tags from description
+        var tempDiv = document.createElement("div");
+        tempDiv.innerHTML = description;
+        description = tempDiv.innerText;
         this.description = description;
     };
     RHDPSearchResult.prototype.computeURL = function (result) {

--- a/typescript/rhdp-search/rhdp-search-result.ts
+++ b/typescript/rhdp-search/rhdp-search-result.ts
@@ -173,6 +173,11 @@ class RHDPSearchResult extends HTMLElement {
             description = result.fields.sys_content_plaintext[0];
         }
 
+        // Removes all HTML tags from description
+        var tempDiv = document.createElement("div");
+        tempDiv.innerHTML = description;
+        description = tempDiv.innerText;
+
         this.description = description;
     }
     computeURL(result) {


### PR DESCRIPTION
[DEVELOPER-4504 - UI issues with books when displayed in search results](https://issues.jboss.org/browse/DEVELOPER-4504)

Some of the search results for books were showing a longer description because the sys_description coming from the DCP contained multiple HTML tags such as p, ul, li.

In this PR, i've stripped all HTML tags from the search result's descriptions so they are all displayed in the same way.

I've also removed two unit tests that used check that the displayed description was exactly like the description coming from the DCP (they are no longer the same since HTML tags are removed).