### PR TITLE
DEVELOPER-5210 - Fix broken links for Events on Search

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.events_rest_query.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.events_rest_query.yml
@@ -1099,12 +1099,12 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/events
       pager:
-        type: some
+        type: none
         options:
-          items_per_page: 10
           offset: 0
       style:
         type: serializer


### PR DESCRIPTION
### JIRA Issue
* https://issues.jboss.org/browse/DEVELOPER-5210

### Verification Process
This is part 1 of the fix.

* Notice that all events should be displayed on /drupal/events instead of just the first 10.
* Upon merge, DCP changes will be submitted to staging. From there, the links returned from search should link to the actual event page instead of the 404 page generated from the event node id.
