### PR TITLE
[DEVELOPER-5403] Content Assembly for Articles

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.content.yml
@@ -1,0 +1,9 @@
+uuid: 40b1294f-c9a3-40c9-83b2-9b457ee23553
+langcode: en
+status: true
+dependencies: {  }
+id: content
+label: Content
+description: ''
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content.default.yml
@@ -1,0 +1,48 @@
+uuid: 7a87b931-0f36-495a-8e19-3566e2b61d8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content
+    - field.field.assembly.content.field_audience_selection
+    - field.field.assembly.content.field_content
+  module:
+    - text
+id: assembly.content.default
+targetEntityType: assembly
+bundle: content
+mode: default
+content:
+  field_audience_selection:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_content:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  moderation_state: true
+  user_id: true
+  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.field_author_name
     - field.field.node.article.field_card_image
+    - field.field.node.article.field_content
     - field.field.node.article.field_content_author
     - field.field.node.article.field_difficulty
     - field.field.node.article.field_hide_toc
@@ -19,6 +20,8 @@ dependencies:
     - node.type.article
   module:
     - content_moderation
+    - entity_browser_entity_form
+    - inline_entity_form
     - interval
     - link
     - metatag
@@ -42,17 +45,35 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     region: content
   field_card_image:
-    weight: 15
+    weight: 16
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_content:
+    weight: 6
+    settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      override_labels: false
+      collapsible: false
+      collapsed: false
+      allow_duplicate: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
     region: content
   field_content_author:
     weight: 4
@@ -63,14 +84,14 @@ content:
     type: string_textfield
     region: content
   field_difficulty:
-    weight: 13
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_hide_toc:
     type: boolean_checkbox
-    weight: 6
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -85,13 +106,13 @@ content:
     type: text_textarea_with_summary
     region: content
   field_meta_tags:
-    weight: 14
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_read_time:
-    weight: 12
+    weight: 13
     settings:
       allowed_periods: {  }
     third_party_settings: {  }
@@ -107,7 +128,7 @@ content:
     region: content
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 16
+    weight: 17
     settings:
       match_operator: CONTAINS
       size: 60
@@ -121,14 +142,14 @@ content:
     type: options_buttons
     region: content
   moderation_state:
-    weight: 26
+    weight: 18
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default
     region: content
   path:
     type: path
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -136,14 +157,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     third_party_settings: {  }
     region: content
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     third_party_settings: {  }
     region: content
   title:
@@ -156,7 +177,7 @@ content:
     region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -164,10 +185,10 @@ content:
     third_party_settings: {  }
     region: content
   url_redirects:
-    weight: 50
+    weight: 19
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   field_author_name: true
   field_image: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.content.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.content.default.yml
@@ -1,0 +1,41 @@
+uuid: 2c13eafc-76aa-4758-8904-ef5ac35f031b
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content
+    - field.field.assembly.content.field_audience_selection
+    - field.field.assembly.content.field_content
+  module:
+    - fences
+    - options
+    - text
+id: assembly.content.default
+targetEntityType: assembly
+bundle: content
+mode: default
+content:
+  field_audience_selection:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_content:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: text_default
+    region: content
+hidden:
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.field_author_name
     - field.field.node.article.field_card_image
+    - field.field.node.article.field_content
     - field.field.node.article.field_content_author
     - field.field.node.article.field_difficulty
     - field.field.node.article.field_hide_toc
@@ -18,6 +19,8 @@ dependencies:
     - field.field.node.article.field_topics
     - node.type.article
   module:
+    - entity_reference_revisions
+    - fences
     - interval
     - link
     - metatag
@@ -33,18 +36,18 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 0
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     label: hidden
     region: content
   content_moderation_control:
-    weight: -20
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
   field_card_image:
-    weight: 105
+    weight: 9
     label: above
     settings:
       trim_length: 80
@@ -55,8 +58,24 @@ content:
     third_party_settings: {  }
     type: link
     region: content
+  field_content:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: entity_reference_revisions_entity_view
+    region: content
   field_content_author:
-    weight: 101
+    weight: 5
     label: hidden
     settings:
       link_to_entity: false
@@ -64,35 +83,35 @@ content:
     type: string
     region: content
   field_difficulty:
