### PR TITLE
[DEVELOPER-5390] Move export file I/O onto local block device in staging

### DIFF
--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -59,7 +59,8 @@ services:
         https_proxy: proxy01.util.phx2.redhat.com:8080
     entrypoint: "ruby _docker/lib/export/export.rb rhdp-drupal.stage.redhat.com"
     volumes:
-      - /data/drupal-export:/export
+      - /home/jenkins_developer/drupal-export-live:/export
+      - /data/drupal-export/export-archives:/export/export-archives
       - /credentials/rsync:/home/jenkins_developer/.ssh
       - ../../../:/home/jenkins_developer/developer.redhat.com
       - ../../../images:/home/jenkins_developer/developer.redhat.com/_docker/lib/export/static/images:ro


### PR DESCRIPTION
This PR moves almost all of the file I/O operations for the export process onto a local block device in `staging` rather than using an NFS mount. This should be a significant performance improvement for the export process.

### JIRA Issue Link
* [DEVELOPER-5390](https://issues.jboss.org/browse/DEVELOPER-5390)

### Verification Process

* This PR is targeting `stage` branch for testing
* Verify that the time of the `Site_Export (developers.stage.redhat.com)` is significantly reduced
* Verify that the export of `developers.stage.redhat.com` continues to work and look as expected.  