### PR TITLE
[DEVELOPER-5414] Added the missing require 'time' from export_diff.rb

### DIFF
--- a/_docker/lib/export/export_diff.rb
+++ b/_docker/lib/export/export_diff.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'time'
 
 require_relative '../default_logger'
 


### PR DESCRIPTION
Somehow a missing `require 'time'` statement in the `export_diff.rb` class has made it through all testing and into production. 

This simply adds the missing `require` statement.

### JIRA Issue Link
* [DEVELOPER-5414](https://issues.jboss.org/browse/DEVELOPER-5414)

### Verification Process

* The export process works as expected.