### PR TITLE
DEVELOPER-5438: Eliminate Build Errors

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -119,8 +119,7 @@
         "enable-patching": true,
         "patches": {
           "drupal/core": {
-            "Fix entity reference view": "https://www.drupal.org/files/issues/2174633-174.patch",
-            "Fix help text not showing": "https://www.drupal.org/files/issues/2421001-124.patch"
+            "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch"
           },
           "drupal/inline_entity_form": {
             "Support entity reference revisions": "https://www.drupal.org/files/issues/support_entity_revision-2367235-92.patch"

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81d37bb4a0ef2ae8007073f39786d27e",
+    "content-hash": "88cc9702f2892dfff423d876478e6ac4",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -1900,7 +1900,7 @@
                     "merge-extra": false
                 },
                 "patches_applied": {
-                    "Fix entity reference view": "https://www.drupal.org/files/issues/2174633-174.patch",
+                    "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
                     "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2018-07-09/2815221-105.patch",

--- a/_docker/drupal/drupal-filesystem/db-migrations/20181011213825_remove_openapi_redoc_module.php
+++ b/_docker/drupal/drupal-filesystem/db-migrations/20181011213825_remove_openapi_redoc_module.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RemoveOpenapiRedocModule extends AbstractMigration
+{
+    /**
+     * Migrate up.
+     */
+    public function up()
+    {
+        $this->execute("DELETE FROM lightning_key_value WHERE collection='system.schema' AND name='openapi_redoc';");
+    }
+
+    /**
+     * Migrate down.
+     */
+    public function down()
+    {
+        $this->execute("INSERT INTO lightning_key_value (collection, name) VALUES ('system.schema', 'openapi_redoc');");
+    }
+}


### PR DESCRIPTION
This eliminates 2 distinct errors that arise currently during the build
process / the execution of setup_local_drupal.sh.

The first is a Drupal core patch that could not apply,
2421001-124.patch. This issue was resolved in Drupal 8.5.x, so this
patch is no longer necessary. I removed it from composer.json. I also
updated our other core patch to a newer version of the patch that had
more user testing reports within the issue queue.

The second error was a 'missing module in filesystem' error for the
openapi_redoc module. To resolve this issue, I created a Phinx DB
migration that deletes that entry from the key_value table. To ensure
that my SQL query would resolve this issue, I locally ran the query via
drush sql-query and re-executed setup_local_drupal.sh, and I did not
observe a warning or error.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5438

### Verification Process

To verify these changes, you would need to pull down this PR locally and run setup_local_drupal.sh.