### PR TITLE
[DEVELOPER-5369] Avoid bad DNS lookups for control.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 rhd.idea/
 *.iml
 .bundle

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -253,34 +253,9 @@ def build_environment_resources(environment, system_exec)
 
 end
 
-#
-# This works around using docker-machine in non-native docker environments e.g. on a Mac.
-# In that scenario, host-mapped container ports are *not* mapped to localhost, instead they are mapped
-# to the VM provisioned by docker-machine.
-#
-# Users are expected to set a host alias of 'docker' for the VM that is running their docker containers. If
-# this alias does not exist, then we have to assume that Docker is running directly on the local machine.
-#
-# Note: We cannot rely on 'docker inspect' to determine this as it reports the host IP as 0.0.0.0 in a
-# docker-machine environment, presumably because that makes sense in the context of the docker-machine install.
-#
-def determine_docker_host_for_container_ports
-
-  begin
-    docker_host = Resolv.getaddress('docker')
-    puts "Host alias for 'docker' found. Assuming container ports are exposed on ip '#{docker_host}'"
-  rescue
-    docker_host = Resolv.getaddress(Socket.gethostname)
-    puts "No host alias for 'docker' found. Assuming container ports are exposed on '#{docker_host}'"
-  end
-
-  docker_host
-
-end
-
 def bind_drupal_container_details_into_environment(environment, supporting_services)
   if check_supported_service_requested(supporting_services, 'drupal')
-    drupal_host = determine_docker_host_for_container_ports
+    drupal_host = environment.get_docker_host
     drupal_port = get_host_mapped_port_for_container(environment, 'drupal', '80/tcp')
 
     # Add this to the ENV so we can pass it to the awestruct build and also to templating of environment resources

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -102,7 +102,7 @@ def wait_for_supporting_service_to_start(environment, service_name, service_port
       end
     end
 
-    raise StandardError("#{service_name} appears to be down.") unless up
+    raise StandardError.new("#{service_name} appears to be down.") unless up
 
     puts "Service '#{service_name}' is up on '#{target_url}'"
 

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -78,7 +78,7 @@ def wait_for_supporting_service_to_start(environment, service_name, service_port
 
     puts "Waiting for service '#{service_name}' to start..."
 
-    host = determine_docker_host_for_container_ports
+    host = environment.get_docker_host
     port = get_host_mapped_port_for_container(environment, service_name, service_port)
 
     target_url = "http://#{host}:#{port}/#{service_url}"

--- a/_docker/lib/rhd_environment.rb
+++ b/_docker/lib/rhd_environment.rb
@@ -134,6 +134,21 @@ class RhdEnvironment
     @environment_name == 'drupal-staging' or @environment_name == 'drupal-production'
   end
 
+  def get_docker_host
+    case @environment_name
+      when 'drupal-dev'
+        return 'docker'
+      when 'drupal-pull-request'
+        return 'rhdp-jenkins-slave.lab4.eng.bos.redhat.com'
+      when 'drupal-staging'
+        return 'rhdp-drupal.stage.redhat.com'
+      when 'drupal-production'
+        return 'rhdp-drupal.redhat.com'
+      else
+        raise StandardError "Cannot determine Docker host for environment '#{@environment_name}'"
+    end
+  end
+
   #
   # Provides the list of supporting services that should be started in each environment before
   # running Awestruct

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -42,8 +42,8 @@ class TestControl < Minitest::Test
     environment = mock()
     supporting_services = %w(drupal)
 
+    environment.expects(:get_docker_host).returns('127.0.0.1')
     expects(:check_supported_service_requested).with(supporting_services, 'drupal').returns(true)
-    expects(:determine_docker_host_for_container_ports).returns('127.0.0.1')
     expects(:get_host_mapped_port_for_container).with(environment, 'drupal', '80/tcp').returns('80')
 
     bind_drupal_container_details_into_environment(environment, supporting_services)
@@ -163,30 +163,6 @@ class TestControl < Minitest::Test
 
     assert_equal(container, get_docker_container(environment, container_name))
 
-  end
-
-  def test_determine_docker_host_for_container_ports_with_docker_host_alias
-
-      host_ip = '10.20.30.40'
-      # won't execute if docker defined.
-      # Socket.expects(:gethostname).returns('localhost')
-      # Resolv.expects(:getaddress).with('localhost').returns(host_ip)
-
-      docker_machine_ip = '192.168.0.1'
-      Resolv.expects(:getaddress).with('docker').returns(docker_machine_ip)
-
-      assert_equal(docker_machine_ip, determine_docker_host_for_container_ports)
-  end
-
-  def test_determine_docker_host_for_container_ports_with_no_docker_host_alias
-
-    host_ip = '10.20.30.40'
-
-    Socket.expects(:gethostname).returns('localhost')
-    Resolv.expects(:getaddress).with('localhost').returns(host_ip)
-    Resolv.expects(:getaddress).with('docker').raises(StandardError.new('No docker alias here!'))
-
-    assert_equal(host_ip, determine_docker_host_for_container_ports)
   end
 
   def test_start_and_wait_for_supporting_services

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -81,7 +81,7 @@ class TestControl < Minitest::Test
     service_port = '80/tcp'
     service_url = 'user/login'
 
-    expects(:determine_docker_host_for_container_ports).returns('127.0.0.1')
+    environment.expects(:get_docker_host).returns('127.0.0.1')
     expects(:get_host_mapped_port_for_container).with(environment, 'drupal', service_port).returns('80').times(2)
 
     response = mock()

--- a/_docker/tests/test_rhd_environment.rb
+++ b/_docker/tests/test_rhd_environment.rb
@@ -32,6 +32,27 @@ class TestRhdEnvironment < MiniTest::Test
 
   end
 
+  def test_should_get_docker_host_for_drupal_dev
+    @environment.environment_name = 'drupal-dev'
+    assert_equal('docker', @environment.get_docker_host)
+  end
+
+  def test_should_get_docker_host_for_drupal_pr
+    @environment.environment_name = 'drupal-pull-request'
+    assert_equal('rhdp-jenkins-slave.lab4.eng.bos.redhat.com', @environment.get_docker_host)
+  end
+
+  def test_should_get_docker_host_for_drupal_staging
+    @environment.environment_name = 'drupal-staging'
+    assert_equal('rhdp-drupal.stage.redhat.com', @environment.get_docker_host)
+  end
+
+  def test_should_get_docker_host_for_drupal_staging
+    @environment.environment_name = 'drupal-production'
+    assert_equal('rhdp-drupal.redhat.com', @environment.get_docker_host)
+  end
+
+
   def test_drupal_pr_environment_does_not_preselect_port_if_required_env_variable_empty
     ENV['ghprbPullId'] = ''
     @environment.environment_name = 'drupal-pull-request'


### PR DESCRIPTION
Something has changed in the staging and production environments that means `control.rb` is now returning bad DNS lookups for the host on which Drupal is exposed. This is causing the Drupal boot management sequence to fail as the scripts believe that Drupal is not running.

### JIRA Issue Link
* [DEVELOPER-5369](https://issues.jboss.org/browse/DEVELOPER-5369)

### Verification Process

The PR build process should work smoothly. Check the output of the PR build to verify that the control.rb script is checking that the Drupal instance is up on host `rhdp-jenkins-slave.lab4.eng.bos.redhat.com`