### PR TITLE
DEVELOPER-4640 - Fix DevSuite file versions to latest 2.2.0

### DIFF
--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -134,8 +134,8 @@ app.products = {
 };
 
 app.products.downloads = {
-    "devsuite" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"},
-    "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/cdk/hello-world/#fndtn-rhel"}
+    "devsuite" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"},
+    "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/cdk/hello-world/#fndtn-rhel"}
 };
 
 /*

--- a/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-all-item.ts
@@ -11,16 +11,8 @@ class RHDPDownloadsAllItem extends HTMLElement {
     private _platform;
 
     productDownloads = {
-        "devsuite": {
-            "windowsUrl": "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe",
-            "macUrl": "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip",
-            "rhelUrl": "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"
-        },
-        "cdk": {
-            "windowsUrl": "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer.exe",
-            "macUrl": "https://developers.redhat.com/download-manager/file/devsuite-2.1.0-GA-bundle-installer-mac.zip",
-            "rhelUrl": "https://developers.redhat.com/products/cdk/hello-world/#fndtn-rhel"
-        }
+        "devsuite" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"},
+        "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.2.0-GA-bundle-installer-mac.zip", "rhelUrl" : "https://developers.redhat.com/products/cdk/hello-world/#fndtn-rhel"}
     };
 
     constructor() {


### PR DESCRIPTION
This fixes the issue with the downloads pages on https://github.com/redhat-developer/developers.redhat.com/pull/2180