### PR TITLE
DEVELOPER-4472 - Direct Links to Customer Portal on https://developers.redhat.com/downloads/

### DIFF
--- a/javascripts/build.js
+++ b/javascripts/build.js
@@ -1372,16 +1372,17 @@ var RHDPDownloadsProducts = /** @class */ (function (_super) {
                     "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
                     "featured": false,
                     "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
-                    "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+                    "downloadLink": "https://developers.redhat.com/products/webserver/download/",
                     "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
                     "version": "",
                     "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
                 }, {
                     "productName": "Red Hat Application Migration Toolkit",
                     "groupHeading": "DEVELOPER TOOLS",
+                    "productCode": "migrationtoolkit",
                     "featured": false,
                     "dataFallbackUrl": "https://access.redhat.com/downloads",
-                    "downloadLink": "https://access.redhat.com/downloads",
+                    "downloadLink": "",
                     "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
                     "version": "",
                     "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
@@ -1480,7 +1481,7 @@ var RHDPDownloadsProducts = /** @class */ (function (_super) {
                     "groupHeading": "MOBILE",
                     "featured": true,
                     "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
-                    "downloadLink": "https://access.redhat.com/downloads/content/316/",
+                    "downloadLink": "https://developers.redhat.com/products/mobileplatform/download/",
                     "description": "Develop and deploy mobile apps in an agile and flexible manner.",
                     "version": "",
                     "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"

--- a/typescript/rhdp-downloads/rhdp-downloads-products.ts
+++ b/typescript/rhdp-downloads/rhdp-downloads-products.ts
@@ -26,16 +26,17 @@ class RHDPDownloadsProducts extends HTMLElement {
             "groupHeading": "ACCELERATED DEVELOPMENT AND MANAGEMENT",
             "featured": false,
             "dataFallbackUrl": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
-            "downloadLink": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=webserver&productChanged=yes",
+            "downloadLink": "https://developers.redhat.com/products/webserver/download/",
             "description": "Apache httpd, Tomcat, etc. to provide a single solution for large-scale websites and light-weight Java web applications.",
             "version": "",
             "learnMoreLink": "https://developers.redhat.com/products/webserver/overview/"
         }, {
             "productName": "Red Hat Application Migration Toolkit",
             "groupHeading": "DEVELOPER TOOLS",
+            "productCode": "migrationtoolkit",
             "featured": false,
             "dataFallbackUrl": "https://access.redhat.com/downloads",
-            "downloadLink": "https://access.redhat.com/downloads",
+            "downloadLink": "",
             "description": "Red Hat Application Migration Toolkit is an assembly of open source tools that enables large-scale application migrations and modernizations. The tooling consists of multiple individual components that provide support for each phase of a migration process.",
             "version": "",
             "learnMoreLink": "https://developers.redhat.com/products/rhamt/overview/"
@@ -134,7 +135,7 @@ class RHDPDownloadsProducts extends HTMLElement {
             "groupHeading": "MOBILE",
             "featured": true,
             "dataFallbackUrl": "https://access.redhat.com/downloads/content/316/",
-            "downloadLink": "https://access.redhat.com/downloads/content/316/",
+            "downloadLink": "https://developers.redhat.com/products/mobileplatform/download/",
             "description": "Develop and deploy mobile apps in an agile and flexible manner.",
             "version": "",
             "learnMoreLink": "https://developers.redhat.com/products/mobileplatform/overview/"


### PR DESCRIPTION
To review: Visiting http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37212/downloads and check to make sure that:
* Red Hat JBoss Web Server points to https://developers.redhat.com/products/webserver/download/
* Red Hat Application Migration Toolkit to link directly to the default download, as this product is now in the download manager.
* Red Hat Mobile Application Platform to link to https://developers.redhat.com/products/mobileplatform/download/ (Check most popular as well).
