### PR TITLE
DEVELOPER-5190 Styling issues on Product pages

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/pdf-links.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/pdf-links.js
@@ -9,6 +9,7 @@ $(document).ready(function() {
       if (this.href.indexOf(ignoredDomains[i]) != -1) { return true; }
     }
     if (this.href.indexOf(location.hostname) == -1) {
+      $(this).append(" <i class='far fa-file-pdf'></i>");
       $(this).on("click", function() { return true; });
       $(this).attr({ target: "_blank" });
       $(this).trigger("click");

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_downloads.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_downloads.scss
@@ -107,6 +107,7 @@ div.download-loading{
   }
   .version-name {
     text-align: center;
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_get-started.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_get-started.scss
@@ -364,13 +364,14 @@ ul.toc {
     -webkit-transition: color 0.5s ease,background 0.5s ease,border-color 0.5s ease;
     -o-transition: color 0.5s ease,background 0.5s ease,border-color 0.5s ease;
     transition: color 0.5s ease,background 0.5s ease,border-color 0.5s ease;
-    min-height: 165px;
+    min-height: 205px;
     height: 100%;
     h4 {
       color: $white;
       margin-top: 0;
       margin-bottom: 8px;
       font-size: 23px;
+      line-height: 1.3;
     }
     .tabs-content {
       margin: 0;
@@ -728,6 +729,9 @@ ul.toc {
   }
 }
 @include tablet-landscape-and-down {
+  #get-started-instructions .card{
+    min-height: auto;
+  }
   .get-started-content img{
     width: 100%;
   }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_microsite.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_microsite.scss
@@ -311,9 +311,6 @@ body.microsite-multi-page, body.microsite {
 
 .promotion-header {
     margin-bottom: 4em;
-    img {
-      max-width: 320px;
-    }
     .report-title {
       margin-top: 20px;
     }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_rhd.scss
@@ -150,17 +150,6 @@ a {
     outline-width: 1px;
     outline-color: color($link);
   }
-  &[href$=".pdf"]:after,
-  &.pdf:after {
-    content: "\f1c1";
-    font-family: FontAwesome;
-    margin-left: 4px;
-  }
-
-  &.img-link {
-    &[href$=".pdf"]:after,
-    &.pdf:after { display: none; }
-  }
 }
 
 p a:hover {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_videos.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_videos.scss
@@ -120,7 +120,6 @@ section.related-content {
 }
 
 .video-caption {
-  margin-top: 1em;
   text-align: center;
   font-size: .9em;
 }
@@ -131,9 +130,6 @@ section.related-content {
 
 .product-video {
   margin: 30px 0;
-  .video-caption {
-    margin-top: -3em;
-  }
 }
 
 @include tablet-landscape-and-down {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/patterns/_buttons.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/patterns/_buttons.scss
@@ -117,11 +117,15 @@ button, .button {
   display: inline-block;
 }
 
-a.button[href$=".pdf"]:after,
-a.heavy-cta[href$=".pdf"]:after,
-a.medium-cta[href$=".pdf"]:after,
-.heavy-cta a[href$=".pdf"]:after,
-.madium-cta a[href$=".pdf"]:after{ display: none; }
+a.button[href$=".pdf"],
+a.heavy-cta[href$=".pdf"],
+a.medium-cta[href$=".pdf"],
+.heavy-cta a[href$=".pdf"],
+.madium-cta a[href$=".pdf"]{ 
+  .fa-file-pdf {
+    display: none;
+  }
+}
 
 a.light-cta{
   color: $link;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/typography/_anchor.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/typography/_anchor.scss
@@ -14,16 +14,10 @@ a {
         outline-width: 1px;
         outline-color: color($link);
     }
-    &[href$=".pdf"]:after,
-    &.pdf:after {
-        content: "\f1c1";
-        font-family: FontAwesome;
-        margin-left: 4px;
-    }
-
-    &.img-link {
-        &[href$=".pdf"]:after,
-        &.pdf:after { display: none; }
+    &.img-link[href$=".pdf"] {
+      .fa-file-pdf {
+        display: none;
+      }
     }
 }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/tsconfig.json
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/tsconfig.json
@@ -39,7 +39,6 @@
         "src/scripts/@rhd/js/foundation/foundation.reveal.js",
         "src/scripts/@rhd/js/foundation/foundation.tooltip.js",
         "src/scripts/@rhd/js/foundation/foundation.dropdown.js",
-        "src/scripts/@rhd/js/foundation/foundation.equalizer.js",
         "src/scripts/@rhd/js/foundation/foundation.accordion.js",
         "src/scripts/@rhd/js/vendor/swipe.js",
         "src/scripts/@rhd/js/mobile.js",

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/paragraph/paragraph--help.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/paragraph/paragraph--help.html.twig
@@ -108,7 +108,7 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
                     </li>
                     <li><span><img src="https://static.jboss.org/rhd/images/help_icon_training.svg"
                                    alt="Help Training Icon"></span><span>
-                            <h5 class="caps offset-img">Training &amp; Certifications</h5>
+                            <h5 class="caps">Training &amp; Certifications</h5>
                             <p>Building enterprise apps requires more than self-paced learning. Get formal training, be certified.</p>
                             <a href="https://www.redhat.com/en/services/training">Learn More</a></span>
                     </li>


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5190 Styling issues on Product pages](https://issues.jboss.org/browse/DEVELOPER-5190)

### Verification Process
Review that the style issues listed are not happening anymore (see jira for screenshots):

- Small columns such as Release Date on downloads table shouldn't wrap into two lines (https://developers-pr.stage.redhat.com/pr/2581/export/products/amq/download/)
- Blue boxes should have equal height (https://developers-pr.stage.redhat.com/pr/2581/export/products/amq/hello-world/)
- PDF icon in the 'View As' dropdowns are not showing up (https://developers-pr.stage.redhat.com/pr/2581/export/products/amq/docs-and-apis/)
- "Red Hat Support and Professional Services" icons should have equal height to make the content look even (https://developers-pr.stage.redhat.com/pr/2581/export/products/amq/help/)
- Add space between "Data Virtualization 6.4.0" text and the downloads table on tablet/mobile (https://developers-pr.stage.redhat.com/pr/2581/export/products/datavirt/download/)
- Video caption is being covered by video player (https://developers-pr.stage.redhat.com/pr/2581/export/products/che/overview/)
