### PR TITLE
use new title search endpoint for wordpress post matching

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/Field/FieldWidget/WppostAutocompleteWidget.php
@@ -39,7 +39,8 @@ class WppostAutocompleteWidget extends WidgetBase {
       '#title' => t('Number of results'),
       '#default_value' => $this->getSetting('result_count'),
       '#required' => TRUE,
-      '#min' => 1
+      '#min' => 1,
+      '#max' => 100
     ];
     return $elements;
   }


### PR DESCRIPTION
This uses the new title search wordpress endpoint to improve functionality of the wordpress post autocomplete from JIRA 4796. Also fixes a bug which would prevent content without featured media from rendering properly. 