### PR TITLE
[DEVELOPER-5461] Add Missing CTA Links to Assemblies

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_list.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - assembly.assembly_type.events_list
     - field.field.assembly.events_list.field_audience_selection
+    - field.field.assembly.events_list.field_cta_link
     - field.field.assembly.events_list.field_event
     - field.field.assembly.events_list.field_navigation_title
   module:
     - content_moderation
+    - link
 id: assembly.events_list.default
 targetEntityType: assembly
 bundle: events_list
@@ -19,6 +21,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
+    region: content
+  field_cta_link:
+    weight: 7
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   field_event:
     weight: 6
@@ -38,7 +48,7 @@ content:
     type: string_textfield
     region: content
   moderation_state:
-    weight: 7
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_products.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_products.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - assembly.assembly_type.featured_products
     - field.field.assembly.featured_products.field_audience_selection
+    - field.field.assembly.featured_products.field_cta_link
     - field.field.assembly.featured_products.field_navigation_title
     - field.field.assembly.featured_products.field_products
     - field.field.assembly.featured_products.field_title
   module:
     - content_moderation
+    - link
 id: assembly.featured_products.default
 targetEntityType: assembly
 bundle: featured_products
@@ -20,6 +22,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
+    region: content
+  field_cta_link:
+    weight: 8
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   field_navigation_title:
     weight: 6
@@ -47,7 +57,7 @@ content:
     type: string_textfield
     region: content
   moderation_state:
-    weight: 8
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.static_content_band.default.yml
@@ -6,11 +6,13 @@ dependencies:
     - assembly.assembly_type.static_content_band
     - field.field.assembly.static_content_band.field_audience_selection
     - field.field.assembly.static_content_band.field_content_list
+    - field.field.assembly.static_content_band.field_cta_link
     - field.field.assembly.static_content_band.field_navigation_title
     - field.field.assembly.static_content_band.field_title
   module:
     - entity_browser_entity_form
     - inline_entity_form
+    - link
 id: assembly.static_content_band.default
 targetEntityType: assembly
 bundle: static_content_band
@@ -40,6 +42,14 @@ content:
         entity_browser_id: _none
     type: inline_entity_form_complex
     region: content
+  field_cta_link:
+    weight: 6
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
   field_navigation_title:
     type: string_textfield
     weight: 4
@@ -66,7 +76,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 6
+    weight: 7
     region: content
     settings:
       display_label: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.events_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.events_list.default.yml
@@ -5,15 +5,37 @@ dependencies:
   config:
     - assembly.assembly_type.events_list
     - field.field.assembly.events_list.field_audience_selection
+    - field.field.assembly.events_list.field_cta_link
     - field.field.assembly.events_list.field_event
     - field.field.assembly.events_list.field_navigation_title
   module:
     - fences
+    - rhd_assemblies
 id: assembly.events_list.default
 targetEntityType: assembly
 bundle: events_list
 mode: default
 content:
+  field_cta_link:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: '80'
+      class: 'button medium-cta'
+      url_only: 0
+      url_plain: 0
+      rel: 0
+      target: 0
+    third_party_settings:
+      fences:
+        fences_field_tag: div
+        fences_field_classes: cta-link
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: link_class
+    region: content
   field_event:
     weight: 0
     label: hidden

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_products.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_products.default.yml
@@ -5,16 +5,38 @@ dependencies:
   config:
     - assembly.assembly_type.featured_products
     - field.field.assembly.featured_products.field_audience_selection
+    - field.field.assembly.featured_products.field_cta_link
     - field.field.assembly.featured_products.field_navigation_title
     - field.field.assembly.featured_products.field_products
     - field.field.assembly.featured_products.field_title
   module:
     - fences
+    - rhd_assemblies
 id: assembly.featured_products.default
 targetEntityType: assembly
 bundle: featured_products
 mode: default
 content:
+  field_cta_link:
+    weight: 2
+    label: hidden
+    settings:
+      trim_length: '80'
+      class: 'button medium-cta blue'
+      url_only: false
+      url_plain: false
+      rel: 0
+      target: 0
+    third_party_settings:
+      fences:
+        fences_field_tag: div
+        fences_field_classes: cta-link
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: link_class
+    region: content
   field_products:
     weight: 1
     label: hidden

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.static_content_band.default.yml
@@ -6,10 +6,12 @@ dependencies:
     - assembly.assembly_type.static_content_band
     - field.field.assembly.static_content_band.field_audience_selection
     - field.field.assembly.static_content_band.field_content_list
+    - field.field.assembly.static_content_band.field_cta_link
     - field.field.assembly.static_content_band.field_navigation_title
     - field.field.assembly.static_content_band.field_title
   module:
     - fences
