### PR TITLE
[DEVELOPER-5422] Fuse Page Connector Images

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.connectors.field_connector_details_url
     - field.field.node.connectors.field_connector_id
+    - field.field.node.connectors.field_connector_image
     - field.field.node.connectors.field_connector_link_1
     - field.field.node.connectors.field_connector_link_1_text
     - field.field.node.connectors.field_connector_link_2
@@ -43,6 +44,20 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_connector_image:
+    type: entity_browser_entity_reference
+    weight: 51
+    settings:
+      entity_browser: media_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      selection_mode: selection_append
+      field_widget_display_settings:
+        view_mode: thumbnail
+      open: true
+    region: content
+    third_party_settings: {  }
   field_connector_link_1:
     weight: 9
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.connectors.field_connector_details_url
     - field.field.node.connectors.field_connector_id
+    - field.field.node.connectors.field_connector_image
     - field.field.node.connectors.field_connector_link_1
     - field.field.node.connectors.field_connector_link_1_text
     - field.field.node.connectors.field_connector_link_2
@@ -52,6 +53,15 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_connector_image:
+    type: entity_reference_entity_view
+    weight: 13
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
     region: content
   field_connector_link_1:
     weight: 9

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.connectors.field_connector_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.connectors.field_connector_image.yml
@@ -1,0 +1,28 @@
+uuid: 00603875-2ad0-4b06-a012-bb66dec8f298
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_connector_image
+    - media.type.image
+    - node.type.connectors
+id: node.connectors.field_connector_image
+field_name: field_connector_image
+entity_type: node
+bundle: connectors
+label: 'Connector Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_connector_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.node.field_connector_image.yml
@@ -1,0 +1,20 @@
+uuid: 8ba54fcc-1702-456d-b318-9c0a19f5d743
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_connector_image
+field_name: field_connector_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.connectors_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.connectors_rest_export.yml
@@ -17,7 +17,9 @@ dependencies:
     - field.storage.node.field_connector_target_product_3
     - node.type.connectors
   module:
+    - image
     - link
+    - media
     - node
     - options
     - rest
@@ -979,6 +981,71 @@ display:
           entity_type: node
           entity_field: created
           plugin_id: field
+        thumbnail__target_id:
+          id: thumbnail__target_id
+          table: media_field_data
+          field: thumbnail__target_id
+          relationship: field_connector_image
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image_url
+          settings:
+            image_style: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
       filters:
         status:
           value: '1'
@@ -1057,7 +1124,16 @@ display:
       header: {  }
       footer: {  }
       empty: {  }
-      relationships: {  }
+      relationships:
+        field_connector_image:
+          id: field_connector_image
+          table: node__field_connector_image
+          field: field_connector_image
+          relationship: none
+          group_type: group
+          admin_label: 'field_connector_image: Media'
+          required: false
+          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
     cache_metadata:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/connectors.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/connectors.js
@@ -20,10 +20,6 @@ app.connectors = {
         $('.overlay-content').empty();
     },
 
-    fallbackImage: function (el) {
-        el.src = "#{cdn( site.base_url + '/images/design/default_connector_200x150.png')}";
-    },
-
     hideCodeSnippetIfEmpty: function (snippet_elem) {
         var snippet_value = snippet_elem.find('.snippet-value');
         if (!snippet_value.val()) {
@@ -152,8 +148,10 @@ app.connectors = {
         for (var i = 0; i < hits.length; i++) {
             var props = hits[i]._source;
 
-            props.img_path_thumb = "https://static.jboss.org/connectors/" + props.id + "_" + thumbnailSize + ".png";
-            props.fallback_img = app.connectors.fallbackImage(this);
+            // Set the img_path_thumb to the DCP thumbnail endpoint, and set the
+            // fallback image to the thumbnail on static.jboss.org.
+            props.img_path_thumb = props.thumbnail__target_id;
+            props.fallback_img = "https://static.jboss.org/connectors/" + props.id + "_" + thumbnailSize + ".png";
 
             //If no 'long description', use the short one (before it is truncated)
             if (!('sys_content' in props)) {


### PR DESCRIPTION
This adds a Media (Image) field to the Connector content type to store a
thumbnail to be displayed on the Connectors page. The new field is added
to the Connectors REST Export View, which will be consumed by the DCP.
In turn, the front-end of our application will make an AJAX call to the
DCP and retrieve the relative URL to the image from the DCP endpoint and
serve that on the Connectors Fuse page. In the event that there is not
an image uploaded to a Connector, a fallback image will display from
static.jboss.org.

### JIRA Issue Link
* Link to the JIRA ticket(s) this pull request solves

### Verification Process
<!--
What process should a tester use to verify this pull request closes the JIRA ticket?

- Which page(s) should one visit?
- Which buttons to click?
- What is the expected outcome?
- etc.
-->
