### PR TITLE
DEVELOPER-5158 Added the Share Image field to additional content types

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.books.field_pull_from_google
     - field.field.node.books.field_read_time
     - field.field.node.books.field_related_product
+    - field.field.node.books.field_share_image
     - field.field.node.books.field_short_description
     - field.field.node.books.field_tags
     - field.field.node.books.field_thumbnail_url
@@ -127,7 +128,7 @@ content:
     type: string_textfield
     region: content
   field_meta_tags:
-    weight: 26
+    weight: 25
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -185,6 +186,19 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_share_image:
+    type: entity_browser_file
+    weight: 22
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_short_description:
     weight: 3
     settings:
@@ -218,7 +232,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 22
+    weight: 23
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -230,7 +244,7 @@ content:
     third_party_settings: {  }
   scheduled_update:
     type: inline_entity_form_complex
-    weight: 23
+    weight: 24
     settings:
       form_mode: default
       override_labels: true
@@ -241,6 +255,7 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.cheat_sheet.field_exclude_from_search
     - field.field.node.cheat_sheet.field_meta_tags
     - field.field.node.cheat_sheet.field_read_time
+    - field.field.node.cheat_sheet.field_share_image
     - field.field.node.cheat_sheet.field_short_description
     - field.field.node.cheat_sheet.field_topics
     - field.field.node.cheat_sheet.scheduled_update
@@ -131,6 +132,19 @@ content:
     third_party_settings: {  }
     type: interval_default
     region: content
+  field_share_image:
+    type: entity_browser_file
+    weight: 18
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_short_description:
     weight: 2
     settings:
@@ -147,7 +161,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 18
+    weight: 19
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -166,7 +180,7 @@ content:
     region: content
   scheduled_update:
     type: inline_entity_form_complex
-    weight: 19
+    weight: 20
     settings:
       form_mode: default
       override_labels: true
@@ -177,6 +191,7 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.product.field_product_short_name
     - field.field.node.product.field_product_summary
     - field.field.node.product.field_product_technology_group
+    - field.field.node.product.field_share_image
     - field.field.node.product.field_short_description
     - field.field.node.product.field_stackoverflow_product_refe
     - field.field.node.product.field_url_product_name
@@ -152,6 +153,19 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  field_share_image:
+    type: entity_browser_file
+    weight: 14
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_short_description:
     type: string_textarea
     weight: 2
@@ -178,13 +192,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 15
     settings: {  }
     region: content
     third_party_settings: {  }
   scheduled_update:
     type: inline_entity_form_complex
-    weight: 15
+    weight: 16
     settings:
       form_mode: default
       override_labels: true
@@ -195,6 +209,7 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -56,6 +56,7 @@ content:
       match_operator: CONTAINS
       collapsible: false
       collapsed: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none
@@ -63,7 +64,7 @@ content:
     region: content
   field_share_image:
     type: entity_browser_file
-    weight: 7
+    weight: 5
     settings:
       entity_browser: image_browser
       field_widget_edit: true
@@ -76,7 +77,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 5
+    weight: 6
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -87,7 +88,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   scheduled_update:
-    weight: 6
+    weight: 7
     settings:
       form_mode: default
       label_singular: ''
@@ -98,6 +99,7 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.video_resource.field_difficulty
     - field.field.node.video_resource.field_duration
     - field.field.node.video_resource.field_likes
+    - field.field.node.video_resource.field_meta_tags
     - field.field.node.video_resource.field_related_content
     - field.field.node.video_resource.field_share_image
     - field.field.node.video_resource.field_short_description
@@ -33,6 +34,7 @@ dependencies:
     - inline_entity_form
     - interval
     - link
+    - metatag
     - path
     - text
     - video_embed_field
@@ -80,6 +82,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: number
+    region: content
+  field_meta_tags:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_firehose
     region: content
   field_related_content:
     weight: 20
@@ -205,7 +213,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 22
+    weight: 21
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -217,7 +225,7 @@ content:
     region: content
   scheduled_update:
     type: inline_entity_form_complex
-    weight: 23
+    weight: 22
     settings:
       form_mode: default
       override_labels: true
@@ -228,7 +236,6 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
-      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -3,12 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.image_browser
     - field.field.node.video_resource.body
     - field.field.node.video_resource.field_card_image
     - field.field.node.video_resource.field_difficulty
     - field.field.node.video_resource.field_duration
     - field.field.node.video_resource.field_likes
     - field.field.node.video_resource.field_related_content
+    - field.field.node.video_resource.field_share_image
     - field.field.node.video_resource.field_short_description
     - field.field.node.video_resource.field_slideshare_source
     - field.field.node.video_resource.field_speakers
@@ -26,6 +28,7 @@ dependencies:
     - node.type.video_resource
   module:
     - datetime
+    - entity_browser
     - entity_browser_entity_form
     - inline_entity_form
     - interval
@@ -87,6 +90,19 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_share_image:
+    type: entity_browser_file
+    weight: 21
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_short_description:
     weight: 2
     settings:
@@ -189,7 +205,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 21
+    weight: 22
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -201,7 +217,7 @@ content:
     region: content
   scheduled_update:
     type: inline_entity_form_complex
