### PR TITLE
DEVELOPER-4915 Fix title display in RHDP theme

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_page_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_page_title.yml
@@ -1,6 +1,6 @@
 uuid: a1fc69de-6518-4d86-8bcf-109e7b5eb89f
 langcode: en
-status: false
+status: true
 dependencies:
   theme:
     - rhdp

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -180,6 +180,18 @@ function rhd_js_settings_alter(array &$settings, \Drupal\Core\Asset\AttachedAsse
 }
 
 /**
+ * Implements template_preprocess_page().
+ */
+function rhdp_preprocess_page(&$variables) {
+  if (isset($variables['node'])) {
+    $alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/'.$variables['node']->id());
+    if ($alias == '/harmonize/home') {
+      $variables['is_front'] = true;
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_node().
  */
 function rhdp_preprocess_node(&$variables) {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--assembly-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--assembly-page.html.twig
@@ -88,11 +88,6 @@
   {% if content.field_hero|render %}
   {{ content.field_hero }}
   {% endif %}
-  {{ title_prefix }}
-  <{{ title_tag }} {{ title_attributes.addClass('row') }}>
-    {% if not page %}<a href="{{ url }}" rel="bookmark">{% endif %}{{ label }}{% if not page %}</a>{% endif %}
-  </{{ title_tag }}>
-  {{ title_suffix }}
 
   {% if display_submitted %}
     <footer class="node__meta">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page.html.twig
@@ -66,9 +66,11 @@
   <div class="rhd-mobile-overlay"></div>
   <div class="rhd-search-toggle-overlay"></div>
 
+  {% if not is_front %}
   <div class="container">
     {{ page.title }}
   </div>
+  {% endif %}
   <main role="main">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
 


### PR DESCRIPTION
The title is now displayed. If the page alias is "harmonize/home", the title will be omitted.