### PR TITLE
Export configs from drupal-data-lite container.

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.learning_paths.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.learning_paths.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: learning_paths
-label: Learning Guides
+label: 'Learning Guides'
 description: ''
 visual_styles: ''
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -163,6 +163,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   field_author_name: true
   field_image: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
@@ -92,6 +92,11 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   promote: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
@@ -136,6 +136,11 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   promote: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
@@ -247,6 +247,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_average_rating: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -199,5 +199,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
@@ -142,6 +142,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
@@ -131,6 +131,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   path: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
@@ -183,6 +183,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_event_type: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
@@ -192,6 +192,11 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   body: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.page.default.yml
@@ -82,5 +82,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
@@ -201,6 +201,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   path: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_card.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_card.default.yml
@@ -64,6 +64,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
@@ -100,6 +100,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
@@ -138,5 +138,10 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
@@ -147,5 +147,10 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_microsite.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_microsite.default.yml
@@ -60,6 +60,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   promote: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_solution_overview.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_solution_overview.default.yml
@@ -63,6 +63,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic.default.yml
@@ -170,6 +170,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -103,6 +103,11 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   promote: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -236,6 +236,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   promote: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/node.type.learning_path.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/node.type.learning_path.yml
@@ -9,7 +9,7 @@ third_party_settings:
     available_menus:
       - main
     parent: 'main:'
-name: Learning Guide
+name: 'Learning Guide'
 type: learning_path
 description: 'A page with a collection of content types that create a Learning Guide.'
 help: ''


### PR DESCRIPTION
It looks like the latest version of Drupal changed how the config is exported which seemed to be blockin `drush cim` from importing correctly. These are the configs exported from the `drupal-data-lite` container.