### PR TITLE
[DEVELOPER-5238] Update content_with_images assembly mobile styles

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
@@ -3,7 +3,7 @@
   @include tablet-portrait-and-down {
     text-align: center;
   }
-  @include tablet-landscape {
+  @include tablet-landscape-and-up {
     padding: 100px 0;
   }
   .header {
@@ -11,7 +11,7 @@
     margin-bottom: 16px;
     font-size: 18px;
     margin-top: 0;
-    @include tablet-landscape {
+    @include tablet-landscape-and-up {
       font-weight: bold;
       font-size: 36px;
       text-align: left;
@@ -59,7 +59,7 @@
     }
     + .assembly-image {
       margin-top: 13px;
-      max-width: 212px;
+      max-width: 320px;
       @include tablet-portrait-and-down {
         max-width: 100%;
         width: 100%;
@@ -76,7 +76,7 @@
         max-width: 320px;
       }
       img {
-        max-width: 212px;
+        max-width: 320px;
       }
     }
   }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
@@ -1,19 +1,27 @@
 .assembly-type-content_with_image {
   padding: 40px 0;
+  @include tablet-portrait-and-down {
+    text-align: center;
+  }
   @include tablet-landscape {
     padding: 100px 0;
   }
   .header {
-    text-align: left;
+    text-align: center;
     margin-bottom: 16px;
     font-size: 18px;
     margin-top: 0;
     @include tablet-landscape {
       font-weight: bold;
       font-size: 36px;
+      text-align: left;
     }
   }
   .container {
+    @include tablet-portrait-and-down {
+      flex-flow: row wrap-reverse;
+      display: flex;
+    }
     @include tablet-portrait {
       display: flex;
     }
@@ -37,6 +45,9 @@
     }
   }
   .assembly-content {
+    @include tablet-portrait-and-down {
+      width: 100% !important;
+    }
     @include tablet-portrait {
       flex-grow: 2;
     }
@@ -49,6 +60,13 @@
     + .assembly-image {
       margin-top: 13px;
       max-width: 212px;
+      @include tablet-portrait-and-down {
+        max-width: 100%;
+        width: 100%;
+        text-align: center;
+        margin-left: 0;
+        margin-bottom: 20px;
+      }
       @include tablet-portrait {
         margin-top: 0;
         margin-left: 30px;
@@ -57,11 +75,19 @@
         margin-left: 50px;
         max-width: 320px;
       }
+      img {
+        max-width: 212px;
+      }
     }
   }
   .assembly-image {
     @include tablet-portrait {
       flex-grow: 1;
+    }
+  }
+  .button {
+    margin: 15px 15px 0 0 !important;
+    @include tablet-portrait {
     }
   }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
@@ -77,6 +77,9 @@
       }
       img {
         max-width: 320px;
+        @include mobile-landscape-and-down {
+          max-width: 212px;
+        }
       }
     }
   }


### PR DESCRIPTION
Update assembly content_with_images mobile styles to push image above content and center image and content. Add button margins.

### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5238

### Verification Process
1. Visit: /topics/linux/ OR create a new "Rich Text with Image" assembly on any page
2. Resize browser to 768px and lower
3. Observe that image now slides above the content and all content is centered

### Screenshots
**Desktop**
![screen shot 2018-07-25 at 9 15 29 am](https://user-images.githubusercontent.com/41014351/43213907-fd7192bc-8ff4-11e8-99f5-8192f8ca6642.png)

**Tablet**
![screen shot 2018-07-25 at 9 15 21 am](https://user-images.githubusercontent.com/41014351/43213943-1493096c-8ff5-11e8-947f-9161a1c5d0c7.png)

**Mobile**
![screen shot 2018-07-25 at 9 15 07 am](https://user-images.githubusercontent.com/41014351/43213946-16f7f4ba-8ff5-11e8-931c-0b80c99cdd4d.png)

**XS Mobile**
![screen shot 2018-07-25 at 9 14 56 am](https://user-images.githubusercontent.com/41014351/43213954-19b03c30-8ff5-11e8-87ec-71ad712de93b.png)

