### PR TITLE
JIRA 4796 - Wordpress post entity reference

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.routing.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.routing.yml
@@ -1,0 +1,7 @@
+rhd_assemblies.wppost_autocomplete:
+  path: '/rhd_assemblies/{field_name}/{count}'
+  defaults:
+    _controller: '\Drupal\rhd_assemblies\Controller\WppostAutocompleteController::handleAutocomplete'
+    _format: json
+  requirements:
+    _access: 'TRUE'

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.services.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.services.yml
@@ -1,0 +1,4 @@
+services:
+  rhd_assemblies.wordpress_api:
+    class: Drupal\rhd_assemblies\Service\WordpressApi
+    arguments: ['@http_client']

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
@@ -25,52 +25,10 @@ class WppostAutocompleteController extends ControllerBase {
       $typed_string = Tags::explode($input);
       $typed_string = Unicode::strtolower(array_pop($typed_string));
       if (strlen($typed_string) >= 3) {
-        $results = $this->wppost_by_title($typed_string, 10);
+        $results = \Drupal::service('rhd_assemblies.wordpress_api')->getAutocompleteContentOptions($typed_string, 10);
       }
     }
 
     return new JsonResponse($results);
   }
-
-  function wppost_by_title($title, $max_results) {
-    $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts';
-    $query = [
-      'per_page' => 100,
-      'page' => 1,
-      'context' => 'embed',
-      'search' => $title
-    ];
-    $client = \Drupal::httpClient();
-    $pages_to_query = 1;
-    $results = [];
-    try {
-      for ($i = 1; $i <= $pages_to_query; $i++) {
-        $query['page'] = $i;
-        $request = $client->request('GET', $feed_url, ['query' => $query]);
-        $request_headers = $request->getHeaders();
-        $pages_to_query = reset($request_headers['X-WP-TotalPages']);
-
-        $response = $request->getBody()->getContents();
-        $api_results = json_decode($response);
-        foreach ($api_results as $api_result) {
-          if (stripos($api_result->title->rendered, $title) !== FALSE) {
-            $results[] = [
-              'value' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')',
-              'label' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')'
-            ];
-            if (count($results) >= $max_results) {
-              return $results;
-            }
-          }
-        }
-      }
-    }
-    catch (\Exception $e) {
-      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
-      return [];
-    }
-    return $results;
-  }
-
-
 }

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
@@ -25,7 +25,7 @@ class WppostAutocompleteController extends ControllerBase {
       $typed_string = Tags::explode($input);
       $typed_string = Unicode::strtolower(array_pop($typed_string));
       if (strlen($typed_string) >= 3) {
-        $results = \Drupal::service('rhd_assemblies.wordpress_api')->getAutocompleteContentOptions($typed_string, 10);
+        $results = \Drupal::service('rhd_assemblies.wordpress_api')->getAutocompleteContentOptions($typed_string, $count);
       }
     }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Controller/WppostAutocompleteController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Controller;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Tags;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Defines a route controller for entity autocomplete form elements.
+ */
+class WppostAutocompleteController extends ControllerBase {
+
+  /**
+   * Handler for autocomplete request.
+   */
+  public function handleAutocomplete(Request $request, $field_name, $count) {
+    $results = [];
+
+    // Get the typed string from the URL, if it exists.
+    if ($input = $request->query->get('q')) {
+      $typed_string = Tags::explode($input);
+      $typed_string = Unicode::strtolower(array_pop($typed_string));
+      if (strlen($typed_string) >= 3) {
+        $results = $this->wppost_by_title($typed_string, 10);
+      }
+    }
+
+    return new JsonResponse($results);
+  }
+
+  function wppost_by_title($title, $max_results) {
+    $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts';
+    $query = [
+      'per_page' => 100,
+      'page' => 1,
+      'context' => 'embed',
+      'search' => $title
+    ];
+    $client = \Drupal::httpClient();
+    $pages_to_query = 1;
+    $results = [];
+    try {
+      for ($i = 1; $i <= $pages_to_query; $i++) {
+        $query['page'] = $i;
+        $request = $client->request('GET', $feed_url, ['query' => $query]);
+        $request_headers = $request->getHeaders();
+        $pages_to_query = reset($request_headers['X-WP-TotalPages']);
+
+        $response = $request->getBody()->getContents();
+        $api_results = json_decode($response);
+        foreach ($api_results as $api_result) {
+          if (stripos($api_result->title->rendered, $title) !== FALSE) {
+            $results[] = [
+              'value' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')',
+              'label' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')'
+            ];
+            if (count($results) >= $max_results) {
+              return $results;
+            }
+          }
+        }
+      }
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return [];
+    }
+    return $results;
+  }
+
+
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/BlogPostsBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/BlogPostsBuild.php
@@ -29,33 +29,16 @@ class BlogPostsBuild extends AssemblyBuildBase implements AssemblyBuildInterface
       }
     }
 
