### PR TITLE
[NO ISSUE]: bump docker-selenium version 

### DIFF
--- a/_tests/e2e/config/browsers/BrowserManager.js
+++ b/_tests/e2e/config/browsers/BrowserManager.js
@@ -82,5 +82,4 @@ class BrowserManager {
     }
 }
 
-module
-    .exports = new BrowserManager;
+module.exports = new BrowserManager;

--- a/_tests/e2e/config/wdio.conf.base.js
+++ b/_tests/e2e/config/wdio.conf.base.js
@@ -1,3 +1,5 @@
+const qs = require('querystring');
+
 if (typeof process.env.RHD_BASE_URL === 'undefined') {
     process.env.RHD_BASE_URL = 'https://developers.redhat.com';
     baseUrl = process.env.RHD_BASE_URL
@@ -82,7 +84,7 @@ exports.config = {
     //
     // Default timeout in milliseconds for request
     // if Selenium Grid doesn't send response
-    connectionRetryTimeout: 90000,
+    connectionRetryTimeout: 95000,
     //
     // Default request retries count
     connectionRetryCount: 3,
@@ -128,7 +130,7 @@ exports.config = {
     mochaOpts: {
         compilers: ['js:babel-register'],
         ui: 'bdd',
-        timeout: 65000
+        timeout: 180000
     },
 
     reporterOptions: {

--- a/_tests/e2e/environments/docker-compose.yml
+++ b/_tests/e2e/environments/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     - GRID_PORT=4444
 
   chrome:
-    image: selenium/standalone-chrome:3.14.0-dubnium
+    image: selenium/standalone-chrome:3.14.0-europium
     volumes:
     - /dev/shm:/dev/shm
     - ../tmp_downloads:/home/e2e/developers.redhat.com/_tests/e2e/tmp_downloads

--- a/_tests/e2e/specs/rhd-downloads.spec.js
+++ b/_tests/e2e/specs/rhd-downloads.spec.js
@@ -1,4 +1,3 @@
-import {Home} from "./support/pages/website/Home.page";
 import {Login} from './support/pages/keycloak/Login.page';
 import {ProductOverview} from './support/pages/website/ProductOverview.page';
 import {CheatSheets} from './support/pages/website/CheatSheets.page';
@@ -10,27 +9,23 @@ const tags = require('mocha-tags');
 
 tags('desktop').describe('Download Manager', function () {
     this.retries(2);
-    let downloadDir, downloadName, siteUser;
-    let home, login;
 
     beforeEach(function () {
-        this.retries(2);
-        login = new Login();
-        home = new Home();
-        downloadDir = new DownloadDir();
+        let downloadDir = new DownloadDir();
         downloadDir.clear();
-        new Utils().logout(process.env.RHD_BASE_URL);
     });
 
     afterEach(function () {
-        this.retries(2);
-        new Utils().logout(process.env.RHD_BASE_URL);
+        let downloadDir = new DownloadDir();
         downloadDir.clear(global.downloadDir);
+        new Utils().logout();
     });
 
     tags('dm')
         .it('@sanity : should allow users to login in and download RHEL', function () {
-            siteUser = new User(process.env.RHD_BASE_URL).rhdAccountDetails();
+            let downloadDir = new DownloadDir();
+            let siteUser = new User(process.env.RHD_BASE_URL).rhdAccountDetails();
+            let login = new Login();
             let productOverview = new ProductOverview('rhel', 'download', 'Red Hat Enterprise Linux');
             productOverview
                 .open();
@@ -40,13 +35,15 @@ tags('desktop').describe('Download Manager', function () {
                 .with(siteUser);
             productOverview
                 .awaitDownload();
-            downloadName = downloadDir.get();
+            let downloadName = downloadDir.get();
             expect(downloadName.toString(), 'rhel download was not triggered').to.include('rhel');
         });
 
     tags('dm')
         .it('@sanity : should allow users to log-in and download advanced-linux-commands', function () {
+            let downloadDir = new DownloadDir();
             let siteUser = new User(process.env.RHD_BASE_URL).rhdAccountDetails();
+            let login = new Login();
             let cheatSheet = new CheatSheets('advanced-linux-commands');
             cheatSheet
                 .open();
@@ -58,7 +55,7 @@ tags('desktop').describe('Download Manager', function () {
                 .with(siteUser);
             cheatSheet
                 .awaitDownload();
-            downloadName = downloadDir.get();
+            let downloadName = downloadDir.get();
             expect(downloadName.toString(), 'rhel advanced linux cheatsheet download was not triggered').to.include('rheladvancedlinux_cheat_sheet')
         });
 });

--- a/_tests/e2e/specs/support/Utils.js
+++ b/_tests/e2e/specs/support/Utils.js
@@ -5,7 +5,6 @@ const qs = require('querystring');
 export class Utils extends Page {
 
     cleanSession(baseUrl) {
-        console.log('i failed to log out')
         let logoutLink;
         let encodedURL = qs.escape(baseUrl);
         if (process.env.RHD_BASE_URL === 'https://developers.stage.redhat.com') {

--- a/_tests/e2e/specs/support/Utils.js
+++ b/_tests/e2e/specs/support/Utils.js
@@ -4,7 +4,8 @@ const qs = require('querystring');
 
 export class Utils extends Page {
 
-    logout(baseUrl) {
+    cleanSession(baseUrl) {
+        console.log('i failed to log out')
         let logoutLink;
         let encodedURL = qs.escape(baseUrl);
         if (process.env.RHD_BASE_URL === 'https://developers.stage.redhat.com') {
@@ -15,4 +16,11 @@ export class Utils extends Page {
         return this.visit(logoutLink);
     }
 
+    logout() {
+        try {
+            return this.userLogout()
+        } catch (e) {
+            return this.cleanSession(process.env.RHD_BASE_URL)
+        }
+    }
 }

--- a/_tests/e2e/specs/support/pages/Page.js
+++ b/_tests/e2e/specs/support/pages/Page.js
@@ -37,7 +37,21 @@ export class Page extends PageExtension {
     }
 
     awaitIsLoggedIn(siteUser) {
-        return this.awaitIsNotVisible('.login', 60000) && this.awaitIsVisible('.logged-in', 60000) &&
-            this.waitForSelectorContainingText('.logged-in-name', `${siteUser['firstName']} ${siteUser['lastName']}`, 60000);
+        try {
+            return this.awaitIsNotVisible('.login', 90000) && this.awaitIsVisible('.logged-in', 90000) &&
+                this.waitForSelectorContainingText('.logged-in-name', `${siteUser['firstName']} ${siteUser['lastName']}`, 80000);
+        } catch (e) {
+            throw Error('user was not logged in after 80 seconds!');
+        }
+    }
+
+    userLogout() {
+        let loggedInName = '.logged-in-name';
+        let menu = 'nav > ul.rhd-menu.rh-universal-login > li.logged-in > ul';
+        let logout = 'li.logged-in > ul > li:nth-child(2) > a';
+        this.awaitIsVisible(loggedInName);
+        this.click(loggedInName);
+        this.awaitIsVisible(menu);
+        return this.click(logout)
     }
 }

--- a/_tests/e2e/specs/support/pages/keycloak/Login.page.js
+++ b/_tests/e2e/specs/support/pages/keycloak/Login.page.js
@@ -29,6 +29,7 @@ export class Login extends Page {
         this.awaitLogin();
         this.type(user['email'], this.getSelector('usernameField'));
         this.type(user['password'], this.getSelector('passwordField'));
-        return this.click(this.getSelector('loginButton'));
+        this.click(this.getSelector('loginButton'));
+        return this.awaitIsLoggedIn(user)
     }
 }


### PR DESCRIPTION
* NO ISSUE
* Just an update to docker-selenium (chrome) and upped timeout for login process as for some reason at times it takes more than 1 minute to log in (when downloading).
* Sometimes the direct logout (via url) doesn't work so added an after hook to to do a regular logout first, and then fallback to do a direct logout. 
