### PR TITLE
DEVELOPER-4385 Style fix for Middleware page

### DIFF
--- a/stylesheets/_middleware.scss
+++ b/stylesheets/_middleware.scss
@@ -1,7 +1,7 @@
 body.middleware {
   .wrapper { padding-bottom: 0; }
 
-  section {
+  section:not(.footer-links) {
     padding: 30px 0 60px 0;
     
     h3 {

--- a/stylesheets/_middleware.scss
+++ b/stylesheets/_middleware.scss
@@ -12,6 +12,7 @@ body.middleware {
     h4 { margin-bottom: 1em; }
 
     &.green {
+      background-color: #286322;
       padding: 30px 0 40px 0;
       h3 { margin-bottom: 8px; }
     }


### PR DESCRIPTION
[DEVELOPER-4385 - Bugs and issues for the /middleware page](https://issues.jboss.org/browse/DEVELOPER-4385)

1. Changes the background color for the green section in /middleware for a green that passes Web contrast/accessibility standards.
2. Fixes issue where footer in /middleware page was getting some extra padding. Footer should now look the same as in the other pages