-    $page_max = 3;
-    $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts';
-    $query = ['per_page' => $page_max];
-
     // Add the category filter if applicable
     if (!empty($categories)) {
       $query['categories'] = $categories;
     }
 
-    try {
-      // retrieve posts
-      $client = \Drupal::httpClient();
-      $request = $client->request('GET', $feed_url, ['query' => $query]);
-      $response = $request->getBody()->getContents();
-      $results = json_decode($response);
-    }
-    catch (\Exception $ex) {
-      \Drupal::logger('rhd_assemblies')->error('Error fetching posts for blog assembly. Assembly ID: @id; URL: @feed_url <br />Query: @query <br />Message: @message', [
-        '@feed_url' => $feed_url,
-        '@query' => print_r($query, TRUE),
-        '@id' => $entity->id->value,
-        '@message' => $ex->getMessage(),
-      ]);
-    }
+    // Get the posts
+    $posts = \Drupal::service('rhd_assemblies.wordpress_api')->getContentByCategory($categories, 3);
 
-    if (!empty($results)) {
-      // make list of posts
+    // Build the posts
+    if (!empty($posts)) {
       $build['posts'] = [
         '#theme' => 'item_list',
         '#list_type' => 'ul',
@@ -63,47 +46,13 @@ class BlogPostsBuild extends AssemblyBuildBase implements AssemblyBuildInterface
         '#attributes' => ['class' => 'blog-post-teaser-list'],
       ];
 
-      foreach ($results as $result) {
-        $build['posts']['#items'][$result->id] = ['#theme' => 'wordpress_post_teaser', '#post' => $result, '#media' => FALSE, '#categories' => FALSE];
-
-        // retrieve categories
-        if (!empty($result->categories)) {
-          $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/categories';
-
-          try {
-            $request = $client->request('GET', $feed_url);
-            $response = $request->getBody()->getContents();
-            $categories = json_decode($response);
-            $build['posts']['#items'][$result->id]['#categories'] = $categories;
-          }
-          catch (\Exception $ex) {
-            \Drupal::logger('rhd_assemblies')->error('Error fetching categories for blog assembly. Assembly ID: @id; URL: @feed_url <br />Message: @message', [
-              '@feed_url' => $feed_url,
-              '@id' => $entity->id->value,
-              '@message' => $ex->getMessage(),
-            ]);
-          }
-        }
-
-        // retrieve images
-        if ($result->featured_media) {
-          $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/media/' . $result->featured_media;
-
-          try {
-            $request = $client->request('GET', $feed_url);
-            $response = $request->getBody()->getContents();
-            $media = json_decode($response);
-            $build['posts']['#items'][$result->id]['#media'] = $media;
-          }
-          catch (\Exception $ex) {
-            \Drupal::logger('rhd_assemblies')->error('Error fetching media for blog assembly. Assembly ID: @id; url: @feed_url <br />Message: @message', [
-              '@feed_url' => $feed_url,
-              '@id' => $entity->id->value,
-              '@message' => $ex->getMessage(),
-            ]);
-          }
-
-        }
+      foreach ($posts as $post) {
+        $build['posts']['#items'][] = [
+          '#theme' => 'wordpress_post_teaser',
+          '#post' => $post->content,
+          '#media' => $post->media,
+          '#categories' => $post->categories
+        ];
       }
     }
   }

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldFormatter/WppostTeaserFormatter.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldFormatter/WppostTeaserFormatter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'wppost_teaser' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "wppost_teaser",
+ *   label = @Translation("Wordpress post teaser"),
+ *   field_types = {
+ *     "wppost"
+ *   }
+ * )
+ */
+class WppostTeaserFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+    $entity = $items->getEntity();
+    $settings = $this->getSettings();
+
+    $client = \Drupal::httpClient();
+    foreach ($items as $delta => $item) {
+      $id = $items[$delta]->get('target_id')->getCastedValue();
+      $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts/' . $id;
+      try {
+        $request = $client->request('GET', $feed_url);
+        $request_headers = $request->getHeaders();
+        $response = $request->getBody()->getContents();
+        $result = json_decode($response);
+
+        $element[$delta] = [
+          '#theme' => 'wordpress_post_teaser',
+          '#post' => $result,
+          '#media' => FALSE,
+          '#categories' => FALSE
+        ];
+      }
+      catch (\Exception $e) {
+        \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      }
+    }
+
+    return $element;
+  }
+
+  function wppost_by_id($ids) {
+    $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts';
+    $query = [
+      'per_page' => count($ids),
+      'page' => 1,
+      'context' => 'view',
+      'include'
+    ];
+    $client = \Drupal::httpClient();
+    $pages_to_query = 1;
+    $results = [];
+    try {
+      for ($i = 1; $i <= $pages_to_query; $i++) {
+        $query['page'] = $i;
+        $request = $client->request('GET', $feed_url, ['query' => $query]);
+        $request_headers = $request->getHeaders();
+        $pages_to_query = reset($request_headers['X-WP-TotalPages']);
+
+        $response = $request->getBody()->getContents();
+        $api_results = json_decode($response);
+        foreach ($api_results as $api_result) {
+          if (stripos($api_result->title->rendered, $title) !== FALSE) {
+            $results[] = [
+              'value' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')',
+              'label' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')'
+            ];
+            if (count($results) >= $max_results) {
+              return $results;
+            }
+          }
+        }
+      }
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return [];
+    }
+    return $results;
+  }
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldFormatter/WppostTeaserFormatter.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldFormatter/WppostTeaserFormatter.php
@@ -26,68 +26,19 @@ class WppostTeaserFormatter extends FormatterBase {
     $entity = $items->getEntity();
     $settings = $this->getSettings();
 
-    $client = \Drupal::httpClient();
     foreach ($items as $delta => $item) {
       $id = $items[$delta]->get('target_id')->getCastedValue();
-      $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts/' . $id;
-      try {
-        $request = $client->request('GET', $feed_url);
-        $request_headers = $request->getHeaders();
-        $response = $request->getBody()->getContents();
-        $result = json_decode($response);
-
+      $post = \Drupal::service('rhd_assemblies.wordpress_api')->getContentById($id);
+      if ($post) {
         $element[$delta] = [
           '#theme' => 'wordpress_post_teaser',
-          '#post' => $result,
-          '#media' => FALSE,
-          '#categories' => FALSE
+          '#post' => $post->content,
+          '#media' => $post->media,
+          '#categories' => $post->categories
         ];
-      }
-      catch (\Exception $e) {
-        \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
       }
     }
 
     return $element;
-  }
-
-  function wppost_by_id($ids) {
-    $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/posts';
-    $query = [
-      'per_page' => count($ids),
-      'page' => 1,
-      'context' => 'view',
-      'include'
-    ];
-    $client = \Drupal::httpClient();
-    $pages_to_query = 1;
-    $results = [];
-    try {
-      for ($i = 1; $i <= $pages_to_query; $i++) {
-        $query['page'] = $i;
-        $request = $client->request('GET', $feed_url, ['query' => $query]);
-        $request_headers = $request->getHeaders();
-        $pages_to_query = reset($request_headers['X-WP-TotalPages']);
-
-        $response = $request->getBody()->getContents();
-        $api_results = json_decode($response);
-        foreach ($api_results as $api_result) {
-          if (stripos($api_result->title->rendered, $title) !== FALSE) {
-            $results[] = [
-              'value' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')',
-              'label' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')'
-            ];
-            if (count($results) >= $max_results) {
-              return $results;
-            }
-          }
-        }
-      }
-    }
-    catch (\Exception $e) {
-      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
-      return [];
-    }
-    return $results;
   }
 }

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldType/ListWpcategoriesItem.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldType/ListWpcategoriesItem.php
@@ -44,29 +44,7 @@ class ListWpcategoriesItem extends ListIntegerItem {
    * {@inheritdoc}
    */
   public function getSettableOptions(AccountInterface $account = NULL) {
-    $count = 0;
-    $page = 1;
-    $page_max = 100;
-    $results = [];
-    do {
-      $feed_url = 'https://developers.redhat.com/blog/wp-json/wp/v2/categories?per_page=' . $page_max . '&page=' . $page;
-      $client = \Drupal::httpClient();
-      $request = $client->request('GET', $feed_url, ['query' => ['per_page' => $page_max, 'page' => $page]]);
-      $response = $request->getBody()->getContents();
-      $page_results = json_decode($response);
-      $count = count($page_results);
-      $results = array_merge($page_results, $results);
-      $page++;
-    } while ($count == $page_max);
-
-    // $build['title'] = ['#markup' => '<h2>' . $results->title . '</h2>'];
-    $options = [];
-    if (!empty($results)) {
-      foreach ($results as $category) {
-        $options[$category->id] = $category->name;
-      }
-    }
-    return $options;
+    return \Drupal::service('rhd_assemblies.wordpress_api')->getCategoryOptions();
   }
 
   /**

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldType/WppostItem.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldType/WppostItem.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\TypedData\OptionsProviderInterface;
+
+/**
+ * Plugin implementation of the 'wppost' field type.
+ *
+ * @FieldType(
+ *   id = "wppost",
+ *   label = @Translation("Wordpress Post"),
+ *   description = @Translation("This field stores a Wordpress post ID."),
+ *   category = @Translation("Reference"),
+ *   default_widget = "wppost_autocomplete",
+ *   default_formatter = "wppost_teaser",
+ * )
+ */
+class WppostItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties = [];
+    $properties['target_id'] = DataDefinition::create('integer')
+      ->setLabel(t('Wordpress post ID'))
+      ->setRequired(TRUE);
+    $properties['title'] = DataDefinition::create('string')
+      ->setLabel(t('Wordpresspost title'))
+      ->setRequired(TRUE);
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [
+      // columns contains the values that the field will store
+      'columns' => [
+        // List the values that the field will save. This
+        // field will only save a single value, 'value'
+        'target_id' => [
+          'description' => 'The Wordpress post ID.',
+          'type' => 'int',
+          'not null' => TRUE,
+        ],
+        'title' => [
+          'description' => 'The title of the Wordpress post at time of selection.',
+          'type' => 'text',
+        ]
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $value = $this->get('target_id')->getValue();
+    return $value === NULL || $value === '';
+  }
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
@@ -20,24 +20,48 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class WppostAutocompleteWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'result_count' => 10,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements['result_count'] = [
+      '#type' => 'number',
+      '#title' => t('Number of results'),
+      '#default_value' => $this->getSetting('result_count'),
+      '#required' => TRUE,
+      '#min' => 1
+    ];
+    return $elements;
+  }
+
   /**
    * {@inheritdoc}
    */
   public function settingsSummary() {
-    return [];
+    $summary = [];
+    $summary[] = t('Matches shown: @count', ['@count' => $this->getSetting('result_count')]);
+    return $summary;
   }
 
   /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-
-
     $output['value'] = $element;
     $output['value'] += [
       '#type' => 'textfield',
       '#autocomplete_route_name' => 'rhd_assemblies.wppost_autocomplete',
-      '#autocomplete_route_parameters' => ['field_name' => $this->fieldDefinition->getLabel(), 'count' => 10],
+      '#autocomplete_route_parameters' => ['field_name' => $this->fieldDefinition->getLabel(), 'count' => $this->getSetting('result_count')],
     ];
 
     if (!$items[$delta]->isEmpty()) {

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
@@ -40,7 +40,7 @@ class WppostAutocompleteWidget extends WidgetBase {
       '#autocomplete_route_parameters' => ['field_name' => $this->fieldDefinition->getLabel(), 'count' => 10],
     ];
 
-    if (isset($items[$delta])) {
+    if (!$items[$delta]->isEmpty()) {
       $id = $items[$delta]->getValue()['target_id'];
       $title = $items[$delta]->getValue()['title'];
       $output['value']['#default_value'] = $title . ' (' . $id . ')';

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'wppost_autocomplete' widget.
+ *
+ * @FieldWidget(
+ *   id = "wppost_autocomplete",
+ *   label = @Translation("Wordpress Post Autocomplete"),
+ *   field_types = {
+ *     "wppost",
+ *   },
+ *   multiple_values = FALSE
+ * )
+ */
+class WppostAutocompleteWidget extends WidgetBase {
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+
+    $output['value'] = $element;
+    $output['value'] += [
+      '#type' => 'textfield',
+      '#autocomplete_route_name' => 'rhd_assemblies.wppost_autocomplete',
+      '#autocomplete_route_parameters' => ['field_name' => $this->fieldDefinition->getLabel(), 'count' => 10],
+    ];
+
+    if (isset($items[$delta])) {
+      $id = $items[$delta]->getValue()['target_id'];
+      $title = $items[$delta]->getValue()['title'];
+      $output['value']['#default_value'] = $title . ' (' . $id . ')';
+    }
+
+    return $output;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    foreach ($values as $key => $value) {
+      $target_id = $this->extractWpIdFromAutocompleteInput($value['value']);
+      $title = str_replace(' (' . $target_id . ')', '', $value['value']);
+      $values[$key] = [
+        'target_id' => $target_id,
+        'title' => $title
+      ];
+    }
+    return $values;
+  }
+
+  /**
+   * Copied directly from Drupal\Core\Entity\Element\EntityAutocomplete,
+   * only this will look for the last match, instead of the second (in case
+   * there are titles with parentheses)
+   */
+  public function extractWpIdFromAutocompleteInput($input) {
+    $match = NULL;
+    if (preg_match("/.+\s\(([^\)]+)\)/", $input, $matches)) {
+      $match = $matches[count($matches)-1];
+    }
+    return $match;
+  }
+
+  public function extractWpTitleFromAutocompleteInput($input) {
+    $id = $this->extractWpTitleFromAutocompleteInput($input);
+    $match = str_replace(' (' . $id . ')', '', $input);
+    return $match;
+  }
+
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/RemoteContentApiInterface.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/RemoteContentApiInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Service;
+
+/**
+ * Interface RemoteContentApiInterface
+ */
+interface RemoteContentApiInterface {
+  public function getContentById($id);
+  public function getContentByCategory($categories, $max_results);
+  public function getAutocompleteContentOptions($search, $max_results);
+  public function getCategories();
+  public function getCategoryOptions();
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Service;
+
+use Drupal\Component\Utility\Html;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Class WordpressApi
+ */
+class WordpressApi implements RemoteContentApiInterface {
+
+  private $apiUrl;
+  private $client;
+
+  public function __construct(ClientInterface $client) {
+    $this->apiUrl = 'https://developers.redhat.com/blog/wp-json/wp/v2';
+    $this->client = $client;
+  }
+
+  public function getContentById($id) {
+    try {
+      $feed_url = $this->apiUrl . '/posts/' . $id;
+      $request = $this->client->request('GET', $feed_url);
+      $response = $request->getBody()->getContents();
+      $result = json_decode($response);
+      return $this->getContentComposite($result);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return false;
+    }
+  }
+
+  public function getContentByCategory($categories, $count) {
+    $items = [];
+    $feed_url = $this->apiUrl . '/posts';
+    $query['per_page'] = $count;
+
+    if (!empty($categories)) {
+      $query['categories'] = $categories;
+    }
+
+    try {
+      $request = $this->client->request('GET', $feed_url, ['query' => $query]);
+      $response = $request->getBody()->getContents();
+      $results = json_decode($response);
+      foreach ($results as $result) {
+        $items[] = $this->getContentComposite($result);
+      }
+      return $items;
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return [];
+    }
+  }
+
+  public function getAutocompleteContentOptions($search, $max_results) {
+    $feed_url = $this->apiUrl . '/posts';
+    $query = [
+      'per_page' => $max_results,
+      'page' => 1,
+      'context' => 'embed',
+      'search' => $search
+    ];
+    $results = [];
+    try {
+      $request = $this->client->request('GET', $feed_url, ['query' => $query]);
+      $response = $request->getBody()->getContents();
+      $api_results = json_decode($response);
+      foreach ($api_results as $api_result) {
+        $results[] = [
+          'value' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')',
+          'label' => Html::escape($api_result->title->rendered) . ' (' . $api_result->id . ')'
+        ];
+      }
+      return $results;
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return [];
+    }
+  }
+
+  public function getCategories() {
+    $feed_url = $this->apiUrl . '/categories';
+    $query = [
+      'per_page' => 100,
+      'page' => 1,
+    ];
+    $pages_to_query = 1;
+    $results = [];
+    try {
+      for ($i = 1; $i <= $pages_to_query; $i++) {
+        $query['page'] = $i;
+        $request = $this->client->request('GET', $feed_url, ['query' => $query]);
+        $request_headers = $request->getHeaders();
+        $pages_to_query = reset($request_headers['X-WP-TotalPages']);
+        $response = $request->getBody()->getContents();
+        $api_results = json_decode($response);
+        foreach ($api_results as $api_result) {
+          $results[$api_result->id] = $api_result;
+        }
+      }
+      return $results;
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('rhd_assemblies')->error("Exception while calling Wordpress API: " . $e->getMessage());
+      return [];
+    }
+  }
+
+  public function getCategoryOptions() {
+    $categories = $this->getCategories();
+    foreach ($categories as $id => $category) {
+      $categories[$id] = $category->name;
+    }
+    return $categories;
+  }
+
+  private function getContentComposite($content) {
+    $item = new \stdClass();
+    $item->content = $content;
+    $item->media = false;
+    $item->categories = false;
+
+    if (isset($content->featured_media)) {
+      $item->media = $this->getContentMedia($content->featured_media);
+    }
+
+    if (isset($content->categories)) {
+      $item->categories = $this->getContentCategoryLinks($content->categories);
+    }
+
+    return $item;
+  }
+
+  private function getContentMedia($id) {
+    $feed_url = $this->apiUrl . '/media/' . $id;
+    $request = $this->client->request('GET', $feed_url);
+    $response = $request->getBody()->getContents();
+    return json_decode($response);
+  }
+
+  private function getContentCategoryLinks($categories) {
+    $links = [];
+    $categories_list = $this->getCategories();
+    foreach($categories as $category_id) {
+      $links[] = [
+        'link' => $categories_list[$category_id]->link,
+        'name' => $categories_list[$category_id]->name,
+      ];
+    }
+    return $links;
+  }
+
+
+}


### PR DESCRIPTION
- Refactors existing wordpress API calls into a service.
- Adds several methods to that service to facilitate display/querying of wordpress content
- Adds a field type, widget, and formatter for a single wordpress post