### PR TITLE
DEVELOPER-4805: new Topic Page node type

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.base_field_override.node.topic_page.promote.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.base_field_override.node.topic_page.promote.yml
@@ -1,0 +1,22 @@
+uuid: ad0fb213-1122-4c67-93df-66d8bf5c3827
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.topic_page
+id: node.topic_page.promote
+field_name: promote
+entity_type: node
+bundle: topic_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -1,0 +1,83 @@
+uuid: 1d4568c9-13eb-4502-a96a-35f0103cb933
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.topic_page.field_sections
+    - field.field.node.topic_page.scheduled_update
+    - node.type.topic_page
+  module:
+    - entity_browser_entity_form
+    - inline_entity_form
+    - path
+    - workbench_moderation
+id: node.topic_page.default
+targetEntityType: node
+bundle: topic_page
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_sections:
+    weight: 6
+    settings:
+      form_mode: default
+      override_labels: true
+      label_singular: section
+      label_plural: sections
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      collapsible: false
+      collapsed: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 2
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduled_update:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden:
+  promote: true
+  status: true
+  sticky: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
@@ -1,0 +1,35 @@
+uuid: 579f5ed8-3dc8-44d9-bc66-a4bfaf03bf1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.topic_page.field_sections
+    - field.field.node.topic_page.scheduled_update
+    - node.type.topic_page
+  module:
+    - entity_reference_revisions
+    - user
+id: node.topic_page.default
+targetEntityType: node
+bundle: topic_page
+mode: default
+content:
+  field_sections:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  scheduled_update:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  links: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
@@ -1,0 +1,20 @@
+uuid: 2f8ffadc-5f6e-492a-ba4b-ee651808a157
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.topic_page.field_sections
+    - node.type.topic_page
+  module:
+    - user
+id: node.topic_page.teaser
+targetEntityType: node
+bundle: topic_page
+mode: teaser
+content:
+  links:
+    weight: 100
+    region: content
+hidden:
+  field_sections: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
@@ -1,0 +1,44 @@
+uuid: cb0ce5f9-b6f5-4c8b-bc79-5161cf177255
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.blog_posts
+    - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.featured_evangelists
+    - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.rich_text
+    - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.videos
+    - field.storage.node.field_sections
+    - node.type.topic_page
+  module:
+    - entity_reference_revisions
+id: node.topic_page.field_sections
+field_name: field_sections
+entity_type: node
+bundle: topic_page
+label: Sections
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:assembly'
+  handler_settings:
+    target_bundles:
+      blog_posts: blog_posts
+      call_to_action: call_to_action
+      content_with_image: content_with_image
+      static_content_band: static_content_band
+      featured_evangelists: featured_evangelists
+      on_page_navigation: on_page_navigation
+      rich_text: rich_text
+      videos: videos
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: blog_posts
+field_type: entity_reference_revisions

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.scheduled_update.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.scheduled_update.yml
@@ -1,0 +1,28 @@
+uuid: 133bcca1-dec5-4eb7-ab3f-52b6d78cb7b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.scheduled_update
+    - node.type.topic_page
+    - scheduled_updates.scheduled_update_type.node__moderation_state
+id: node.topic_page.scheduled_update
+field_name: scheduled_update
+entity_type: node
+bundle: topic_page
+label: 'Scheduled updates'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:scheduled_update'
+  handler_settings:
+    target_bundles:
+      node__moderation_state: node__moderation_state
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/node.type.topic_page.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/node.type.topic_page.yml
@@ -1,4 +1,4 @@
-uuid: ef6d8b09-e100-45a3-9110-20712ac27110
+uuid: 231d9406-d5bf-4db8-b676-6e704585f163
 langcode: en
 status: true
 dependencies:
@@ -7,8 +7,9 @@ dependencies:
     - workbench_moderation
 third_party_settings:
   menu_ui:
-    available_menus: {  }
-    parent: ''
+    available_menus:
+      - main
+    parent: 'main:'
   workbench_moderation:
     enabled: true
     allowed_moderation_states:
@@ -17,12 +18,10 @@ third_party_settings:
       - draft
       - needs_review
     default_moderation_state: draft
-_core:
-  default_config_hash: MgVh0-aL08L1QpvfWdpDEn8R_Z6zmrMYmBdbem_ctz0
-name: 'Topic Page (Deprecated)'
-type: topic
+name: 'Topic Page'
+type: topic_page
 description: ''
 help: ''
-new_revision: false
+new_revision: true
 preview_mode: 1
 display_submitted: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/simple_sitemap.bundle_settings.node.topic_page.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/simple_sitemap.bundle_settings.node.topic_page.yml
@@ -1,0 +1,2 @@
+index: 1
+priority: '0.5'


### PR DESCRIPTION
There might need to be a followup issue on this - I can't add assembly types to the sections field that are currently pending pull requests. Any future tasks to create an assembly type should consider it part of that task to add the assembly type to the sections field for Landing Pages and Topic Pages.