### PR TITLE
[DEVELOPER-5364] Determine changed content between runs of the export

### DIFF
--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -341,10 +341,6 @@ if $0 == __FILE__
     system_exec.execute_docker_compose(environment, :run, tasks[:unit_tests])
   end
 
-  if tasks[:export]
-    system_exec.execute_docker_compose(environment, :exec, %w[-T drupal drush cr])
-  end
-
   start_and_wait_for_supporting_services(environment, tasks[:supporting_services], system_exec)
 
   if tasks[:awestruct_command_args]

--- a/_docker/lib/export/export_diff.rb
+++ b/_docker/lib/export/export_diff.rb
@@ -1,0 +1,124 @@
+require 'nokogiri'
+
+require_relative '../default_logger'
+
+module RedhatDeveloper
+  module Export
+
+    #
+    # Uses the sitemap.xml of the current export and a previous export to determine a list of URLs that have changed
+    # content between runs of the export process.
+    #
+    # @author rblake@redhat.com
+    #
+    class ExportDiff
+      def initialize(export_archive_directory)
+        @export_archive_directory = export_archive_directory
+        @log = DefaultLogger.logger
+      end
+
+      #
+      # Builds an array of URLs that have changed since the previous export. A URL is deemed to have changed if the <lastmod>
+      # entry for the URL in the current sitemap.xml is after the <lastmod> entry for the URL in the sitemap.xml of the previous
+      # export.
+      #
+      # The previous export is determined by looking within the export archive directory and selecting the most recently archived
+      # export. If no archives exist or the sitemap.xml within the archive cannot be read, then the process will return an
+      # empty array of changed content. Additionally if the current sitemap.xml is malformed, then again an empty array is returned.
+      #
+      def modified_content_urls(export_directory)
+        current_sitemap = load_current_sitemap(export_directory)
+        return [] if current_sitemap.nil?
+
+        previous_sitemap = load_previous_sitemap
+        return [] if previous_sitemap.nil?
+
+        check_for_modified_content(current_sitemap, previous_sitemap)
+      end
+
+      private
+
+      def load_current_sitemap(export_directory)
+        sitemap_xml_path = "#{ export_directory }/sitemap.xml"
+        current_sitemap = load_sitemap_xml(sitemap_xml_path)
+        if current_sitemap.nil?
+          @log.warn("Unable to locate sitemap.xml for current export at expected location '#{sitemap_xml_path}'. Cannot generate list of URLs to clear from cache.")
+        end
+        current_sitemap
+      end
+
+      def load_previous_sitemap
+        previous_export_directory = Dir.glob("#{ @export_archive_directory }/export-*").sort.select{ |directory| File.exist?("#{ directory }/sitemap.xml") }.last
+
+        if previous_export_directory.nil?
+          @log.warn("Unable to perform export comparison as there appear to be no previous exports within the export archive directory '#{ @export_archive_directory }'.")
+          return nil
+        end
+
+        @log.info("Using sitemap.xml from previous export archived at '#{ previous_export_directory }' to determine any modified content.")
+        load_sitemap_xml("#{ previous_export_directory }/sitemap.xml")
+      end
+
+      def load_sitemap_xml(sitemap_xml_path)
+        return nil unless File.exist?(sitemap_xml_path)
+
+        xml_document = nil
+
+        begin
+          xml_document = Nokogiri::XML(File.open(sitemap_xml_path))
+          if xml_document.css('url').size == 0
+            log.warn("A sitemap.xml exists at '#{ sitemap_xml_path }' but it contains 0 <url> entries and cannot be used to determine content that has changed.")
+            return nil
+          end
+        rescue
+          @log.error("Failed to parse or open sitemap.xml at path '#{ sitemap_xml_path }'.")
+          return nil
+        end
+
+        @log.info("Using current sitemap.xml at location '#{sitemap_xml_path}'.")
+        xml_document
+      end
+
+
+      def build_lastmod_hash(sitemap)
+        url_modification_dates = {}
+        sitemap.css('url').each do |url|
+          location = url.css('loc')
+          unless location.empty?
+            last_modification_time = url.css('lastmod')
+            url_modification_dates[location.first.text] = last_modification_time.empty? ? Time.now.to_s : last_modification_time.first.text
+          end
+        end
+
+        url_modification_dates
+      end
+
+
+      def check_for_modified_content(current_sitemap, previous_sitemap)
+
+        previous_urls = build_lastmod_hash(previous_sitemap)
+        current_urls = build_lastmod_hash(current_sitemap)
+
+        modified_urls = []
+
+        current_urls.keys.each do |url|
+          current_timestamp = current_urls[url]
+          previous_timestamp = previous_urls[url]
+
+          if previous_timestamp.nil?
+            @log.info("URL '#{ url }' did not exist in the previous export and is new content. No cache clear required.")
+            next
+          end
+
+          if Date.parse(current_timestamp) > Date.parse(previous_timestamp)
+            @log.info("Content of URL '#{ url }' has changed. <lastmod> in current sitemap '#{ current_timestamp }', <lastmod> in previous sitemap '#{ previous_timestamp }'.")
+            modified_urls.push(url)
+          end
+
+        end
+        modified_urls
+
+      end
+    end
+  end
+end

--- a/_docker/tests/export/test_export.rb
+++ b/_docker/tests/export/test_export.rb
@@ -14,7 +14,8 @@ class TestExport < MiniTest::Test
     @export_strategy = mock()
     @rsync_handler = mock()
     @rsync_destination = 'foo@bar:/my/export'