-    weight: 103
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_long_description:
-    weight: 108
+    weight: 12
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   field_meta_tags:
-    weight: 102
+    weight: 6
     label: above
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
     region: content
   field_read_time:
-    weight: 104
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
     type: interval_default
     region: content
   field_short_description:
-    weight: 107
+    weight: 11
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -100,7 +119,7 @@ content:
     region: content
   field_tags:
     type: entity_reference_label
-    weight: 10
+    weight: 3
     label: hidden
     settings:
       link: false
@@ -114,7 +133,7 @@ content:
         fences_label_classes: ''
     region: content
   field_topics:
-    weight: 106
+    weight: 10
     label: above
     settings:
       link: true
@@ -122,7 +141,7 @@ content:
     type: entity_reference_label
     region: content
   links:
-    weight: 100
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content.field_audience_selection.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content.field_audience_selection.yml
@@ -1,0 +1,21 @@
+uuid: 2c41d819-47f4-40d0-b52e-6f904dddade5
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content
+    - field.storage.assembly.field_audience_selection
+  module:
+    - options
+id: assembly.content.field_audience_selection
+field_name: field_audience_selection
+entity_type: assembly
+bundle: content
+label: 'Audience Selection'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content.field_content.yml
@@ -1,0 +1,21 @@
+uuid: a09df3bd-ad18-4c2a-a9bc-b66c03ea97c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content
+    - field.storage.assembly.field_content
+  module:
+    - text
+id: assembly.content.field_content
+field_name: field_content
+entity_type: assembly
+bundle: content
+label: Content
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
@@ -1,0 +1,30 @@
+uuid: a35ad118-b7e6-4599-8aae-36824d81e6fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content
+    - field.storage.node.field_content
+    - node.type.article
+  module:
+    - entity_reference_revisions
+id: node.article.field_content
+field_name: field_content
+entity_type: node
+bundle: article
+label: Content
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:assembly'
+  handler_settings:
+    target_bundles:
+      content: content
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference_revisions

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_content.yml
@@ -1,0 +1,21 @@
+uuid: 122691e4-6587-425f-a754-d1ca1d27d279
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+    - entity_reference_revisions
+    - node
+id: node.field_content
+field_name: field_content
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: assembly
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article.html.twig
@@ -100,6 +100,7 @@ other methods (such as node.delete) will result in an exception.
     {% endif %}
     <div{{ content_attributes.addClass(article_classes) }}>
         {{ content.body }}
+        {{ content.field_content }}
     </div>
   </div>
   <div class="medium-20 medium-offset-4 columns">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--content.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--content.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file assembly.html.twig
+ * Default theme implementation to present Assembly data.
+ *
+ * This template is used when viewing Assembly pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_assembly()
+ *
+ * @ingroup themeable
+ */
+#}
+<section{{ attributes.addClass('assembly') }}{{ audience_selection }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</section>


### PR DESCRIPTION
Create Content assembly and add to field_content on Articles content type.

### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5403

### Verification Process
1. Create an article or update an existing article
2. Add a content assembly to the article
3. Ensure the content assembly appears per the mocks.

### Screens

#### Admin
##### New
![screen shot 2018-09-28 at 1 37 53 pm](https://user-images.githubusercontent.com/41014351/46230354-996c0680-c325-11e8-8d0c-538ff6f040dd.png)

##### Edit
![screen shot 2018-09-28 at 1 40 49 pm](https://user-images.githubusercontent.com/41014351/46230362-9d982400-c325-11e8-8d65-0e110b552fa3.png)

#### Front-end
##### After Body
![screen shot 2018-09-28 at 1 41 15 pm](https://user-images.githubusercontent.com/41014351/46230402-bf91a680-c325-11e8-8b80-64f92f7edf5b.png)

##### No Body
![screen shot 2018-09-28 at 1 41 52 pm](https://user-images.githubusercontent.com/41014351/46230405-c3252d80-c325-11e8-8a30-852849b07d78.png)

##### No Content
![screen shot 2018-09-28 at 1 42 45 pm](https://user-images.githubusercontent.com/41014351/46230410-c6b8b480-c325-11e8-8d4a-f0f2880a22c6.png)