+    - rhd_assemblies
 id: assembly.static_content_band.default
 targetEntityType: assembly
 bundle: static_content_band
@@ -23,6 +25,26 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
+    region: content
+  field_cta_link:
+    weight: 2
+    label: hidden
+    settings:
+      trim_length: '80'
+      class: 'button medium-cta blue'
+      url_only: false
+      url_plain: false
+      rel: 0
+      target: 0
+    third_party_settings:
+      fences:
+        fences_field_tag: div
+        fences_field_classes: cta-link
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: link_class
     region: content
   field_title:
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.events_list.field_cta_link.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.events_list.field_cta_link.yml
@@ -1,0 +1,23 @@
+uuid: f6817232-0726-4174-9331-acca6c569325
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.events_list
+    - field.storage.assembly.field_cta_link
+  module:
+    - link
+id: assembly.events_list.field_cta_link
+field_name: field_cta_link
+entity_type: assembly
+bundle: events_list
+label: 'CTA Link'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_products.field_cta_link.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_products.field_cta_link.yml
@@ -1,0 +1,23 @@
+uuid: 2bbd1c4f-e3e2-4a33-8849-38d78b40961b
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.featured_products
+    - field.storage.assembly.field_cta_link
+  module:
+    - link
+id: assembly.featured_products.field_cta_link
+field_name: field_cta_link
+entity_type: assembly
+bundle: featured_products
+label: 'CTA Link'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_cta_link.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.static_content_band.field_cta_link.yml
@@ -1,0 +1,23 @@
+uuid: d1f62c47-44f6-4f62-a4ea-b7b6fd5b153f
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.static_content_band
+    - field.storage.assembly.field_cta_link
+  module:
+    - link
+id: assembly.static_content_band.field_cta_link
+field_name: field_cta_link
+entity_type: assembly
+bundle: static_content_band
+label: 'CTA Link'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_event_list.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_event_list.scss
@@ -82,4 +82,15 @@
       border-bottom: none;
     }
   }
+
+  .cta-link {
+    margin-top: 2rem;
+    .button {
+      display: inline-block;
+      width: 100%;
+      @include tablet-portrait {
+        width: auto;
+      }
+    }
+  }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_products.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_products.scss
@@ -47,4 +47,24 @@
   @media screen and (max-width: 768px) {
     .grid { grid-template-columns: repeat(1, 300px); }
   }
+
+  .cta-link {
+    margin-top: 2rem;
+    text-align: center;
+    @include tablet-portrait {
+      grid-column-start: 1;
+      grid-column-end: 3;
+    }
+    @include desktop-small {
+      grid-column-start: 1;
+      grid-column-end: 4;
+    }
+    .button {
+      display: inline-block;
+      width: 100%;
+      @include tablet-portrait {
+        width: auto;
+      }
+    }
+  }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_learning_paths.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_learning_paths.scss
@@ -45,7 +45,7 @@
     display: grid;
     grid-gap: $gutter $gutter;
     grid-template-columns: 1fr 1fr;
-    @include tablet-landscape {
+    @include desktop-small {
       grid-template-columns: 1fr 1fr 1fr 1fr;
     }
   }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_static_content_band.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_static_content_band.scss
@@ -29,6 +29,13 @@
       }
     }
   }
+  .cta-link {
+    margin-top: 1rem;
+    text-align: center;
+    a {
+      display: inline-block;
+    }
+  }
 }
 
 .assembly-type-node_reference,


### PR DESCRIPTION
## JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5461

## Verification Process

1. Add/Edit each of the updated assemblies to see new CTA Link field
2. Update CTA Link field and view on front-end.

**Updated Assemblies:**
1. Curated Content (static_content_band)
2. Events List
3. Featured Products

## Screens
### Admin
![screen shot 2018-10-17 at 12 28 14 pm](https://user-images.githubusercontent.com/41014351/47108121-31b02980-d208-11e8-89ed-4de215d26eb7.png)

### Curated Content
![screen shot 2018-10-17 at 12 13 03 pm](https://user-images.githubusercontent.com/41014351/47108027-062d3f00-d208-11e8-892c-2e2f186a47a1.png)

### Events List
![screen shot 2018-10-17 at 12 12 56 pm](https://user-images.githubusercontent.com/41014351/47108030-088f9900-d208-11e8-8b15-b7af6e09e282.png)

### Featured Products
![screen shot 2018-10-17 at 12 12 45 pm](https://user-images.githubusercontent.com/41014351/47108039-0c232000-d208-11e8-9a48-7b657f1e8adc.png)
