### PR TITLE
DEVELOPER-5378: Update Book Node Edit Form

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.form_validations.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.form_validations.inc
@@ -79,28 +79,47 @@ function rhd_common_form_node_books_edit_form_alter(&$form, FormStateInterface $
  */
 function add_books_validations(array &$form, FormStateInterface $form_state)
 {
-  // Simple validation to test that the end date is after the start date
+  // Retrieve the value of the ISBN field in the form state.
   $isbn_number = $form_state->getValue('field_isbn')[0]['value'];
+
   if (!is_numeric($isbn_number) && !empty($isbn_number))
   {
-    $form_state->setErrorByName('field_isbn', t('The ISBN field must be a number!')); // Create the error
+    // Set an error if the ISBN value is set and isn't numeric.
+    $form_state->setErrorByName(
+      'field_isbn',
+      t('The ISBN field must be a number!')
+    );
   }
   if (strlen($isbn_number) != 13 && strlen($isbn_number) != 10 && !empty($isbn_number))
   {
-    $form_state->setErrorByName('field_isbn', t('The ISBN field must be a valid 10 or 13 digit number!')); // Create the error
+    // Set an error if the ISBN value is set and isn't 10 or 13 digits.
+    $form_state->setErrorByName(
+      'field_isbn',
+      t('The ISBN field must be a valid 10 or 13 digit number!')
+    );
   }
 
-  // Checks for books that need pages
+  // Checks for books that need pages.
   $needs_own_page_value = (bool) $form_state->getValue('field_needs_own_page')['value'];
+  // Determines if the moderation state is 'published'.
+  $is_published = ($form_state->getValue('moderation_state')[0]['value'] === 'published');
 
-  if ($needs_own_page_value === TRUE) {
+  // If the Needs Own Page field is checked and the node is published, verify
+  // the Book Excerpt and PDF Link fields are not empty.
+  if ($needs_own_page_value === TRUE && $is_published === TRUE) {
     if (empty($form_state->getValue('field_book_excerpt')[0]['value'])) {
-      $form_state->setErrorByName('field_book_excerpt',
-        t('Book excerpt is required'));
+      // Set an error if the Book Excerpt field is empty.
+      $form_state->setErrorByName(
+        'field_book_excerpt',
+        t('Book excerpt is required')
+      );
     }
     if (empty($form_state->getValue('field_pdf_link')[0]['uri'])) {
-      $form_state->setErrorByName('field_pdf_link',
-        t('PDF link is required'));
+      // Set an error if the PDF Link field is empty.
+      $form_state->setErrorByName(
+        'field_pdf_link',
+        t('PDF link is required')
+      );
     }
   }
 }


### PR DESCRIPTION
This change allows a draft to be saved without a value for the PDF Link
field. I also verified that I could submit the form without a value for
the ISBN field.

### JIRA Issue Link

* https://issues.jboss.org/browse/DEVELOPER-5378

### Verification Process

Go here:

Relative URL: `/node/add/books`

Do this:

* Fill out all of the required fields with some data
* Check the RHDP hosted book checkbox field
* Do **not** enter a value for the ISBN or PDF Link fields
* Leave the moderation state "Save as" value as Draft (the default)
* Save and submit the node edit form

#### You should see

* The form should submit successfully without errors and should redirect you to the newly create Book node

Example:

![developer-5378--successful](https://user-images.githubusercontent.com/7155034/46757942-6e1bdc80-cc80-11e8-8c8d-dc7194359393.png)

#### You should **not** see

![developer-5378--errors](https://user-images.githubusercontent.com/7155034/46757869-4167c500-cc80-11e8-9740-e7d2e66da71d.png)