### PR TITLE
Revert "DEVELOPER-4914 fix title display of dynamic content assembly"

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--dynamic-content-feed.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--dynamic-content-feed.html.twig
@@ -1,7 +1,8 @@
 <section{{ attributes.addClass('assembly') }}>
   <div class="container narrow">
+  {{ content.field_title }}
   {% if content %}
-    {{- content -}}
+    {{- content|without('name') -}}
   {% endif %}
   </div>
   {% if background_image_url %}


### PR DESCRIPTION
Reverts redhat-developer/developers.redhat.com#2327

This might be the cause of the broken https://developers.redhat.com/downloads/ page in production. The products are failing to display.