### PR TITLE
DEVELOPER-4610 - Updated REST export query for DCP indexing

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
@@ -696,12 +696,12 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/cheat-sheets
       pager:
-        type: some
+        type: none
         options:
-          items_per_page: 10
           offset: 0
       style:
         type: serializer


### PR DESCRIPTION
https://issues.jboss.org/browse/DEVELOPER-4610

You can review this by visiting /drupal/cheat-sheets. Pagination limited the results to 10. I switched the setting so it now returns all cheatsheets for the indexer.