### PR TITLE
 Added as_is_html tag to StackOverflow page

### DIFF
--- a/javascripts/middleware-blog.js
+++ b/javascripts/middleware-blog.js
@@ -54,7 +54,6 @@ app.middlewareBlog.render = function(materials) {
 
 $(function() {
   var $middlewareBlogResourceList = $('.middleware-blog-latest');
-  console.log("here");
   // check if we are on a page that needs this to run
   if($middlewareBlogResourceList.length) {
     app.middlewareBlog.fetch();

--- a/stack-overflow.html.slim
+++ b/stack-overflow.html.slim
@@ -1,6 +1,7 @@
 ---
 layout: technology-base
 title: Stack Overflow
+drupal_format: as_is_html
 ---
 
 .hero.hero-wide.stackoverflow-main


### PR DESCRIPTION
/StackOverflow was still an Awestruct page. I added the as_is_html to fix that.

I also removed a random console.log that was mistakenly left behind in a js script.