### PR TITLE
DEVELOPER-4609 - .NET Core download page incorrect

### DIFF
--- a/javascripts/downloads.js
+++ b/javascripts/downloads.js
@@ -227,7 +227,7 @@ $(function() {
 
   if($productDownloads && productCode) {
     $.getJSON(app.downloads.url + productCode,function(data) {
-      if(!data.length) {
+      if(!data.length || !data[0].productVersions.length || !data[0].featuredArtifact) {
         $("div.download-loading").removeClass('loading');
         $('.no-download').show();
         return;


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4609

Adds additional logic to test the download manager service response to make sure an empty table isn't created.