### PR TITLE
DEVELOPER-5306 - Fixes missing videos in search

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.video_resource.field_card_image
     - field.field.node.video_resource.field_difficulty
     - field.field.node.video_resource.field_duration
+    - field.field.node.video_resource.field_exclude_from_search
     - field.field.node.video_resource.field_likes
     - field.field.node.video_resource.field_meta_tags
     - field.field.node.video_resource.field_related_content
@@ -73,6 +74,13 @@ content:
     third_party_settings: {  }
     type: interval_default
     region: content
+  field_exclude_from_search:
+    weight: 21
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_likes:
     weight: 11
     settings:
@@ -81,7 +89,7 @@ content:
     type: number
     region: content
   field_meta_tags:
-    weight: 26
+    weight: 23
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
@@ -97,7 +105,7 @@ content:
     region: content
   field_share_image:
     type: entity_browser_file
-    weight: 21
+    weight: 22
     settings:
       entity_browser: image_browser
       field_widget_edit: true
@@ -209,7 +217,7 @@ content:
     type: number
     region: content
   moderation_state:
-    weight: 27
+    weight: 24
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.video_resource.field_card_image
     - field.field.node.video_resource.field_difficulty
     - field.field.node.video_resource.field_duration
+    - field.field.node.video_resource.field_exclude_from_search
     - field.field.node.video_resource.field_likes
     - field.field.node.video_resource.field_meta_tags
     - field.field.node.video_resource.field_related_content
@@ -76,6 +77,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: interval_default
+    region: content
+  field_exclude_from_search:
+    weight: 21
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_likes:
     weight: 6

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_exclude_from_search.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_exclude_from_search.yml
@@ -1,0 +1,23 @@
+uuid: b50445a0-3758-4388-8e79-17d84a81a6ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_exclude_from_search
+    - node.type.video_resource
+id: node.video_resource.field_exclude_from_search
+field_name: field_exclude_from_search
+entity_type: node
+bundle: video_resource
+label: 'Exclude from search'
+description: 'Select to exclude this page from the Search page results.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'True'
+  off_label: 'False'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/coding-resource/node--coding-resource.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/coding-resource/node--coding-resource.html.twig
@@ -1,7 +1,3 @@
-<noscript>
-    <meta name="DCP:WebpageSearchExclude" content="true">
-</noscript>
-
 {% set repo_url = content.field_source_link[0]['#url'].uri %}
 
 <div class="row">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource.html.twig
@@ -82,6 +82,8 @@
     </div>
 </div>
 
-<noscript>
+{% if node.field_exclude_from_search.value == '1' %}
+  <noscript>
     <meta name="DCP:WebpageSearchExclude" content="true">
-</noscript>
+  </noscript>
+{% endif %}


### PR DESCRIPTION
### JIRA Issue Link
* [DEVELOPER-5306 - DevNation sessions missing from search engine.](https://issues.jboss.org/browse/DEVELOPER-5306)

### Verification Process
- Go to edit one of the video pages on Drupal
- Check the option to 'Exclude from search'
- Preview the page, and look at the source
- this meta tag should be present: `<meta name="DCP:WebpageSearchExclude" content="true">`
- go back to edit the page, and uncheck 'Exclude from search'
- save the page and look at the source code, the meta tag should no longer be there.

Once this is merged and the DCP re-indexes the video pages, all pages that have 'Exclude from search' unchecked should appear on the search results
