### PR TITLE
DEVELOPER-5089 Pre and Code tags style fix

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -419,6 +419,14 @@ img {
   p { margin-bottom: 0; }
 }
 
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, serif;
+  font-size: 1em;
+}
+
 pre {
   padding: 10px;
   background: #f9f9f9;
@@ -430,6 +438,14 @@ pre {
   white-space: -pre-wrap;
   white-space: -o-pre-wrap;
   word-wrap: break-word;
+}
+
+code {
+  padding: 1px;
+  border: 1px solid #d5d5d5;
+  background-color: #f9f9f9;
+  font-weight: normal;
+  color: #0a0a0a;
 }
 
 .content-type-label {


### PR DESCRIPTION
[DEVELOPER-5089 - CSS style for Code snippets within body text is missing or being overwritten	
](https://issues.jboss.org/browse/DEVELOPER-5089)