### PR TITLE
[DEVELOPER-5390] Changed directory for local filesystem export work

### DIFF
--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         https_proxy: proxy01.util.phx2.redhat.com:8080
     entrypoint: "ruby _docker/lib/export/export.rb rhdp-drupal.stage.redhat.com"
     volumes:
-      - /home/jenkins_developer/drupal-export-live:/export
+      - /drupal-export-workspace:/export
       - /data/drupal-export/export-archives:/export/export-archives
       - /credentials/rsync:/home/jenkins_developer/.ssh
       - ../../../:/home/jenkins_developer/developer.redhat.com


### PR DESCRIPTION
Changed the directory in which the export does local filesystem work to something much more self-explanatory. This is going into `stage` only at this moment in time as a test. No other environments are impacted by this.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5390

### Verification Process

- The export continues to work as expected in staging.
