### PR TITLE
DEVELOPER-5255: Image Style URLs

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -513,3 +513,13 @@ function rhdp_preprocess_assembly(&$variables) {
       $variables['eloqua_assembly_id'] = $eloqua_assembly_id;
     }
 }
+
+function rhdp_preprocess_views_view_grouping__product_groups(&$variables) {
+  // Replace Twig HTML comments and unwanted whitespace from the Twig title
+  // variable.
+  $variables['title'] = preg_replace(
+    '/(<!--(.)+-->|\s)/',
+    '',
+    $variables['title']
+  );
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--static-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--static-item.html.twig
@@ -1,5 +1,5 @@
 <section{{ attributes.addClass('assembly') }}{{ audience_selection }}>
-  <a href="{{ content.field_url }}">
+  <a href={{ content.field_url['#items'][0].uri }}>
     <div class="tile-image">
       <div class="image-table">
         <div class="image-cell">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/events/node--events--tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/events/node--events--tile.html.twig
@@ -11,7 +11,10 @@
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
   <a href="{{ url }}">
-    <img src="{{ content.field_tile_thumbnail }}"/>
+    <img{{create_attribute{(
+        'src': content.field_tile_thumbnail['#items'][0].value
+      )}
+    }}
     <h3 class="tile-title">{{ event_title }}</h3>
   </a>
 </article>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--product--featured-tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--product--featured-tile.html.twig
@@ -13,7 +13,7 @@
   </a>
     {{ content.field_short_description }}
     {% if cta_url %}
-      <a class="button medium-cta" href="{{ cta_url }}">{{ cta_title }}</a>
+      <a class="button medium-cta" href="{{ cta_url['#markup'] }}">{{ cta_title }}</a>
     {% endif %}
   </a>
 </article>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--teaser.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--teaser.html.twig
@@ -11,7 +11,11 @@
         <div {{ content_attributes.addClass('rhd-list-entry--summary') }}>{{ content.field_short_description }}</div>
     </div>
     <div class="rhd-list-entry--image">
-        <img src="{{ content.field_video_thumbnail_url }}" alt="Video Thumbnail">
+        <img{{create_attribute({
+            'src': content.field_video_thumbnail_url['#items'][0].value,
+            'alt': 'Video Thumbnail'
+          })
+        }} />
         <div class="rhd-play-button"><span>►</span></div>
     </div>
     <div class="rhd-list-entry--comment-link"><a href="{{ url }}#comments"><span class="fa fa-comment"></span> Leave a comment</a></div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--tile.html.twig
@@ -14,7 +14,10 @@
     <div class="tile-image">
       <div class="image-table">
         <div class="image-cell">
-          <img src="{{ content.field_video_thumbnail_url }}"/>
+          <img{{create_attribute({
+              'src': content.field_video_thumbnail_url['#items'][0].value
+            })
+          }} />
           <div class="play-button">►</div>
         </div>
       </div>


### PR DESCRIPTION
In this commit, in the 5 changed template files, we are passing just the
plain-text string to the <img> src or a <href> attribute(s). Previously,
many of these attributes were having entire Node objects passed to them,
which resulted in instances where HTML comments, for example, were being
injected into the src or href attributes. In addition to the 4 entity
type + display modes detailed in DEVELOPER-5255:

* Node, Events, Tile
* Node, Product, Featured Tile
* Node, Video Resource, Teaser
* Node, Video Resource, Tile

I also discovered a similar issue with the Assembly, Static Item entity
type + display mode, so I resolved that in this commit as well.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5255

### Verification Process

##### Assembly, Static Item (broken)

<img width="1226" alt="assembly--staticitem--broken" src="https://user-images.githubusercontent.com/7155034/46745565-28e8b200-cc62-11e8-9765-cc9980569766.png">

Here is an example of the behavior of this bug prior to my changes. You can see all of the whitespace and the HTML comments within the <a> href attribute. You **should not** see either whitespace or HTML comments, or anything other than the actual URL being referenced, within the href or src attributes.

##### Video Resource, Teaser (fixed)

<img width="1227" alt="videoresource--teaser--fixed" src="https://user-images.githubusercontent.com/7155034/46745566-28e8b200-cc62-11e8-9080-9eb28acf0ccb.png">

##### Video Resource, Tile (fixed)

<img width="1228" alt="videoresource--tile--fixed" src="https://user-images.githubusercontent.com/7155034/46745567-28e8b200-cc62-11e8-9814-fcf7f41b83dd.png">

##### Event, Tile

Unfortunately, I could not find an instance of the Event, Tile content type + display mode on the website. I asked in Slack, and it seemed from Luke's response that this component may not be currently in use on the website. I still resolved the issue to safeguard the potential use of this component in the future, but there isn't a good way to verify this if the component is not being used on the website. I suppose we could create an instance of this component on a QA or Test environment for the purpose of testing this ticket if that is desirable.

##### Assembly, Static Item (fixed)

<img width="1226" alt="assembly--staticitem--fixed" src="https://user-images.githubusercontent.com/7155034/46745568-28e8b200-cc62-11e8-9fdf-824f4d2c6a90.png">

<!--
What process should a tester use to verify this pull request closes the JIRA ticket?

- Which page(s) should one visit?
- Which buttons to click?
- What is the expected outcome?
- etc.
-->
