### PR TITLE
[DO NOT MERGE] DEVELOPER-4799: Static Content Band assembly type

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.node_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.node_reference.yml
@@ -1,0 +1,9 @@
+uuid: e3a46f43-3039-454d-b999-733e0457a783
+langcode: en
+status: true
+dependencies: {  }
+id: node_reference
+label: 'Node Reference'
+description: 'An assembly referencing a single node'
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.static_content_band.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.static_content_band.yml
@@ -1,0 +1,9 @@
+uuid: e910021f-2e4e-4da0-b469-c73d8ebb0d11
+langcode: en
+status: true
+dependencies: {  }
+id: static_content_band
+label: 'Static Content Band'
+description: 'An assembly that displays a curated list of wordpress posts and/or drupal nodes.'
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.wordpress_post_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.wordpress_post_reference.yml
@@ -1,0 +1,9 @@
+uuid: c97837bb-cde5-44b7-a5b8-777fa8fd8178
+langcode: en
+status: true
+dependencies: {  }
+id: wordpress_post_reference
+label: 'Wordpress Post Reference'
+description: 'An assembly referencing a single Wordpress post'
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.node_reference.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.node_reference.default.yml
@@ -1,0 +1,27 @@
+uuid: 596ec091-68b5-4e7e-8e92-459cdda2e624
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.node_reference
+    - field.field.assembly.node_reference.field_node_reference
+id: assembly.node_reference.default
+targetEntityType: assembly
+bundle: node_reference
+mode: default
+content:
+  field_node_reference:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  moderation_state: true
+  name: true
+  status: true
+  user_id: true
+  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
@@ -1,0 +1,57 @@
+uuid: 4e34e04c-6302-4294-9e5c-3cd0ab73249d
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.static_content_band
+    - field.field.assembly.static_content_band.field_content_list
+  module:
+    - entity_browser_entity_form
+    - inline_entity_form
+id: assembly.static_content_band.default
+targetEntityType: assembly
+bundle: static_content_band
+mode: default
+content:
+  field_content_list:
+    weight: 3
+    settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      match_operator: CONTAINS
+      override_labels: false
+      collapsible: false
+      collapsed: false
+      allow_existing: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  visual_styles:
+    type: options_select
+    multiple: true
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  moderation_state: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.wordpress_post_reference.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.wordpress_post_reference.default.yml
@@ -1,0 +1,27 @@
+uuid: a91a804a-f1b9-4bfd-810d-e8dc8f2eefc1
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.wordpress_post_reference
+    - field.field.assembly.wordpress_post_reference.field_post_reference
+  module:
+    - rhd_assemblies
+id: assembly.wordpress_post_reference.default
+targetEntityType: assembly
+bundle: wordpress_post_reference
+mode: default
+content:
+  field_post_reference:
+    weight: 0
+    settings:
+      result_count: 10
+    third_party_settings: {  }
+    type: wppost_autocomplete
+    region: content
+hidden:
+  moderation_state: true
+  name: true
+  status: true
+  user_id: true
+  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.node_reference.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.node_reference.default.yml
@@ -1,0 +1,24 @@
+uuid: 1ddeb91f-9e3f-4c4f-a721-2b73844fccae
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.node_reference
+    - field.field.assembly.node_reference.field_node_reference
+id: assembly.node_reference.default
+targetEntityType: assembly
+bundle: node_reference
+mode: default
+content:
+  field_node_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
@@ -1,0 +1,24 @@
+uuid: 2a261b76-c227-4398-b90d-517e4814ff35
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.static_content_band
+    - field.field.assembly.static_content_band.field_content_list
+id: assembly.static_content_band.default
+targetEntityType: assembly
+bundle: static_content_band
+mode: default
+content:
+  field_content_list:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.wordpress_post_reference.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.wordpress_post_reference.default.yml
@@ -1,0 +1,24 @@
+uuid: 635d73fa-5092-46b5-8455-dc142dda5d1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.wordpress_post_reference
+    - field.field.assembly.wordpress_post_reference.field_post_reference
+  module:
+    - rhd_assemblies
+id: assembly.wordpress_post_reference.default
+targetEntityType: assembly
+bundle: wordpress_post_reference
+mode: default
+content:
+  field_post_reference:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: wppost_teaser
+    region: content
+hidden:
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.node_reference.field_node_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.node_reference.field_node_reference.yml
@@ -1,0 +1,28 @@
+uuid: 9edf19bb-3633-4761-a2b6-42a608531c46
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.node_reference
+    - field.storage.assembly.field_node_reference
+    - node.type.video_resource
+id: assembly.node_reference.field_node_reference
+field_name: field_node_reference
+entity_type: assembly
+bundle: node_reference
+label: 'Node Reference'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      video_resource: video_resource
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: article
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_content_list.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_content_list.yml
@@ -1,0 +1,30 @@
+uuid: d17ab1ac-66ab-426c-a06c-5984e52b4fde
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.node_reference
+    - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.wordpress_post_reference
+    - field.storage.assembly.field_content_list
+id: assembly.static_content_band.field_content_list
+field_name: field_content_list
+entity_type: assembly
+bundle: static_content_band
+label: 'Content List'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:assembly'
+  handler_settings:
+    target_bundles:
+      node_reference: node_reference
+      wordpress_post_reference: wordpress_post_reference
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: node_reference
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.wordpress_post_reference.field_post_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.wordpress_post_reference.field_post_reference.yml
@@ -1,0 +1,21 @@
+uuid: 1a907ec2-eab0-4b7b-80d7-579c574530c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.wordpress_post_reference
+    - field.storage.assembly.field_post_reference
+  module:
+    - rhd_assemblies
+id: assembly.wordpress_post_reference.field_post_reference
+field_name: field_post_reference
+entity_type: assembly
+bundle: wordpress_post_reference
+label: 'Post Reference'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: wppost

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
@@ -6,6 +6,7 @@ dependencies:
     - assembly.assembly_type.blog_posts
     - assembly.assembly_type.content_with_image
     - assembly.assembly_type.rich_text
