### PR TITLE
[URGENT] EventsValidationFix - Fixed date comparison bug

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.form_validations.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.form_validations.inc
@@ -31,7 +31,7 @@ function rhd_common_form_node_events_edit_form_alter(&$form, FormStateInterface 
 function add_events_validations(array &$form, FormStateInterface $form_state)
 {
   // Basic date comparison
-  $end_before_start = $form_state->getValue('field_end_date')[0]['value'] < $form_state->getValue('field_start_date')[0]['value']['object'];
+  $end_before_start = $form_state->getValue('field_end_date')[0]['value']->getTimeStamp() < $form_state->getValue('field_start_date')[0]['value']->getTimeStamp();
   if ($end_before_start === TRUE)
   {
     $form_state->setErrorByName('field_end_date', t('End Date must be after Start Date')); // Create the error


### PR DESCRIPTION
To test: Create a new event with dates included. This should no longer bug out.

Also, make sure that form error is thrown when end date is before start date.