### PR TITLE
fences shouldn't do anything when rhd is the active theme

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -42,6 +42,7 @@ module:
   entity_reference: 0
   entity_reference_revisions: 0
   events: 0
+  fences: 0
   field: 0
   field_group: 0
   field_ui: 0

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhd/rhd.theme
@@ -12,6 +12,13 @@ use Drupal\Core\Link;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 
+function rhd_theme_registry_alter(&$theme_registry) {
+  $theme = \Drupal::config('system.theme')->get('default');
+  if ($theme == 'rhd') {
+    $theme_registry['field']['path'] = 'core/themes/classy/templates/field';
+  }
+}
+
 
 function rhd_theme_suggestions_page_alter(array &$suggestions, array $variables) {
     $node = \Drupal::request()->attributes->get('node');


### PR DESCRIPTION
Fences needs to be enabled for a lot of the frontend work we're doing with the new theme, but we don't want it to have any effect on the current them. Fences works by altering the theme registry and inserting its own path the field templates - this simply forces the path to be that of the Classy theme (what RHD inherits from)