### PR TITLE
[DEVELOPER-4647] Ensure prod Drupal uses puppet managed configuration file

### DIFF
--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "80:80"
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
-      - /credentials/drupal/rhd.settings-lightning.php:/var/www/drupal/web/sites/default/rhd.settings.php
+      - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - /data/drupal/config/lightning:/var/www/drupal/web/config/active
       - /data/drupal-logs/lightning:/var/log/httpd


### PR DESCRIPTION
This PR ensures that the production Drupal instance loads the `rhd.settings.php` file rather than `rhd.settings-lightning.php`. I assume the latter was created as part of the migration to the lightning profile, but as we're now running on completely new hardware, it is not required.

The `rhd.settings.php` already exists on the production host and has the exact same content as the `rhd.settings-lightning.php`:

```
[root@developer-rhdp-drupal drupal]# pwd
/credentials/drupal
[developer-rhdp-drupal.web.prod.ext.phx2.redhat.com] [12:46:07 PM]

[root@developer-rhdp-drupal drupal]# ls
rhd.settings-lightning.php  rhd.settings.php  rhd.settings.yml
[developer-rhdp-drupal.web.prod.ext.phx2.redhat.com] [12:46:08 PM]

[root@developer-rhdp-drupal drupal]# diff rhd.settings.php rhd.settings-lightning.php 
[developer-rhdp-drupal.web.prod.ext.phx2.redhat.com] [12:46:16 PM]
[root@developer-rhdp-drupal drupal]#
```