### PR TITLE
[DEVELOPER-4644] Ensured that login URL comparison for keycloak redir…

### DIFF
--- a/javascripts/sso.js
+++ b/javascripts/sso.js
@@ -7,7 +7,7 @@ app.sso = function () {
         digitalData.user = digitalData.user || [{profile: [{profileInfo: {}}]}];
         var usr = digitalData.user[0].profile[0].profileInfo || {};
 
-        if (window.location.href.indexOf('/login') >= 0 && window.location.href.indexOf('/user') < 0) {
+        if (window.location.href.toLowerCase().indexOf('/login') >= 0 && window.location.href.toLowerCase().indexOf('/user') < 0) {
             keycloak.login({"redirectUri": app.ssoConfig.logout_url});
         }
 


### PR DESCRIPTION
This PR makes the URL check for login case-insensitive so that content editors attempting to login to Drupal are not re-directed to the keycloak login page if they accidentally type '/User/login'.

To test:

- Ensure that you are not re-directed to keycloak login when entering the '/User/login' URL on the Drupal instance of this PR.