### PR TITLE
[DEVELOPER-5437] Fix broken Docker image builds

### DIFF
--- a/_docker/awestruct/Dockerfile
+++ b/_docker/awestruct/Dockerfile
@@ -1,4 +1,4 @@
-FROM developer.redhat.com/ruby:2.3.0
+FROM developer.redhat.com/ruby:2.4.0
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy

--- a/_docker/backup/Dockerfile
+++ b/_docker/backup/Dockerfile
@@ -1,16 +1,11 @@
-FROM developer.redhat.com/ruby:2.3.0
+FROM developer.redhat.com/ruby:2.4.0
 
 ARG http_proxy
 ARG https_proxy
 
 COPY mariadb/MariaDB.repo /etc/yum.repos.d/MariaDB.repo
 
-RUN curl -s https://setup.ius.io/ | bash
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
-RUN yum erase -y git \
-    && yum install -y \
-    git2u \
-    git-lfs \
+RUN yum install -y \
     MariaDB-client \
     && yum clean all
 RUN groupadd -g 1000 jenkins_developer

--- a/_docker/control.rb
+++ b/_docker/control.rb
@@ -227,7 +227,7 @@ def build_base_docker_images(environment, system_exec)
 
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/base:2.0.0).concat(build_args).concat(%w(./base)))
   system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/java:3.0.0).concat(build_args).concat(%w(./java)))
-  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/ruby:2.3.0).concat(build_args).concat(%w(./ruby)))
+  system_exec.execute_docker(:build, %w(--tag=developer.redhat.com/ruby:2.4.0).concat(build_args).concat(%w(./ruby)))
 end
 
 #

--- a/_docker/drupal/Dockerfile
+++ b/_docker/drupal/Dockerfile
@@ -1,4 +1,4 @@
-FROM developer.redhat.com/ruby:2.3.0
+FROM developer.redhat.com/ruby:2.4.0
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy
@@ -15,7 +15,6 @@ RUN rpm -Uvh /root/remi-release-6.rpm
 RUN yum-config-manager --enable remi-php71; \
     yum -y update; \
     yum -y install \
-           git \
            httpd.x86_64 \
            mysql \
            nodejs \

--- a/_docker/export/Dockerfile
+++ b/_docker/export/Dockerfile
@@ -1,4 +1,4 @@
-FROM developer.redhat.com/ruby:2.3.0
+FROM developer.redhat.com/ruby:2.4.0
 
 ARG http_proxy
 ARG https_proxy

--- a/_docker/ruby/Dockerfile
+++ b/_docker/ruby/Dockerfile
@@ -26,18 +26,23 @@ RUN yum install -y  \
   sqlite-devel \
   tar \
   which \
-  wget && \
+  wget \
+  rsync \
+  centos-release-scl && \
   yum clean all && \
   rm -rf /var/cache/yum
 
-# Install Git here. Installing the 'git' package directly via yum no longer works.
-RUN curl -s https://setup.ius.io/ | bash
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
-RUN yum install -y \
-    git2u \
-    git-lfs && \
+
+RUN yum install -y yum install http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm && \
+    yum install -y git && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+RUN cd /tmp && \
+    wget https://github.com/git-lfs/git-lfs/releases/download/v2.5.2/git-lfs-linux-amd64-v2.5.2.tar.gz && \
+    tar xvf git-lfs-linux-amd64-v2.5.2.tar.gz && \
+    ./install.sh && \
+    rm -rf /tmp/*
 
 WORKDIR /tmp
 

--- a/_docker/ruby/Dockerfile
+++ b/_docker/ruby/Dockerfile
@@ -11,7 +11,6 @@ RUN yum install -y  \
   epel-release \
   gcc \
   gcc-c++ \
-  git \
   libcurl-devel \
   libffi-devel \
   libtool \
@@ -27,7 +26,18 @@ RUN yum install -y  \
   sqlite-devel \
   tar \
   which \
-  wget
+  wget && \
+  yum clean all && \
+  rm -rf /var/cache/yum
+
+# Install Git here. Installing the 'git' package directly via yum no longer works.
+RUN curl -s https://setup.ius.io/ | bash
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
+RUN yum install -y \
+    git2u \
+    git-lfs && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 WORKDIR /tmp
 

--- a/_docker/tests/test_control.rb
+++ b/_docker/tests/test_control.rb
@@ -240,7 +240,7 @@ class TestControl < Minitest::Test
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 ./base))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 ./java))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.3.0 ./ruby))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.4.0 ./ruby))
 
     build_base_docker_images(environment, system_exec)
 
@@ -258,7 +258,7 @@ class TestControl < Minitest::Test
 
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/base:2.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./base))
     system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/java:3.0.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./java))
-    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.3.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./ruby))
+    system_exec.expects(:execute_docker).with(:build,%w(--tag=developer.redhat.com/ruby:2.4.0 --build-arg http_proxy=http://foo.com --build-arg https_proxy=http://bar.com ./ruby))
 
     build_base_docker_images(environment, system_exec)
 


### PR DESCRIPTION
*Something* has changed which means that installing git via `yum` in our CentOS 6 images no longer works. This is causing the re-build of the Drupal image to fail.

I've therefore updated the Ruby image to install Git and Git LFS from a different source. This is a significant bump to our Git version.

I've made sure to tag the new ruby image as `2.4.0` and updated all dependent Dockerfiles to use the new version.

I've additionally tested that the `backup` container can still successfully `git lfs clone` the backup repo using the new version of Git and Git LFS.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5437

### Verification Process

* The build should be completely green
* Verify that  Drupal seems to be working as expected