### PR TITLE
Updates for cookie banner blocking log in to download button.

### DIFF
--- a/_tests/e2e/config/browsers/BrowserManager.js
+++ b/_tests/e2e/config/browsers/BrowserManager.js
@@ -28,7 +28,7 @@ class BrowserManager {
                 acceptInsecureCerts: true,
 
                 chromeOptions: {
-                    args: ['disable-web-security', 'user-agent=Red Hat Developers Testing'],
+                    args: ['start-fullscreen', 'disable-web-security', 'user-agent=Red Hat Developers Testing'],
                     prefs: {
                         "download": {
                             "default_directory": pathToChromeDownloads,

--- a/_tests/e2e/specs/support/pages/website/CheatSheets.page.js
+++ b/_tests/e2e/specs/support/pages/website/CheatSheets.page.js
@@ -9,7 +9,7 @@ export class CheatSheets extends Page {
 
         this.addSelectors({
             cheatSheetPage: '#rhd-cheat-sheet',
-            loginToDownloadBtn: '.hidden-after-login',
+            loginToDownloadBtn: "//*[contains(text(),'Log in to download')]",
             thankYou: '.thankyou'
         });
     }


### PR DESCRIPTION
* NO ISSUE: Fix for failing sanity checks. Cookie banner is blocking log in to download button.