### PR TITLE
DEVELOPER-5177 Add image.style.media.asset.cover_medium.yam to site config for new m…

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/image.style.media_asset_cover_medium.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/image.style.media_asset_cover_medium.yml
@@ -1,0 +1,15 @@
+uuid: 93e7b7a0-7c97-4a0a-be4f-aa8bdc5ce1b4
+langcode: en
+status: true
+dependencies: {  }
+name: media_asset_cover_medium
+label: 'Media Asset Cover Medium (250x377)'
+effects:
+  278112b0-8a25-4d70-984b-b20ba083b155:
+    uuid: 278112b0-8a25-4d70-984b-b20ba083b155
+    id: image_scale
+    weight: 1
+    data:
+      width: 250
+      height: null
+      upscale: true


### PR DESCRIPTION
…edia image style

### JIRA Issue
https://issues.jboss.org/browse/DEVELOPER-5177

### Verification Process
The style is called "Media Cover Image", and needs to be preserved in the configuration so it can be used going forward.

Image style is maintained even after Drupal server rebuilds

Add an image from the media library and see that the new image style is available
