### PR TITLE
DEVELOPER-5337 Modifying export disqus links

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -151,6 +151,20 @@ class ExportHtmlPostProcessor
         element['href'] = new_url.to_s
       end
       modified = true
+      end
+
+    html_doc.css("*[data-disqus-thread-link*='#{host}']").each do |element|
+      disqus_link = element['data-disqus-thread-link']
+      if disqus_link.index('//')
+        new_url = URI.parse(final_base_url_location + disqus_link[disqus_link.index('/', disqus_link.index('//') + 3)..-1])
+        new_url.query = nil
+        element['data-disqus-thread-link'] = new_url.to_s
+      else
+        new_url = URI.parse(final_base_url_location + disqus_link)
+        new_url.query = nil
+        element['data-disqus-thread-link'] = new_url.to_s
+      end
+      modified = true
     end
 
     @log.info("\tRemoved Drupal host identifying markup.") if modified

--- a/_docker/tests/export/test_export_form_rewrite/drupal-host-leak/index.html
+++ b/_docker/tests/export/test_export_form_rewrite/drupal-host-leak/index.html
@@ -729,6 +729,7 @@
                                             <div class="rhd-list-entry--image">
                                                 <img src="https://developers.redhat.com/blog/wp-content/uploads/2018/06/python-flask-logo.png">
                                             </div>
+                                            <div class="tile-comment-count hidden" data-disqus-thread-link="http://rhdp-drupal.redhat.com/videos/youtube/Cv8_EHQgUZ4" data-disqus-comment-count><a href="videos/youtube/Cv8_EHQgUZ4/#comments"><span class="fa fa-comment"></span><span class="comment-number" data-disqus-comment-count-number></span> <span class="count-verbage" data-disqus-comment-count-verbage>Comments</span></a></div>
                                         </article>
                                     </li>
                                 </ul></div></div>


### PR DESCRIPTION
Adding another step where we modify links in the export. Test included.


### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5337

### Verification Process
* Go to the home page of the export
* Look for the KubeBoot video about half way down the page
* Inspect the element in dev tools
* Verify the data-disqus-thread-link attribute points to the correct location instead of Drupal