### PR TITLE
[DEVELOPER-5462] Add alt tags to images in assemblies

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-teaser.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-teaser.html.twig
@@ -10,7 +10,7 @@
     </div>
     {% if media and media.media_type == 'image' %}
         <div class="rhd-list-entry--image">
-            <img src="{{ media.source_url }}"/>
+            <img src="{{ media.source_url }}" alt="{{ post.title.rendered|replace({'"':''}) }}" />
         </div>
     {% endif %}
 </article>

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
@@ -4,7 +4,7 @@
       <div class="tile-image {{ media.scale_orientation }}">
         <div class="image-table">
           <div class="image-cell">
-            <img src="{{ media.source_url }}"/>
+            <img src="{{ media.source_url }}" alt="{{ post.title.rendered|replace({'"':''}) }}" />
           </div>
         </div>
       </div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -291,6 +291,11 @@ function rhdp_preprocess_node(&$variables) {
     $variables['product_pages'] = $product_pages_url;
   }
 
+  if ($node->getType() == 'video_resource' && $variables['view_mode'] == 'tile') {
+    $node_title = $node->label();
+    $variables['node_title'] = str_replace('"', '', $node_title);
+  }
+
   if ($node->getType() == 'product' && $variables['view_mode'] == 'featured_tile') {
     $product_code = $node->get('field_product_machine_name')->getValue();
     if (count($product_code)) {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -295,6 +295,11 @@ function rhdp_preprocess_node(&$variables) {
     $node_title = $node->label();
     $variables['node_title'] = str_replace('"', '', $node_title);
   }
+  
+  if ($node->getType() == 'events' && $variables['view_mode'] == 'teaser') {
+    $node_title = $node->label();
+    $variables['node_title'] = str_replace('"', '', $node_title);
+  }
 
   if ($node->getType() == 'product' && $variables['view_mode'] == 'featured_tile') {
     $product_code = $node->get('field_product_machine_name')->getValue();

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/events/node--events--teaser.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/events/node--events--teaser.html.twig
@@ -1,5 +1,5 @@
 <li class="event-item">
-    <img class="event-thumbnail" src="{{ event_image_url }}">
+    <img class="event-thumbnail" src="{{ event_image_url }}" alt="{{ node_title }}">
     <div class="event-info">
         <a class="event-title" href="{{ event_url }}">{{ event_title }}</a>
         <p class="event-date">{{ content.field_start_date}}</p>
@@ -9,4 +9,3 @@
     {{ content.field_presenter_s_ }}
 
 </li>
-

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--tile.html.twig
@@ -17,7 +17,7 @@
           <img{{create_attribute({
               'src': content.field_video_thumbnail_url['#items'][0].value
             })
-          }} />
+          }} alt="{{ node_title }}"/>
           <div class="play-button">►</div>
         </div>
       </div>


### PR DESCRIPTION
## JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5462

## Verification Process
- Linked images in drupal assemblies have auto generated alt text

NOTE: After auditing assemblies I found the following three were not including alts tags in their images.

## Screens
### Events List
![screen shot 2018-10-17 at 2 55 12 pm](https://user-images.githubusercontent.com/41014351/47115935-65e21500-d21d-11e8-905d-9cade0361535.png)

### Dynamic Content List
![screen shot 2018-10-17 at 2 50 35 pm](https://user-images.githubusercontent.com/41014351/47115939-67abd880-d21d-11e8-9fa2-7566ae49f0ac.png)

### Dynamic Content
![screen shot 2018-10-17 at 2 40 07 pm](https://user-images.githubusercontent.com/41014351/47115942-6a0e3280-d21d-11e8-8ef4-f952428838fb.png)
