### PR TITLE
DEVELOPER-4553 - Display Content Type in Entity Reference Autocomplete

### DIFF
--- a/_docker/drupal/drupal-filesystem/2174633-174.patch
+++ b/_docker/drupal/drupal-filesystem/2174633-174.patch
@@ -1,0 +1,357 @@
+diff --git a/core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php b/core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php
+index 466032d96a..f6a21ae8dd 100644
+--- a/core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php
++++ b/core/lib/Drupal/Core/Entity/Element/EntityAutocomplete.php
+@@ -296,7 +296,9 @@ protected static function matchEntityByTitle(SelectionInterface $handler, $input
+         $multiples[] = $name . ' (' . $id . ')';
+       }
+       $params['@id'] = $id;
+-      $form_state->setError($element, t('Multiple entities match this reference; "%multiple". Specify the one you want by appending the id in parentheses, like "@value (@id)".', ['%multiple' => implode('", "', $multiples)] + $params));
++      // Call strip_tags to clean up the label display if we are getting the
++      // list of matches from an entity reference view.
++      $form_state->setError($element, t('Multiple entities match this reference; "%multiple". Specify the one you want by appending the id in parentheses, like "@value (@id)".', ['%multiple' => strip_tags(implode('", "', $multiples))] + $params));
+     }
+     else {
+       // Take the one and only matching entity.
+diff --git a/core/modules/field/tests/src/Functional/EntityReference/Views/SelectionTest.php b/core/modules/field/tests/src/Functional/EntityReference/Views/SelectionTest.php
+index cfb5ecf084..c3fa48bf1d 100644
+--- a/core/modules/field/tests/src/Functional/EntityReference/Views/SelectionTest.php
++++ b/core/modules/field/tests/src/Functional/EntityReference/Views/SelectionTest.php
+@@ -2,6 +2,9 @@
+
+ namespace Drupal\Tests\field\Functional\EntityReference\Views;
+
++use Drupal\Component\Serialization\Json;
++use Drupal\Component\Utility\Crypt;
++use Drupal\Core\Site\Settings;
+ use Drupal\field\Entity\FieldConfig;
+ use Drupal\Tests\BrowserTestBase;
+ use Drupal\views\Views;
+@@ -17,7 +20,7 @@ class SelectionTest extends BrowserTestBase {
+   public static $modules = ['node', 'views', 'entity_reference_test', 'entity_test'];
+
+   /**
+-   * Nodes for testing.
++   * An array of node titles, keyed by content type and node ID.
+    *
+    * @var array
+    */
+@@ -36,14 +39,16 @@ class SelectionTest extends BrowserTestBase {
+   protected function setUp() {
+     parent::setUp();
+
+-    // Create nodes.
+-    $type = $this->drupalCreateContentType()->id();
+-    $node1 = $this->drupalCreateNode(['type' => $type]);
+-    $node2 = $this->drupalCreateNode(['type' => $type]);
+-    $node3 = $this->drupalCreateNode();
++    // Create content types and nodes.
++    $type1 = $this->drupalCreateContentType()->id();
++    $type2 = $this->drupalCreateContentType()->id();
++    $node1 = $this->drupalCreateNode(['type' => $type1, 'title' => 'Test first node']);
++    $node2 = $this->drupalCreateNode(['type' => $type1, 'title' => 'Test second node']);
++    $node3 = $this->drupalCreateNode(['type' => $type2, 'title' => 'Test third node']);
+
+     foreach ([$node1, $node2, $node3] as $node) {
+-      $this->nodes[$node->getType()][$node->id()] = $node->label();
++      $this->nodes[] = $node;
++      $this->nodeTitles[$node->getType()][$node->id()] = $node->label();
+     }
+
+     // Create a field.
+@@ -77,6 +82,50 @@ protected function setUp() {
+   }
+
+   /**
++   * Tests that the Views selection handles the views output properly.
++   */
++  public function testAutocompleteOutput() {
++    // Reset any internal static caching.
++    \Drupal::service('entity_type.manager')->getStorage('node')->resetCache();
++
++    $view = Views::getView('test_entity_reference');
++    $view->setDisplay();
++
++    // Enable the display of the 'type' field so we can test that the output
++    // does not contain only the entity label.
++    $fields = $view->displayHandlers->get('entity_reference_1')->getOption('fields');
++    $fields['type']['exclude'] = FALSE;
++    $view->displayHandlers->get('entity_reference_1')->setOption('fields', $fields);
++    $view->save();
++
++    // Prepare the selection settings key needed by the entity reference
++    // autocomplete route.
++    $target_type = 'node';
++    $selection_handler = $this->field->getSetting('handler');
++    $selection_settings = $this->field->getSetting('handler_settings');
++    $selection_settings_key = Crypt::hmacBase64(serialize($selection_settings) . $target_type . $selection_handler, Settings::getHashSalt());
++    \Drupal::keyValue('entity_autocomplete')->set($selection_settings_key, $selection_settings);
++
++    $result = Json::decode($this->drupalGet('entity_reference_autocomplete/' . $target_type . '/' . $selection_handler . '/' . $selection_settings_key, ['query' => ['q' => 't']]));
++
++    $expected = [
++      0 => [
++        'value' => $this->nodes[0]->bundle() . ': ' . $this->nodes[0]->label() . ' (' . $this->nodes[0]->id() . ')',
++        'label' => '<span class="views-field views-field-type"><span class="field-content">' . $this->nodes[0]->bundle() . '</span></span>: <span class="views-field views-field-title"><span class="field-content">' . $this->nodes[0]->label() . '</span></span>',
++      ],
++      1 => [
++        'value' => $this->nodes[1]->bundle() . ': ' . $this->nodes[1]->label() . ' (' . $this->nodes[1]->id() . ')',
++        'label' => '<span class="views-field views-field-type"><span class="field-content">' . $this->nodes[1]->bundle() . '</span></span>: <span class="views-field views-field-title"><span class="field-content">' . $this->nodes[1]->label() . '</span></span>',
++      ],
++      2 => [
++        'value' => $this->nodes[2]->bundle() . ': ' . $this->nodes[2]->label() . ' (' . $this->nodes[2]->id() . ')',
++        'label' => '<span class="views-field views-field-type"><span class="field-content">' . $this->nodes[2]->bundle() . '</span></span>: <span class="views-field views-field-title"><span class="field-content">' . $this->nodes[2]->label() . '</span></span>',
++      ],
++    ];
++    $this->assertEqual($result, $expected, 'The autocomplete result of the Views entity reference selection handler contains the proper output.');
++  }
++
++  /**
+    * Confirm the expected results are returned.
+    *
+    * @param array $result
+@@ -86,7 +135,7 @@ protected function assertResults(array $result) {
+     $success = FALSE;
+     foreach ($result as $node_type => $values) {
+       foreach ($values as $nid => $label) {
+-        if (!$success = $this->nodes[$node_type][$nid] == trim(strip_tags($label))) {
++        if (!$success = $this->nodeTitles[$node_type][$nid] == trim(strip_tags($label))) {
+           // There was some error, so break.
+           break;
+         }
+diff --git a/core/modules/system/tests/modules/entity_reference_test/config/install/views.view.test_entity_reference.yml b/core/modules/system/tests/modules/entity_reference_test/config/install/views.view.test_entity_reference.yml
+index 3e78c51080..3b7ef18fcf 100644
+--- a/core/modules/system/tests/modules/entity_reference_test/config/install/views.view.test_entity_reference.yml
++++ b/core/modules/system/tests/modules/entity_reference_test/config/install/views.view.test_entity_reference.yml
+@@ -2,7 +2,6 @@ langcode: en
+ status: true
+ dependencies:
+   module:
+-    - entity_reference_test
+     - node
+     - user
+ id: test_entity_reference
+@@ -35,6 +34,71 @@ display:
+       row:
+         type: fields
+       fields:
++        type:
++          id: type
++          table: node_field_data
++          field: type
++          relationship: none
++          group_type: group
++          admin_label: ''
++          label: ''
++          exclude: true
++          alter:
++            alter_text: false
++            text: ''
++            make_link: false
++            path: ''
++            absolute: false
++            external: false
++            replace_spaces: false
++            path_case: none
++            trim_whitespace: false
++            alt: ''
++            rel: ''
++            link_class: ''
++            prefix: ''
++            suffix: ''
++            target: ''
++            nl2br: false
++            max_length: 0
++            word_boundary: true
++            ellipsis: true
++            more_link: false
++            more_link_text: ''
++            more_link_path: ''
++            strip_tags: false
++            trim: false
++            preserve_tags: ''
++            html: false
++          element_type: ''
++          element_class: ''
++          element_label_type: ''
++          element_label_class: ''
++          element_label_colon: false
++          element_wrapper_type: ''
++          element_wrapper_class: ''
++          element_default_classes: true
++          empty: ''
++          hide_empty: false
++          empty_zero: false
++          hide_alter_empty: true
++          click_sort_column: target_id
++          type: entity_reference_label
++          settings:
++            link: false
++          group_column: target_id
++          group_columns: {  }
++          group_rows: true
++          delta_limit: 0
++          delta_offset: 0
++          delta_reversed: false
++          delta_first_last: false
++          multi_type: separator
++          separator: ', '
++          field_api_classes: false
++          entity_type: node
++          entity_field: type
++          plugin_id: field
+         title:
+           id: title
+           table: node_field_data
+@@ -99,14 +163,30 @@ display:
+           entity_type: node
+           entity_field: status
+       sorts:
+-        created:
+-          id: created
++        nid:
++          id: nid
+           table: node_field_data
+-          field: created
+-          order: DESC
+-          plugin_id: date
++          field: nid
++          relationship: none
++          group_type: group
++          admin_label: ''
++          order: ASC
++          exposed: false
++          expose:
++            label: ''
+           entity_type: node
+-          entity_field: created
++          entity_field: nid
++          plugin_id: standard
++      display_extenders: {  }
++    cache_metadata:
++      max-age: -1
++      contexts:
++        - 'languages:language_content'
++        - 'languages:language_interface'
++        - url.query_args
++        - 'user.node_grants:view'
++        - user.permissions
++      tags: {  }
+   entity_reference_1:
+     display_plugin: entity_reference
+     id: entity_reference_1
+@@ -123,3 +203,19 @@ display:
+         type: none
+         options:
+           offset: 0
++      display_extenders: {  }
++      row:
++        type: entity_reference
++        options:
++          default_field_elements: true
++          inline: {  }
++          separator: ': '
++          hide_empty: false
++    cache_metadata:
++      max-age: -1
++      contexts:
++        - 'languages:language_content'
++        - 'languages:language_interface'
++        - 'user.node_grants:view'
++        - user.permissions
++      tags: {  }
+\ No newline at end of file
+diff --git a/core/modules/views/src/Plugin/EntityReferenceSelection/ViewsSelection.php b/core/modules/views/src/Plugin/EntityReferenceSelection/ViewsSelection.php
+index 9911f61a0c..116aa32374 100644
+--- a/core/modules/views/src/Plugin/EntityReferenceSelection/ViewsSelection.php
++++ b/core/modules/views/src/Plugin/EntityReferenceSelection/ViewsSelection.php
+@@ -2,12 +2,18 @@
+
+ namespace Drupal\views\Plugin\EntityReferenceSelection;
+
++use Drupal\Component\Utility\Xss;
++use Drupal\Core\Entity\EntityManagerInterface;
+ use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginBase;
+ use Drupal\Core\Entity\EntityReferenceSelection\SelectionTrait;
++use Drupal\Core\Extension\ModuleHandlerInterface;
+ use Drupal\Core\Form\FormStateInterface;
+ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
++use Drupal\Core\Render\RendererInterface;
++use Drupal\Core\Session\AccountInterface;
+ use Drupal\Core\Url;
+ use Drupal\views\Views;
++use Symfony\Component\DependencyInjection\ContainerInterface;
+
+ /**
+  * Plugin implementation of the 'selection' entity_reference.
+@@ -31,6 +37,49 @@ class ViewsSelection extends SelectionPluginBase implements ContainerFactoryPlug
+   protected $view;
+
+   /**
++   * The renderer.
++   *
++   * @var \Drupal\Core\Render\RendererInterface
++   */
++  protected $renderer;
++
++  /**
++   * Constructs a new selection object.
++   *
++   * @param array $configuration
++   *   A configuration array containing information about the plugin instance.
++   * @param string $plugin_id
++   *   The plugin_id for the plugin instance.
++   * @param mixed $plugin_definition
++   *   The plugin implementation definition.
++   * @param \Drupal\Core\Render\RendererInterface $renderer
++   *   The current renderer service.
++   */
++  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, RendererInterface $renderer) {
++    parent::__construct($configuration, $plugin_id, $plugin_definition);
++
++    $this->entityManager = $entity_manager;
++    $this->moduleHandler = $module_handler;
++    $this->currentUser = $current_user;
++    $this->renderer = $renderer;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
++    return new static(
++      $configuration,
++      $plugin_id,
++      $plugin_definition,
++      $container->get('entity.manager'),
++      $container->get('module_handler'),
++      $container->get('current_user'),
++      $container->get('renderer')
++    );
++  }
++
++  /**
+    * {@inheritdoc}
+    */
+   public function defaultConfiguration() {
+@@ -162,9 +211,17 @@ public function getReferenceableEntities($match = NULL, $match_operator = 'CONTA
+
+     $return = [];
+     if ($result) {
+-      foreach ($this->view->result as $row) {
+-        $entity = $row->_entity;
+-        $return[$entity->bundle()][$entity->id()] = $entity->label();
++      // These results are usually displayed in an autocomplete field, which is
++      // surrounded by anchor tags. Most tags are allowed inside anchor tags,
++      // except for other anchor tags.
++      $allowed_tags = Xss::getAdminTagList();
++      if (($key = array_search('a', $allowed_tags)) !== FALSE) {
++        unset($allowed_tags[$key]);
++      }
++
++      foreach ($result as $id => $row) {
++        $entity = $row['#row']->_entity;
++        $return[$entity->bundle()][$id] = Xss::filter($this->renderer->renderPlain($row), $allowed_tags);
+       }
+     }
+     return $return;

--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -112,6 +112,9 @@
         "patches": {
           "drupal/asciidoc": {
             "Removing reference to String": "https://www.drupal.org/files/issues/issue-2916620.patch"
+          },
+          "drupal/core": {
+            "Fix entity reference view": "https://www.drupal.org/files/issues/2174633-174.patch"
           }
         }
     }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -43,18 +43,18 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  field_difficulty:
+    weight: 12
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_duration:
     weight: 11
     settings:
       allowed_periods: {  }
     third_party_settings: {  }
     type: interval_default
-    region: content
-  field_difficulty:
-    weight: 12
-    settings: {  }
-    third_party_settings: {  }
-    type: options_select
     region: content
   field_likes:
     weight: 8

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_related_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_related_content.yml
@@ -4,9 +4,6 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_related_content
-    - node.type.article
-    - node.type.books
-    - node.type.cheat_sheet
     - node.type.video_resource
 id: node.video_resource.field_related_content
 field_name: field_related_content
@@ -19,15 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      article: article
-      books: books
-      cheat_sheet: cheat_sheet
-      video_resource: video_resource
-    sort:
-      field: _none
-    auto_create: false
-    auto_create_bundle: article
+    view:
+      view_name: entity_type_view
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.entity_type_view.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.entity_type_view.yml
@@ -82,39 +82,54 @@ display:
           id: title
           table: node_field_data
           field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          label: ''
           exclude: false
+          alter:
+            alter_text: true
+            text: '{{title}} '
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -125,6 +140,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -135,8 +153,8 @@ display:
           label: ''
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: ' ({{type}})'
             make_link: false
             path: ''
             absolute: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.entity_type_view.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.entity_type_view.yml
@@ -1,0 +1,257 @@
+uuid: 842bb10f-a252-40ba-80a9-30ffa3ce1890
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: entity_type_view
+label: 'Entity Type View'
+module: views
+description: 'Use this view to display the content type along with the content'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+            type: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
To test: https://issues.jboss.org/browse/DEVELOPER-4553

You should be able to replicate this image
![content_type_reference](https://user-images.githubusercontent.com/938664/34011796-2e50fcda-e0c6-11e7-9bbd-edc1aadf1b7b.png)
