### PR TITLE
DEVELOPER-4573 Adding katacoda

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
@@ -5,6 +5,8 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
 ] %}
 {% include  '@rhd/paragraph/download_thankyou.html.twig' %}
 
+{# Adding in katacoda #}
+<script src="//katacoda.com/embed.js"></script>
 <div{{ attributes.addClass(classes) }}>
     {{ title_prefix }}
     <div{{ title_attributes }}>{{ label }}</div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/paragraph/paragraph--get-started.html.twig
@@ -6,7 +6,7 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
 {% include  '@rhd/paragraph/download_thankyou.html.twig' %}
 
 {# Adding in katacoda #}
-<script src="//katacoda.com/embed.js"></script>
+<script src="https://katacoda.com/embed.js"></script>
 <div{{ attributes.addClass(classes) }}>
     {{ title_prefix }}
     <div{{ title_attributes }}>{{ label }}</div>


### PR DESCRIPTION
Christina Lin wants to use katacoda for some of their stuff in Fuse.
We needed to add the script for katacoda.
I tried a couple of approaches, but this was the easiest and probably least invasive way of doing it.
We end up downloading an extra script file that at worst we won't need, but that doesn't seem to be that bad.

JIRA: https://issues.jboss.org/browse/DEVELOPER-4573

Testing:

Update a product Hello World page to include the following code (I tested in the additional section so you don't have to wade through tabs):

    <div id="my-element-1"
        data-katacoda-env="node"
        data-katacoda-layout="editor-terminal"
        data-katacoda-port="3000"
        data-katacoda-filename="app.js" style="border: 2px solid #ccc;" >
    var http = require('http');
    var requestListener = function (req, res) {
    res.writeHead(200);
    res.end('Hello, World!');
    }
    
    var server = http.createServer(requestListener);
    server.listen(3000, function() { console.log("Listening on port 3000")});
    </div>

You'll need to do that as source in the editor and save it without going back to the WYSIWYG part of the editor (I think).

Go and view the updated product and check to see if there is a katacoda section in the updated Hello World Page (It'll look like Eclipse Che, or an embeded terminal).