### PR TITLE
Fix DEVELOPER-4961: add title field to expandable product groups; use…

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.all_products_listing.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.all_products_listing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - assembly.assembly_type.all_products_listing
     - field.field.assembly.all_products_listing.field_content
     - field.field.assembly.all_products_listing.field_navigation_title
+    - field.field.assembly.all_products_listing.field_title
   module:
     - text
     - workbench_moderation
@@ -15,7 +16,7 @@ bundle: all_products_listing
 mode: default
 content:
   field_content:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -23,7 +24,15 @@ content:
     type: text_textarea
     region: content
   field_navigation_title:
-    weight: 6
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_title:
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -32,7 +41,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 4
+    weight: 5
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -46,19 +55,10 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
-  user_id:
-    type: entity_reference_autocomplete
-    weight: 3
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    region: content
     third_party_settings: {  }
   visual_styles:
     type: options_select
@@ -67,4 +67,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_categories.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_categories.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.product_categories
     - field.field.assembly.product_categories.field_navigation_title
+    - field.field.assembly.product_categories.field_title
   module:
     - workbench_moderation
 id: assembly.product_categories.default
@@ -13,7 +14,15 @@ bundle: product_categories
 mode: default
 content:
   field_navigation_title:
-    weight: 100
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_title:
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -22,13 +31,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 5
+    weight: 4
     settings: {  }
     region: content
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -4
+    weight: 0
     region: content
     settings:
       size: 60
@@ -36,19 +45,10 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 99
+    weight: 5
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
-  user_id:
-    type: entity_reference_autocomplete
-    weight: 5
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    region: content
     third_party_settings: {  }
   visual_styles:
     type: options_select
@@ -57,4 +57,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.all_products_listing.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.all_products_listing.default.yml
@@ -6,7 +6,9 @@ dependencies:
     - assembly.assembly_type.all_products_listing
     - field.field.assembly.all_products_listing.field_content
     - field.field.assembly.all_products_listing.field_navigation_title
+    - field.field.assembly.all_products_listing.field_title
   module:
+    - fences
     - text
 id: assembly.all_products_listing.default
 targetEntityType: assembly
@@ -20,14 +22,22 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
-  name:
-    label: hidden
-    type: string
+  field_title:
     weight: 0
-    region: content
+    label: hidden
     settings:
       link_to_entity: false
-    third_party_settings: {  }
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
+        fences_field_item_classes: section-title
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: string
+    region: content
 hidden:
   field_navigation_title: true
+  name: true
   user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_categories.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_categories.default.yml
@@ -5,11 +5,29 @@ dependencies:
   config:
     - assembly.assembly_type.product_categories
     - field.field.assembly.product_categories.field_navigation_title
+    - field.field.assembly.product_categories.field_title
+  module:
+    - fences
 id: assembly.product_categories.default
 targetEntityType: assembly
 bundle: product_categories
 mode: default
-content: {  }
+content:
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: h2
+        fences_field_item_classes: section-title
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: string
+    region: content
 hidden:
   field_navigation_title: true
   name: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.all_products_listing.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.all_products_listing.field_title.yml
@@ -1,0 +1,19 @@
+uuid: bcfe23a6-a696-4b46-8e1f-73d6d547005f
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.all_products_listing
+    - field.storage.assembly.field_title
+id: assembly.all_products_listing.field_title
+field_name: field_title
+entity_type: assembly
+bundle: all_products_listing
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_categories.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_categories.field_title.yml
@@ -1,0 +1,19 @@
+uuid: a25e7a2a-ac15-49ca-b52d-c9d0df1850c1
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.product_categories
+    - field.storage.assembly.field_title
+id: assembly.product_categories.field_title
+field_name: field_title
+entity_type: assembly
+bundle: product_categories
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_assembly.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_assembly.scss
@@ -15,3 +15,4 @@
 @import "learning_paths";
 @import "event_list";
 @import "content_with_image";
+@import "product_categories";

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_product_categories.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_product_categories.scss
@@ -1,0 +1,13 @@
+.assembly-type-product_categories {
+  background-color: $grey-1;
+  padding: 5rem 0 0;
+
+  .section-title {
+    font-size: 32px;
+    color: $grey-8;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 1em;
+  }
+}
+

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -72,20 +72,20 @@
     grid-template-columns: repeat(2, [content-start] 1fr) [content-end];
     margin: 0 30px;
     min-width: 640px;
-    max-width: auto;  
+    max-width: auto;
   }
 
   @media (min-width: 960px) {
     grid-template-columns: repeat(4, [content-start] 1fr) [content-end];
     margin: 0 30px;
     min-width: 960px;
-    max-width: auto;      
+    max-width: auto;
   }
 
   @media (min-width: 1260px) {
     grid-template-columns: repeat(12, [content-start] 70px) [content-end];
     min-width: 1260px;
-    max-width: auto;      
+    max-width: auto;
   }
 }
 
@@ -100,20 +100,20 @@
     grid-template-columns: repeat(2, [content-start] 1fr) [content-end];
     margin: 0 30px;
     min-width: 640px;
-    max-width: auto;  
+    max-width: auto;
   }
 
   @media (min-width: 960px) {
     grid-template-columns: repeat(3, [content-start] 1fr) [content-end];
     margin: 0 30px;
     min-width: 960px;
-    max-width: auto;      
+    max-width: auto;
   }
 
   @media (min-width: 1260px) {
     grid-template-columns: repeat(4, [content-start] 1fr) [content-end];
     min-width: 1260px;
-    max-width: auto;      
+    max-width: auto;
   }
 }
 
@@ -128,18 +128,18 @@
     grid-template-columns: repeat(2, [content-start] 1fr) [content-end];
     margin: 0 30px;
     min-width: 640px;
-    max-width: auto;  
+    max-width: auto;
   }
 
   @media (min-width: 960px) {
     min-width: 960px;
-    max-width: auto;      
+    max-width: auto;
   }
 
   @media (min-width: 1260px) {
     grid-template-columns: repeat(3, [content-start] 1fr) [content-end];
     min-width: 1260px;
-    max-width: auto;      
+    max-width: auto;
   }
 
   @media (min-width: 1260px) {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/styles/rhd.css
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/styles/rhd.css
@@ -1686,6 +1686,16 @@ a.light-cta {
     .assembly-type-content_with_image .assembly-image {
       flex-grow: 1; } }
 
+.assembly-type-product_categories {
+  background-color: #F9F9F9;
+  padding: 5rem 0 0; }
+  .assembly-type-product_categories .section-title {
+    font-size: 32px;
+    color: #242424;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 1em; }
+
 meta.foundation-version {
   font-family: "/5.4.4/"; }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--all_products_listing.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--all_products_listing.html.twig
@@ -1,12 +1,12 @@
 <section{{ attributes.addClass('assembly') }}>
     <div class="container">
         <header>
-            {{ content.name }}
+            {{ content.field_title }}
         </header>
         {{ content.content }}
         <div>
             {% if content %}
-                {{- content|without('name', 'content') -}}
+                {{- content|without('field_title', 'content') -}}
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
… title instead of name for all products

To review: add a title to an expandable products assembly, see that it works. create/edit an all products listing assembly -- note that it uses title instead of name now.