### PR TITLE
DEVELOPER-4530 Changed Security topic name on main nav

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -337,7 +337,7 @@
                             <a href="/topics/iot">Internet of Things</a>
                             <a href="/topics/microservices">Microservices</a>
                             <a href="/topics/mobile">Mobile</a>
-                            <a href="/topics/security">Security</a>
+                            <a href="/topics/security">Secure Programming</a>
                             <a href="/topics/web-and-api-development">Web and API Development</a>
                             <a href="/topics/dotnet">.NET Core</a>
                         </div>

--- a/_tests/e2e/features/website/rhd_navigationMenu.feature
+++ b/_tests/e2e/features/website/rhd_navigationMenu.feature
@@ -57,6 +57,7 @@ Feature: Site navigation menu
       | Internet of Things      |
       | Microservices           |
       | Mobile                  |
+      | Secure Programming      |
       | Web and API Development |
       | .NET Core               |
 
@@ -71,6 +72,7 @@ Feature: Site navigation menu
       | Internet of Things      |
       | Microservices           |
       | Mobile                  |
+      | Secure Programming      |
       | Web and API Development |
       | .NET Core               |
 

--- a/_tests/e2e/features/website/rhd_topics_white_cards.feature
+++ b/_tests/e2e/features/website/rhd_topics_white_cards.feature
@@ -13,5 +13,6 @@ Feature: White Card Count
       | iot                     |
       | microservices           |
       | mobile                  |
+      | security                |
       | web-and-api-development |
       | dotnet                  |


### PR DESCRIPTION
[DEVELOPER-4530 - Change Security topic name on Topics pulldown](https://issues.jboss.org/browse/DEVELOPER-4530)

To review:
- In the Topics pulldown, "Security" should be changed to "Secure Programming".