### PR TITLE
Sanity check for blog page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ _docker/searchisko/overlay/searchisko_2.sql.zip
 _docker/searchisko_configure/overlay/searchisko_2.sql.zip
 _docker/mysql/searchisko_mysql_data.tar.gz
 _docker/searchisko/searchisko_es_data.tar.gz
-*.orig
 
 # awestruct overlays
 _docker/awestruct/overlay/ssh-key/id*
@@ -61,12 +60,6 @@ _docker/drupal/.idea
 .gitignore
 _tests/unit/package.json
 _tests/unit/report/
-_tests/e2e/screenshots
-_tests/e2e/etc
-_tests/e2e/npm-debug.log
-_tests/e2e/desktop-results
-_tests/e2e/mobile-results
-_tests/e2e/node_modules
 local.log
 /_tests/e2e/BrowserStackLocal
 
@@ -77,3 +70,11 @@ _docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/rhd.min.css
 _docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/rhd.js
 _docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/rhd.min.js
 
+_tests/e2e/report/desktop-results/results.html
+_tests/e2e/report/desktop-results/results.json
+_tests/e2e/report/desktop-results/screenshots/
+_tests/e2e/tmp_downloads/
+_tests/e2e/report/mobile-results/results.html
+_tests/e2e/report/mobile-results/results.json
+_tests/e2e/report/mobile-results/screenshots/
+_tests/e2e/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _docker/searchisko/overlay/searchisko_2.sql.zip
 _docker/searchisko_configure/overlay/searchisko_2.sql.zip
 _docker/mysql/searchisko_mysql_data.tar.gz
 _docker/searchisko/searchisko_es_data.tar.gz
+*.orig
 
 # awestruct overlays
 _docker/awestruct/overlay/ssh-key/id*

--- a/_tests/e2e/specs/rhd-blog.spec.js
+++ b/_tests/e2e/specs/rhd-blog.spec.js
@@ -1,0 +1,16 @@
+const SearchPage = require('./support/pages/website/Search.page');
+const searchPage = new SearchPage();
+
+const tags = require('mocha-tags');
+
+describe('Red Hat Blog Page', function () {
+
+    tags('sanity').it("should contain an embedded hash string for the nagios health check", function () {
+        searchPage
+            .open('/');
+        expect(searchPage.getPageSource(),
+            'WARNING! Please check the page title! The site export will break, ' +
+            'the nagios health check expects 00fef0cf90c42f3e40921fb3370e520a').to.include('00fef0cf90c42f3e40921fb3370e520a')
+    });
+
+});

--- a/_tests/e2e/specs/support/pages/website/Blog.page.js
+++ b/_tests/e2e/specs/support/pages/website/Blog.page.js
@@ -1,0 +1,13 @@
+const BasePage = require('../Base.page');
+
+class BlogPage extends BasePage {
+    constructor() {
+        super({
+            path: '/blog',
+            pageTitle: 'RHD Blog - Insights and news on Red Hat developer tools, platforms and more',
+            selector: '.content-teaser-list'
+        });
+    }
+}
+
+module.exports = BlogPage;


### PR DESCRIPTION
Adding sanity check for the blog page. Test verifies that the page source contains the binary string for RHD.