### PR TITLE
[DEVELOPER-5380] Ensure Drupal automatically restarts in staging & production

### DIFF
--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -8,6 +8,7 @@ services:
        https_proxy: proxy01.util.phx2.redhat.com:8080
     ports:
       - "80:80"
+    restart: 'unless-stopped'
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         https_proxy: proxy01.util.phx2.redhat.com:8080
     ports:
       - "80:80"
+    restart: 'unless-stopped'
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php


### PR DESCRIPTION
Whenever IT perform any maintenance to our staging or production environments that involve either a reboot of the VM or a restart of the Docker daemon, our Drupal instance is not automatically restarted until the deploy job runs in Jenkins. This causes two problems:

1. Anyone wanting to edit content after IT maintenance has to wait until Drupal is re-deployed to do so
2. We set off a lot of Nagios alerts because our Drupal instance remains down after IT maintenance

This PR simply applies a Docker restart policy to the Drupal containers in `stage` and `production` environments. We apply the `unless-stopped` policy which says that the Drupal container will be restarted unless it has been explicitly stopped via `docker stop` or `docker-compose down`.

### JIRA Issue Link
* [DEVELOPER-5380](https://issues.jboss.org/browse/DEVELOPER-5380)

### Verification Process

I have already tested this in `staging` but to verify:

1. Wait until the Drupal deployment has occurred into staging after this PR is merged
2. Log on to the staging VM and ensure Drupal is currently running with `docker ps`
3. Re-start the Docker daemon with `service docker restart` (you will need to be root to do this)
4. Observe that the Drupal container is automatically restarted by again doing a `docker ps` once the Docker daemon has restarted.