### PR TITLE
mocha-tags are not honoured when running production smoke checks.

### DIFF
--- a/_tests/e2e/config/wdio.conf.base.js
+++ b/_tests/e2e/config/wdio.conf.base.js
@@ -168,7 +168,6 @@ exports.config = {
 
         const path = require('path');
         global.downloadDir = path.resolve('tmp_downloads');
-        global.tags = require('mocha-tags');
 
         const log4js = require('log4js');
         global.logger = log4js.getLogger();

--- a/_tests/e2e/specs/rhd-cheatsheet-downloads.js
+++ b/_tests/e2e/specs/rhd-cheatsheet-downloads.js
@@ -9,6 +9,8 @@ const qs = require('querystring');
 const dowloadHelper = require('./support/DownloadHelper');
 const User = require("./support/rest/keycloak/Site.user");
 
+const tags = require('mocha-tags');
+
 describe('RHD Cheatsheet downloads', function () {
 
     let siteUser;
@@ -39,6 +41,7 @@ describe('RHD Cheatsheet downloads', function () {
         try {
             expect(dowloadHelper.getDownloads(), 'Failed to download cheatsheet').to.eql(1)
         } catch (e) {
+            console.log('cheatsheet download did not trigger first time');
             cheatSheetPage
                 .retryDownload();
             expect(dowloadHelper.getDownloads(), 'Failed to download cheatsheet').to.eql(1)

--- a/_tests/e2e/specs/rhd-home.spec.js
+++ b/_tests/e2e/specs/rhd-home.spec.js
@@ -1,6 +1,8 @@
 const HomePage = require('./support/pages/website/Home.page');
 const homePage = new HomePage();
 
+const tags = require('mocha-tags');
+
 describe('Home Page', function () {
 
     tags('sanity').it("homepage should contain an embedded hash string for the nagios health check", function () {

--- a/_tests/e2e/specs/rhd-navigation-spec.js
+++ b/_tests/e2e/specs/rhd-navigation-spec.js
@@ -6,6 +6,8 @@ const homePage = new HomePage();
 const siteNav = new SiteNav();
 const loginPage = new LoginPage();
 
+const tags = require('mocha-tags');
+
 describe('Navigation bar', function () {
 
     tags('sanity').it("should navigate users to the Keycloak Login page", function () {

--- a/_tests/e2e/specs/rhd-search.spec.js
+++ b/_tests/e2e/specs/rhd-search.spec.js
@@ -7,6 +7,8 @@ const homePage = new HomePage();
 const searchPage = new SearchPage();
 const siteNav = new SiteNav();
 
+const tags = require('mocha-tags');
+
 describe('Search Page', function () {
 
     tags('sanity').it('should allow users to search for content via site-nav search field', function () {


### PR DESCRIPTION
Mocha-tags are not honoured when running production smoke checks.