### PR TITLE
DEVELOPER-3932 Removed Resources from main nav

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -145,7 +145,6 @@
               contentType = subs[0];
             }
             break;
-          case 'resources':
           case 'search':
           case 'projects':
             pageType = 'search-results';
@@ -413,7 +412,6 @@
                     <li class="has-sub-nav">
                       <a href="#" class="sub-nav-help">Help<i class="fa fa-angle-down"></i></a>
                       <div class="sub-nav pull-right" id="sub-nav-help">
-                        <a href="/resources">Resources<span class="page-description">Important technical resources for you in all shapes and sizes:  blogs, books, code, videos and more.</span></a>
                         <a href="/forums">Forums<span class="page-description">We've extended our popular JBoss.org forums to cover our entire Red Hat portfolio for you.</span></a>
                         <a href="/stack-overflow">Stack Overflow Q&amp;A<span class="page-description">You already use Stack Overflow, so we'll help you use it to find your best answers.</span></a>
                       </div>

--- a/_tests/e2e/features/website/rhd_navigationMenu.feature
+++ b/_tests/e2e/features/website/rhd_navigationMenu.feature
@@ -89,11 +89,9 @@ Feature: Site navigation menu
     Given I am on the Home page
     When I scroll to the "Help" menu item
     Then I should see the following "Help" sub-menu items:
-      | Resources          |
       | Forums             |
       | Stack Overflow Q&A |
     Then each "Help" sub-menu item should contain a link to its retrospective page:
-      | resources      |
       | forums         |
       | stack-overflow |
 
@@ -102,7 +100,6 @@ Feature: Site navigation menu
     Given I am on the Home page
     When I tap on the "Help" menu item
     Then I should see the following "Help" sub-menu items:
-      | Resources          |
       | Forums             |
       | Stack Overflow Q&A |
 


### PR DESCRIPTION
[DEVELOPER-3932](https://issues.jboss.org/browse/DEVELOPER-3932)

Removes the Resources page from the main nav, and from the navigation e2e tests.

_Part 1 of a series of PRs to remove the Resources page._