### PR TITLE
[HOLD] DEVELOPER-4078 Fix the auto-generated URL

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
@@ -89,7 +89,6 @@ function rhd_common_ajax_test(array &$form, FormStateInterface $form_state) {
     $video_url = current(current($form_state->getValue('field_video_resource')));
 
     if (!empty($video_url)) {
-        // TODO: do a youtube check
         $video = NULL;
         try {
             $youtube = new Madcoda\Youtube\Youtube(array('key' => $key));
@@ -120,7 +119,7 @@ function rhd_common_ajax_test(array &$form, FormStateInterface $form_state) {
 
         // Build the url alias and set that
         $response->addCommand(new InvokeCommand('#edit-path-0-alias', 'val',
-          ['/video/youtube/' . getYouTubeVideoId($video_url)]));
+          ['/videos/youtube/' . getYouTubeVideoId($video_url)]));
     }
 
     return $response;


### PR DESCRIPTION
Also removing a TODO comment that is done

JIRA: https://issues.jboss.org/browse/DEVELOPER-4078

Testing:

* Create a new video resource instance
* Paste in the YouTube link
* Wait for the AJAX call to finish
* Verify the URL alias is /videos instead of /video