-    weight: 22
+    weight: 23
     settings:
       form_mode: default
       override_labels: true
@@ -212,6 +228,7 @@ content:
       collapsible: false
       collapsed: false
       allow_existing: false
+      allow_duplicate: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.books.field_pull_from_google
     - field.field.node.books.field_read_time
     - field.field.node.books.field_related_product
+    - field.field.node.books.field_share_image
     - field.field.node.books.field_short_description
     - field.field.node.books.field_tags
     - field.field.node.books.field_thumbnail_url
@@ -283,6 +284,7 @@ content:
     region: content
 hidden:
   field_cover_image: true
+  field_share_image: true
   links: true
   scheduled_update: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.cheat_sheet.field_exclude_from_search
     - field.field.node.cheat_sheet.field_meta_tags
     - field.field.node.cheat_sheet.field_read_time
+    - field.field.node.cheat_sheet.field_share_image
     - field.field.node.cheat_sheet.field_short_description
     - field.field.node.cheat_sheet.field_topics
     - field.field.node.cheat_sheet.scheduled_update
@@ -144,4 +145,5 @@ content:
     third_party_settings: {  }
 hidden:
   field_cover_image: true
+  field_share_image: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.product.field_product_short_name
     - field.field.node.product.field_product_summary
     - field.field.node.product.field_product_technology_group
+    - field.field.node.product.field_share_image
     - field.field.node.product.field_short_description
     - field.field.node.product.field_stackoverflow_product_refe
     - field.field.node.product.field_url_product_name
@@ -134,6 +135,7 @@ content:
 hidden:
   field_image: true
   field_product_categories: true
+  field_share_image: true
   field_short_description: true
   links: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.video_resource.field_duration
     - field.field.node.video_resource.field_likes
     - field.field.node.video_resource.field_related_content
+    - field.field.node.video_resource.field_share_image
     - field.field.node.video_resource.field_short_description
     - field.field.node.video_resource.field_slideshare_source
     - field.field.node.video_resource.field_speakers
@@ -223,6 +224,7 @@ content:
     type: number_integer
     region: content
 hidden:
+  field_share_image: true
   links: true
   scheduled_update: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
@@ -8,8 +8,9 @@ dependencies:
     - field.field.node.video_resource.field_difficulty
     - field.field.node.video_resource.field_duration
     - field.field.node.video_resource.field_likes
-    - field.field.node.video_resource.field_related_content
+    - field.field.node.video_resource.field_meta_tags
     - field.field.node.video_resource.field_share_image
+    - field.field.node.video_resource.field_related_content
     - field.field.node.video_resource.field_short_description
     - field.field.node.video_resource.field_slideshare_source
     - field.field.node.video_resource.field_speakers
@@ -224,6 +225,7 @@ content:
     type: number_integer
     region: content
 hidden:
+  field_meta_tags: true
   field_share_image: true
   links: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.books.field_share_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.books.field_share_image.yml
@@ -1,0 +1,38 @@
+uuid: 024bed91-fd6f-4c0e-9981-83e26c7a739e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_share_image
+    - node.type.books
+  module:
+    - image
+id: node.books.field_share_image
+field_name: field_share_image
+entity_type: node
+bundle: books
+label: 'Share image'
+description: 'The image used when sharing this content on social media.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.cheat_sheet.field_share_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.cheat_sheet.field_share_image.yml
@@ -1,0 +1,38 @@
+uuid: 58f31617-34e7-4d02-ba7a-09b56adc7f02
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_share_image
+    - node.type.cheat_sheet
+  module:
+    - image
+id: node.cheat_sheet.field_share_image
+field_name: field_share_image
+entity_type: node
+bundle: cheat_sheet
+label: 'Share image'
+description: 'The image used when sharing this content on social media.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_share_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_share_image.yml
@@ -1,0 +1,38 @@
+uuid: a5407152-1657-47db-8a1c-51747076c3c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_share_image
+    - node.type.product
+  module:
+    - image
+id: node.product.field_share_image
+field_name: field_share_image
+entity_type: node
+bundle: product
+label: 'Share image'
+description: 'The image used when sharing this content on social media.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_meta_tags.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_meta_tags.yml
@@ -1,0 +1,23 @@
+uuid: d6326694-841e-4046-b122-743098a54766
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.video_resource
+  module:
+    - metatag
+id: node.video_resource.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: video_resource
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 'a:0:{}'
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_share_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_share_image.yml
@@ -1,0 +1,38 @@
+uuid: b0423f29-21c6-4e66-86ab-3f728c61a8dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_share_image
+    - node.type.video_resource
+  module:
+    - image
+id: node.video_resource.field_share_image
+field_name: field_share_image
+entity_type: node
+bundle: video_resource
+label: 'Share image'
+description: 'The image used when sharing this content on social media.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image


### PR DESCRIPTION
### JIRA Issue Link
* [DEVELOPER-5158 Add the Share Image field to additional content types](https://issues.jboss.org/browse/DEVELOPER-5158)

### Review Process

- Go to each of the content types (Books, Cheat Sheets, Products, Videos) and verify the field to add a 'Share Image" is available.
- Verify that you can also reference that field in the Open Graph > Image section in the Meta Tags area. ([node:field_share_image:share:url])