+    - assembly.assembly_type.static_content_band
     - assembly.assembly_type.videos
     - field.storage.node.field_sections
     - node.type.assembly_page
@@ -28,6 +29,7 @@ settings:
       blog_posts: blog_posts
       content_with_image: content_with_image
       rich_text: rich_text
+      static_content_band: static_content_band
       videos: videos
     sort:
       field: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_content_list.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_content_list.yml
@@ -1,0 +1,19 @@
+uuid: c76d5d9e-04c6-407f-a49a-88ec7d597167
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+id: assembly.field_content_list
+field_name: field_content_list
+entity_type: assembly
+type: entity_reference
+settings:
+  target_type: assembly
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_node_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_node_reference.yml
@@ -1,0 +1,20 @@
+uuid: 6daa9023-e260-4ac9-b6e4-2545b517e0da
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+    - node
+id: assembly.field_node_reference
+field_name: field_node_reference
+entity_type: assembly
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_post_reference.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_post_reference.yml
@@ -1,0 +1,19 @@
+uuid: ad05f35a-13ac-47af-be94-585278807302
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+    - rhd_assemblies
+id: assembly.field_post_reference
+field_name: field_post_reference
+entity_type: assembly
+type: wppost
+settings: {  }
+module: rhd_assemblies
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
@@ -5,7 +5,9 @@
  * Contains rhd_assemblies.module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_help().
@@ -53,4 +55,22 @@ function rhd_assemblies_theme($existing, $type, $theme, $path) {
     ],
   ];
   return $theme;
+}
+
+function rhd_assemblies_entity_presave(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() == 'assembly' && in_array($entity->bundle(), ['node_reference', 'wordpress_post_reference'])) {
+    if ($entity->bundle() == 'node_reference') {
+      $field = $entity->get('field_node_reference')->getValue();
+      $node_id = reset($field)['target_id'];
+      $node = Node::load($node_id);
+      $title = $node->label();
+      $entity->set('name', $title);
+    }
+
+    if ($entity->bundle() == 'wordpress_post_reference') {
+      $field = $entity->get('field_post_reference')->getValue();
+      $title = reset($field)['title'];
+      $entity->set('name', $title);
+    }
+  }
 }


### PR DESCRIPTION
New assembly type that allows a reorderable curated list of wordpress and/or drupal posts/nodes. There's an entity presave hook that will update the names of the subassemblies based on the content they reference.