### PR TITLE
Fixes styles for middleware page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
@@ -94,6 +94,7 @@ function rhd_theme_suggestions_taxonomy_term_alter(array &$suggestions, array $v
 }
 
 function rhd_preprocess_html(array &$variables) {
+    $current_path = \Drupal::service('path.current')->getPath();
     $environment = \Drupal::config('redhat_developers')->get('environment');
     $dtm_code = \Drupal::config('redhat_developers')->get('dtm_code');
     $sentry_track = \Drupal::config('redhat_developers')->get('sentry_track');
@@ -111,6 +112,7 @@ function rhd_preprocess_html(array &$variables) {
     $variables['rhd_sentry_code'] = $sentry_code;
     $variables['rhd_base_url'] = $rhd_base_url;
     $variables['rhd_final_base_url'] = $rhd_final_base_url;
+    $variables['current_path'] = \Drupal::service('path.alias_manager')->getAliasByPath($current_path);
 
     if ($environment != 'prod') {
         $referrer = [

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -47,6 +47,7 @@
     not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
     node_type ? 'page-node-type-' ~ node_type|clean_class,
     db_offline ? 'db-offline',
+    current_path ? 'page' ~ current_path|clean_class,
   ]
 %}
 <!DOCTYPE html>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/templates/system/html.html.twig
@@ -493,7 +493,7 @@
           <div class="medium-5 small-24 columns">
             <a href="https://www.redhat.com" target="_blank" rel="noopener noreferrer"><img alt="Red Hat" class="rh-logo" src="/images/branding/RHLogo_white.svg" /></a>
           </div>
-          <div class="medium-14 columns">
+          <div class="medium-15 columns">
               <ul class="inline-list">
                   <li><a class="copyright">Copyright © {{ "now"|date("Y") }} Red Hat Inc.</a></li>
                   <li><a href="http://www.redhat.com/en/about/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy statement</a></li>
@@ -501,7 +501,7 @@
                   <li><a href="http://www.redhat.com/en/about/all-policies-guidelines" target="_blank" rel="noopener noreferrer">All policies and guidelines</a></li>
               </ul>
           </div>
-          <div class="medium-5 small-24 right columns">
+          <div class="medium-4 small-24 right columns">
               <a class="summit-logo" href="http://www.redhat.com/summit/" target="_blank" rel="noopener noreferrer"><img src="/images/design/logo-summit.png" alt="Red Hat Summit"></a>
           </div>
         </div>

--- a/stylesheets/_middleware.scss
+++ b/stylesheets/_middleware.scss
@@ -1,7 +1,7 @@
 body.page-middleware {
   .wrapper { padding-bottom: 0; }
 
-  section:not(.footer-links) {
+  section:not(.footer-links):not(.footer-legal) {
     padding: 30px 0 60px 0;
     
     h3 {
@@ -104,5 +104,4 @@ body.page-middleware {
       i { margin-bottom: 10px; }
     }
   }
-
 }

--- a/stylesheets/_middleware.scss
+++ b/stylesheets/_middleware.scss
@@ -1,4 +1,4 @@
-body.middleware {
+body.page-middleware {
   .wrapper { padding-bottom: 0; }
 
   section:not(.footer-links) {


### PR DESCRIPTION
Fixed issue where the page's path wasn't being added to the body tag of all pages. This will fix any issues where we need the path as a CSS class, such as the /middleware page to have page-specific CSS.