### PR TITLE
DEVELOPER-5103 drop query string from url

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -57,7 +57,9 @@ class ExportHtmlPostProcessor
 
     @additional_static_resources.each do |i|
       unless File.exists?(File.join(export_directory, URI.parse(i).path))
-        request = Typhoeus::Request.new(i, followlocation: true)
+        url = URI.parse(i.to_s)
+        url.query = nil
+        request = Typhoeus::Request.new(url, followlocation: true)
 
         request.on_complete do |response|
           # Make the directory
@@ -126,9 +128,13 @@ class ExportHtmlPostProcessor
       content = element['content']
       @additional_static_resources << content.gsub('https', 'http') # remove ssl for this part
       if content.index('//')
-        element['content'] = final_base_url_location + content[content.index('/', content.index('//') + 2)..-1]
+        new_url = URI.parse(final_base_url_location + content[content.index('/', content.index('//') + 3)..-1])
+        new_url.query = nil
+        element['content'] = new_url.to_s
       else
-        element['content'] = final_base_url_location + content
+        new_url = URI.parse(final_base_url_location + content)
+        new_url.query = nil
+        element['content'] = new_url.to_s
       end
       modified = true
     end
@@ -136,9 +142,13 @@ class ExportHtmlPostProcessor
     html_doc.css("link[href*='#{host}']").each do |element|
       href = element['href']
       if href.index('//')
-        element['href'] = final_base_url_location + href[href.index('/', href.index('//') + 2)..-1]
+        new_url = URI.parse(final_base_url_location + href[href.index('/', href.index('//') + 3)..-1])
+        new_url.query = nil
+        element['href'] = new_url.to_s
       else
-        element['href'] = final_base_url_location + href
+        new_url = URI.parse(final_base_url_location + href)
+        new_url.query = nil
+        element['href'] = new_url.to_s
       end
       modified = true
     end

--- a/_docker/tests/export/test_export_html_post_processor.rb
+++ b/_docker/tests/export/test_export_html_post_processor.rb
@@ -176,13 +176,13 @@ class TestExportHtmlPostProcessor < MiniTest::Test
     test_page = get_html_document("#{@export_directory}/drupal-host-leak/index.html")
     assert test_page.to_s.include? 'rhdp-drupal.redhat.com'
 
-    stub_request(:get, 'http://rhdp-drupal.redhat.com/sites/default/files/styles/share/public/share-image-homepage.png?itok=OS1h6w8I').
+    stub_request(:get, 'http://rhdp-drupal.redhat.com/sites/default/files/styles/share/public/share-image-homepage.png').
         to_return(status: 200, body: "", headers: {})
 
     @export_post_processor.post_process_html_export('rhdp-drupal.redhat.com', @export_directory)
     test_page = get_html_document("#{@export_directory}/drupal-host-leak/index.html")
     refute test_page.to_s.include? 'rhdp-drupal.redhat.com'
 
-    assert_requested(:get, 'http://rhdp-drupal.redhat.com/sites/default/files/styles/share/public/share-image-homepage.png?itok=OS1h6w8I')
+    assert_requested(:get, 'http://rhdp-drupal.redhat.com/sites/default/files/styles/share/public/share-image-homepage.png')
   end
 end


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5103

### Verification Process
Look at the export, make sure the og:image doesn't include a reference which has a query string in it.