### PR TITLE
Fix for intermittent failures on PR's.

### DIFF
--- a/_tests/e2e/features/step_definitions/hooks.js
+++ b/_tests/e2e/features/step_definitions/hooks.js
@@ -35,28 +35,39 @@ const hooks = function () {
     });
 
     this.After(function () {
-        let encodedURL = qs.escape(process.env.RHD_BASE_URL);
-        if (process.env.RHD_BASE_URL === 'https://developers.stage.redhat.com') {
-            browser.url(`https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`)
-        } else {
-            browser.url(`https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`)
+        try {
+            let encodedURL = qs.escape(process.env.RHD_BASE_URL);
+            if (process.env.RHD_BASE_URL === 'https://developers.stage.redhat.com') {
+                browser.url(`https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`)
+            } else {
+                browser.url(`https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`)
+            }
+        } catch (e) {
+            console.log(e)
         }
 
         if (typeof downloadStarted !== 'undefined') {
-            let dirSize = [];
-            fs.readdirSync(global.downloadDir).forEach(file => {
-                dirSize.push(file)
-            });
-            if (dirSize.length > 0) {
-                fs.emptyDir(global.downloadDir)
+            try {
+                let dirSize = [];
+                fs.readdirSync(global.downloadDir).forEach(file => {
+                    dirSize.push(file)
+                });
+                if (dirSize.length > 0) {
+                    fs.emptyDir(global.downloadDir)
+                }
+            } catch (e) {
+                console.log(e)
             }
         }
 
         if (typeof socialAccountHolder !== 'undefined') {
-            let keycloakAdmin = new KeyCloakAdmin();
-            keycloakAdmin.deleteUser(siteUserDetails['email'])
+            try {
+                let keycloakAdmin = new KeyCloakAdmin();
+                keycloakAdmin.deleteUser(siteUserDetails['email'])
+            } catch (e) {
+                console.log(e)
+            }
         }
-
         browser.deleteCookie();
         browser.execute('window.localStorage.clear();');
     });

--- a/_tests/e2e/features/support/pages/keycloak/Login.page.js
+++ b/_tests/e2e/features/support/pages/keycloak/Login.page.js
@@ -26,7 +26,7 @@ class LoginPage extends BasePage {
     }
 
     loginPageDisplayed() {
-        driver.waitForTitle('Log In');
+        driver.waitForTitle('Log In', 30000);
         let el = driver.element(this.getSelector('loginPage'));
         return driver.isDisplayed(el)
     }

--- a/_tests/e2e/features/support/pages/keycloak/Register.page.js
+++ b/_tests/e2e/features/support/pages/keycloak/Register.page.js
@@ -37,7 +37,7 @@ class RegisterPage extends BasePage {
     }
 
     kcRegisterFormDispalyed() {
-        driver.waitForTitle('Register');
+        driver.waitForTitle('Register', 30000);
         return driver.isDisplayed(this.getSelector('registerForm'), 30000);
     }
 


### PR DESCRIPTION
Minor changes to fix intermittent failures on PR's. 

- Upped the wait time for login/register pages.
- Added try/catch to after hooks. Noticed on @KamiQuasi 's PR the after hook timed out with `function timed out after 60000 milliseconds`. Catching the after hook with console output as we don't want the test to fail after it is already complete. 