### PR TITLE
DEVELOPER-5243 Removing the headers via apache

### DIFF
--- a/_docker/drupal/apache/drupal.conf
+++ b/_docker/drupal/apache/drupal.conf
@@ -7,6 +7,17 @@
         AllowOverride All
         Order deny,allow
         Allow from all
+
+        <IfModule mod_headers.c>
+            Header unset link
+            Header unset x-drupal-cache
+            Header unset x-drupal-cache-tags
+            Header unset x-drupal-cache-contexts
+            Header unset x-drupal-dynamic-cache
+            Header unset x-generator
+            Header unset x-powered-by
+            Header unset x-ua-compatible
+        </IfModule>
     </Directory>
 </VirtualHost>
 


### PR DESCRIPTION
I had tried to do this at the Drupal level, but that didn't really work
well, so I'm removing it at the apache level.


### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5243

### Verification Process
* Log into the Drupal instance
* Open dev tools
* Navigate to a new web page on the site
* Look at the response headers in the Network tab of the dev tools
* Verify the following headers are not present:
** link
** x-drupal-cache
** x-drupal-dynamic-cache
** x-generator
** x-powered-by
** x-ua-compatible

Probably a good idea to do this as a logged in user and also as an anonymous user