### PR TITLE
DEVELOPER-4599 - This page is missing Red Hat Mobile Application Platform

### DIFF
--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -128,7 +128,7 @@ app.products = {
   "rhoar": {"stackoverflow": ["redhat-rhoar"]},
   "softwarecollections": {"upstream": null,"stackoverflow": ["rhel","rhel5","rhel6","rhel7"], "buzz_tags": ["software collections"]},
   "webserver": {"upstream": ["tomcat","httpd","mod_cluster"],"stackoverflow": ["jboss-web"], "buzz_tags": ["webserver"]},
-  "rhmap": {"upstream": ["feedhenry"],"stackoverflow": ["redhat-rhamt"],"buzz_tags": ["mobileplatform","mobile"]},
+  "rhmap": {"upstream": ["feedhenry"],"stackoverflow": ["rhmap"],"buzz_tags": ["mobileplatform","mobile"]},
   "clang-llvm-go-rust": {"upstream": null,"stackoverflow": {"AND" : {"tag_set_one" : ["redhat","red hat","rhel"], "tag_set_two" :["go","golang","rust","llvm","clang"]}},"buzz_tags": ["rhel","rhel7"]},
   "migrationtoolkit": {"upstream": null,"stackoverflow": ["rhamt"],"buzz_tags": ["windup","rhamt"]}
 };


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4599

The tag was updated to rhmap. This will still not return any results in staging since the below dcp call returns no results.
http://dcp.stage.jboss.org/v2/rest/search/stackoverflow/?field=sys_url_view&field=sys_title&field=is_answered&field=author&field=sys_tags&field=answers&field=sys_created&field=view_count&field=answer_count&field=down_vote_count&field=up_vote_count&field=sys_content&from=0&product=rhmap&project=&query=&query_highlight=true&size=10&size10=true&tag=rhmap

However, it will return results in production. The production DCP has results for the new tag:
https://dcp2.jboss.org/v2/rest/search/stackoverflow/?field=sys_url_view&field=sys_title&field=is_answered&field=author&field=sys_tags&field=answers&field=sys_created&field=view_count&field=answer_count&field=down_vote_count&field=up_vote_count&field=sys_content&from=0&product=rhmap&project=&query=&query_highlight=true&size=10&size10=true&tag=rhmap