-    @export = Export.new(@drupal_host, @export_directory, @cron_invoker, @page_url_list_generator, @export_strategy, @rsync_handler, @rsync_destination)
+    @export_diff = mock()
+    @export = Export.new(@drupal_host, @export_directory, @cron_invoker, @page_url_list_generator, @export_strategy, @rsync_handler, @rsync_destination, @export_diff)
   end
 
   def test_export
@@ -27,12 +28,13 @@ class TestExport < MiniTest::Test
     @page_url_list_generator.expects(:save_sitemap).with(nil, '/export/foo/sitemap.xml')
     @export_strategy.expects(:export!).with(url_list_file, @drupal_host, @export_directory).returns('/export/foo')
     @rsync_handler.expects(:rsync_static_export).with('/export/foo', @rsync_destination, true)
+    @export_diff.expects(:modified_content_urls).with('/export/foo')
 
     @export.export!
   end
 
   def test_export_with_no_rsync_location
-    @export = Export.new(@drupal_host, @export_directory, @cron_invoker, @page_url_list_generator, @export_strategy, @rsync_handler, nil)
+    @export = Export.new(@drupal_host, @export_directory, @cron_invoker, @page_url_list_generator, @export_strategy, @rsync_handler, nil, @export_diff)
 
     url_list_file = mock()
 

--- a/_docker/tests/export/test_export_diff.rb
+++ b/_docker/tests/export/test_export_diff.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+require 'fileutils'
+
+require_relative '../test_helper'
+require_relative '../../lib/export/export_diff'
+
+
+class TestExportDiff < MiniTest::Test
+
+  def setup
+    @example_sitemaps_dir = Dir.open(File.expand_path('test_export_diff',File.dirname(__FILE__))).path
+    @export_dir = Dir.mktmpdir
+    @export_archive_dir = Dir.mktmpdir
+
+    @export_diff = RedhatDeveloper::Export::ExportDiff.new(@export_archive_dir)
+  end
+
+  def make_export_archives
+    @first_export_archive = "#{@export_archive_dir}/export-2018-09-12-21-14-51"
+    @second_export_archive = "#{@export_archive_dir}/export-2018-09-13-10-15-19"
+
+    FileUtils.mkdir([@first_export_archive, @second_export_archive])
+    FileUtils.cp("#{@example_sitemaps_dir}/sitemap-1.xml", "#{@first_export_archive}/sitemap.xml")
+    FileUtils.cp("#{@example_sitemaps_dir}/sitemap-1.xml", "#{@second_export_archive}/sitemap.xml")
+  end
+
+  def make_current_sitemap(sitemap_file='sitemap-1.xml')
+    FileUtils.cp("#{@example_sitemaps_dir}/#{sitemap_file}", "#{@export_dir}/sitemap.xml")
+  end
+
+  def test_cannot_perform_comparison_with_no_export_archives
+    make_current_sitemap
+    assert_equal([], @export_diff.modified_content_urls(@export_dir))
+  end
+
+  def test_cannot_perform_comparison_with_no_current_sitemap
+      assert_equal([], @export_diff.modified_content_urls(@export_dir))
+  end
+
+  def test_no_urls_reported_when_all_modification_times_the_same
+    make_current_sitemap
+    make_export_archives
+
+    assert_equal([], @export_diff.modified_content_urls(@export_dir))
+  end
+
+  def test_correctly_reports_modified_urls
+    make_current_sitemap('sitemap-2.xml')
+    make_export_archives
+
+    urls = @export_diff.modified_content_urls(@export_dir)
+    assert_equal(2, urls.size)
+    assert(urls.include?('http://developers.redhat.com/articles/no-cost-rhel-faq'))
+    assert(urls.include?('http://developers.redhat.com/about'))
+  end
+
+  def teardown
+    FileUtils.rm_rf(@export_dir)
+    FileUtils.rm_rf(@export_archive_dir)
+  end
+
+end

--- a/_docker/tests/export/test_export_diff/sitemap-1.xml
+++ b/_docker/tests/export/test_export_diff/sitemap-1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://developers.redhat.com/</loc>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/articles/no-cost-rhel-faq</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/about</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/articles/rhel-what-you-need-to-know</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/community/contributor</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/community/contributor/signup</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:32-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+</urlset>

--- a/_docker/tests/export/test_export_diff/sitemap-2.xml
+++ b/_docker/tests/export/test_export_diff/sitemap-2.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>http://developers.redhat.com/</loc>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/articles/no-cost-rhel-faq</loc>
+    <priority>0.5</priority>
+    <lastmod>2017-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/about</loc>
+    <priority>0.5</priority>
+    <lastmod>2017-06-06T08:56:29-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/articles/rhel-what-you-need-to-know</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/community/contributor</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:31-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/community/contributor/signup</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:32-07:00</lastmod>
+  </url>
+  <url>
+    <loc>http://developers.redhat.com/confirmation</loc>
+    <priority>0.5</priority>
+    <lastmod>2016-06-06T08:56:33-07:00</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
This PR adds the ability for the export process to determine which page content has changed between runs. It does this by inspecting the current `sitemap.xml` and comparing the `<lastmod>` entry for each page against that from the previous export.

It locates the previous export by looking in the export archive directory. Each time an export is successfully rsynced, a copy is made into the archive directory to facilitate easy rollback. This copy contains the previous version of the `sitemap.xml` with previous content modification times.

This PR merely adds the ability to detect which pages have changed, it does not add anything to act on that e.g. clearing the Akamai cache. This will be added in another PR.

Additionally this PR removes an unnecessary call to clear the Drupal cache each time an export was run.

### JIRA Issue Link
* [DEVELOPER-5364](https://issues.jboss.org/browse/DEVELOPER-5364)

### Verification Process

* Ensure that the build completes successfully
* Ensure that the tests pass against the exported version of the site 