### PR TITLE
Updating CDK version to 3.5.0-1

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
@@ -135,7 +135,7 @@ app.products = {
 
 app.products.downloads = {
     "devsuite" : {"windowsUrl" : "/download-manager/file/devsuite-2.3.0-GA-installer.exe", "macUrl" : "/download-manager/file/devsuite-2.3.0-GA-bundle-installer-mac.dmg", "rhelUrl" : "/products/devsuite/hello-world/#fndtn-rhel"},
-    "cdk" : {"windowsUrl" : "/download-manager/file/cdk-3.4.0-2-minishift-windows-amd64.exe", "macUrl" : "/download-manager/file/cdk-3.4.0-2-minishift-darwin-amd64", "rhelUrl" : "/download-manager/file/cdk-3.4.0-2-minishift-linux-amd64"}
+    "cdk" : {"windowsUrl" : "/download-manager/file/cdk-3.5.0-1-minishift-windows-amd64.exe", "macUrl" : "/download-manager/file/cdk-3.5.0-1-minishift-darwin-amd64", "rhelUrl" : "/download-manager/file/cdk-3.5.0-1-minishift-linux-amd64"}
 };
 
 /*

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/rhdp-os-download.ts
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/rhdp-os-download.ts
@@ -14,7 +14,7 @@ class RHDPOSDownload extends HTMLElement {
     stage_download_url = 'https://developers.stage.redhat.com';
     productDownloads = {
         "devsuite" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.3.0-GA-installer.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/devsuite-2.3.0-GA-bundle-installer-mac.dmg", "rhelUrl" : "https://developers.redhat.com/products/devsuite/hello-world/#fndtn-rhel"},
-        "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.4.0-2-minishift-windows-amd64.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.4.0-2-minishift-darwin-amd64", "rhelUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.4.0-2-minishift-linux-amd64"}
+        "cdk" : {"windowsUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.5.0-1-minishift-windows-amd64.exe", "macUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.5.0-1-minishift-darwin-amd64", "rhelUrl" : "https://developers.redhat.com/download-manager/file/cdk-3.5.0-1-minishift-linux-amd64"}
     };
 
     get url() {


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5244

### Verification Process
* Visit - https://developers.redhat.com/products/cdk/download/ and verify that the button version is 3.5.0-1 on Mac, Linux, and Windows