### PR TITLE
DEVELOPER-5310 Title is displayed on home page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page.html.twig
@@ -67,7 +67,9 @@
   <div class="rhd-search-toggle-overlay"></div>
 
   <div class="container">
-    {{ page.title }}
+    {%  if not is_front %}
+      {{ page.title }}
+    {% endif %}
   </div>
 
   <main role="main">


### PR DESCRIPTION
Removing the title display on the home page.


### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5310

### Verification Process
Look at the home page, verify the title is no longer showing.