### PR TITLE
DEVELOPER-5211 remove flex-shrink and grow for compatibility with saf…

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_learning-paths.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_learning-paths.scss
@@ -18,8 +18,6 @@ body.page-node-type-learning-path {
   min-width: 1px; 
 
   .lp-info {
-    flex-grow: 1;
-    flex-shrink: 1;
     margin: 30px 15px;
     border: 1px solid #CCC;
     padding: 30px;
@@ -65,8 +63,6 @@ body.page-node-type-learning-path {
 
   .lp-cards-container {
     background-color: #EEE;
-    flex-grow: 2;
-    flex-shrink: .5;
     margin: 0 15px;
     display: flex;
     flex-direction: column;
@@ -214,7 +210,7 @@ body.page-node-type-learning-path {
     .lp-info { margin: 0; }
     
     .lp-cards-container {
-      margin: -15px 0 0 15px;
+      //margin: -15px 0 0 15px;
       padding: 15px;
     }
   }


### PR DESCRIPTION
…ari and ie edge.

### JIRA Issue
DEVELOPER-5211

### Verification Process
When displaying a learning path on Safari (https://developers.redhat.com/learning-paths/microservices/), it displays correctly when the screen is narrow and medium width, but when the window is wide, the word-wrap disappears.

should work on wide screens now too