### PR TITLE
Use title field instead of name on assemblies

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.dynamic_content_feed.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.dynamic_content_feed.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.dynamic_content_feed.field_cta_link
     - field.field.assembly.dynamic_content_feed.field_drupal_term_filter
     - field.field.assembly.dynamic_content_feed.field_number_of_posts
+    - field.field.assembly.dynamic_content_feed.field_title
   module:
     - link
     - rhd_assemblies
@@ -23,7 +24,7 @@ content:
     type: wpcategories_options_select
     region: content
   field_cta_link:
-    weight: 27
+    weight: 6
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -31,7 +32,7 @@ content:
     type: link_default
     region: content
   field_drupal_term_filter:
-    weight: 26
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -43,6 +44,14 @@ content:
     third_party_settings: {  }
     type: number
     region: content
+  field_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -53,7 +62,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 7
     region: content
     settings:
       display_label: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.dynamic_content_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.dynamic_content_list.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.dynamic_content_list.field_cta_link
     - field.field.assembly.dynamic_content_list.field_drupal_term_filter
     - field.field.assembly.dynamic_content_list.field_links
+    - field.field.assembly.dynamic_content_list.field_title
   module:
     - link
     - rhd_assemblies
@@ -23,7 +24,7 @@ content:
     type: wpcategories_options_select
     region: content
   field_cta_link:
-    weight: 27
+    weight: 6
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -37,12 +38,20 @@ content:
     type: options_select
     region: content
   field_links:
-    weight: 26
+    weight: 5
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield
@@ -54,7 +63,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 7
     region: content
     settings:
       display_label: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_evangelists.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_evangelists.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - assembly.assembly_type.featured_evangelists
     - field.field.assembly.featured_evangelists.field_cta_link
     - field.field.assembly.featured_evangelists.field_evangelists
+    - field.field.assembly.featured_evangelists.field_title
   module:
     - link
 id: assembly.featured_evangelists.default
@@ -14,7 +15,7 @@ bundle: featured_evangelists
 mode: default
 content:
   field_cta_link:
-    weight: 26
+    weight: 4
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -30,6 +31,14 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -40,7 +49,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 5
     region: content
     settings:
       display_label: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.static_content_band
     - field.field.assembly.static_content_band.field_content_list
+    - field.field.assembly.static_content_band.field_title
   module:
     - entity_browser_entity_form
     - inline_entity_form
@@ -30,6 +31,14 @@ content:
         entity_browser_id: _none
     type: inline_entity_form_complex
     region: content
+  field_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -40,7 +49,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 4
     region: content
     settings:
       display_label: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.dynamic_content_feed.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.dynamic_content_feed.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.dynamic_content_feed.field_cta_link
     - field.field.assembly.dynamic_content_feed.field_drupal_term_filter
     - field.field.assembly.dynamic_content_feed.field_number_of_posts
+    - field.field.assembly.dynamic_content_feed.field_title
   module:
     - fences
     - link
@@ -35,23 +36,24 @@ content:
         fences_label_classes: ''
     type: link
     region: content
-  name:
-    type: string
+  field_title:
     weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings:
       fences:
-        fences_field_tag: h2
-        fences_field_classes: header
-        fences_field_item_tag: none
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
+    type: string
+    region: content
 hidden:
   field_category_filter: true
   field_drupal_term_filter: true
   field_number_of_posts: true
+  name: true
   user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.dynamic_content_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.dynamic_content_list.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.dynamic_content_list.field_cta_link
     - field.field.assembly.dynamic_content_list.field_drupal_term_filter
     - field.field.assembly.dynamic_content_list.field_links
+    - field.field.assembly.dynamic_content_list.field_title
   module:
     - fences
     - link
@@ -54,22 +55,23 @@ content:
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
-  name:
-    type: string
+  field_title:
     weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings:
       fences:
-        fences_field_tag: h2
-        fences_field_classes: header
-        fences_field_item_tag: none
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
+    type: string
+    region: content
 hidden:
   field_category_filter: true
   field_drupal_term_filter: true
+  name: true
   user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_evangelists.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_evangelists.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - assembly.assembly_type.featured_evangelists
     - field.field.assembly.featured_evangelists.field_cta_link
     - field.field.assembly.featured_evangelists.field_evangelists
+    - field.field.assembly.featured_evangelists.field_title
   module:
     - fences
     - link
@@ -49,20 +50,21 @@ content:
         fences_label_classes: ''
     type: entity_reference_entity_view
     region: content
-  name:
-    type: string
+  field_title:
     weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings:
       fences:
-        fences_field_tag: h2
-        fences_field_classes: header
-        fences_field_item_tag: none
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
+    type: string
+    region: content
 hidden:
+  name: true
   user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.static_content_band
     - field.field.assembly.static_content_band.field_content_list
+    - field.field.assembly.static_content_band.field_title
   module:
     - fences
 id: assembly.static_content_band.default
@@ -21,20 +22,21 @@ content:
     third_party_settings: {  }
     type: entity_reference_entity_view
     region: content
-  name:
-    type: string
+  field_title:
     weight: 0
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings:
       fences:
-        fences_field_tag: h2
-        fences_field_classes: header
-        fences_field_item_tag: none
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
         fences_field_item_classes: ''
         fences_label_tag: none
         fences_label_classes: ''
+    type: string
+    region: content
 hidden:
+  name: true
   user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
@@ -31,5 +31,8 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  workbench_moderation_control:
+    weight: -20
+    region: content
 hidden:
   links: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
@@ -16,5 +16,9 @@ content:
   links:
     weight: 100
     region: content
+  workbench_moderation_control:
+    weight: -20
+    region: content
 hidden:
   field_sections: true
+  scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_feed.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_feed.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 3dd9a4c0-ff00-480a-95fd-86c2c54c0ad5
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.dynamic_content_feed
+    - field.storage.assembly.field_title
+id: assembly.dynamic_content_feed.field_title
+field_name: field_title
+entity_type: assembly
+bundle: dynamic_content_feed
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_list.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_list.field_title.yml
@@ -1,0 +1,19 @@
+uuid: a1e87914-3784-41f5-9bbe-ebc994d4553d
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.dynamic_content_list
+    - field.storage.assembly.field_title
+id: assembly.dynamic_content_list.field_title
+field_name: field_title
+entity_type: assembly
+bundle: dynamic_content_list
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_evangelists.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_evangelists.field_title.yml
@@ -1,0 +1,19 @@
+uuid: fbd50a39-2815-4ae0-9ede-edefcf37c44a
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.featured_evangelists
+    - field.storage.assembly.field_title
+id: assembly.featured_evangelists.field_title
+field_name: field_title
+entity_type: assembly
+bundle: featured_evangelists
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 7c1475b2-8a4d-4740-9a78-cafcd1e39a26
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.static_content_band
+    - field.storage.assembly.field_title
+id: assembly.static_content_band.field_title
+field_name: field_title
+entity_type: assembly
+bundle: static_content_band
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string


### PR DESCRIPTION
We were in correctly using the assembly "Name" field as a visitor-facing bit of content.