### PR TITLE
DEVELOPER-5460: Remove rel nofollow

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
@@ -22,7 +22,7 @@ filters:
     settings:
       allowed_html: '<a href hreflang class target data-* aria-* ng-*> <em class> <strong class> <cite class> <blockquote cite class> <code class data-*> <ul id type class data-* aria-*> <ol start type class id data-* aria-*> <li class data-* aria-*> <dl class data-* aria-*> <dt class data-* aria-*> <dd class data-* aria-*> <h2 id class data-* aria-*> <h3 id class data-* aria-*> <h4 id class data-* aria-*> <h5 id class data-* aria-*> <h6 id class aria-* data-*> <p class data-* aria-*> <br class> <span class data-* aria-*> <img class src alt height width data-* aria-*> <div class id data-* aria-* ng-*> <h1 class data-* aria-* id> <pre class data-* aria-*> <u class> <table class> <caption class> <tbody class> <thead class> <tfoot class> <th class> <td class> <tr class> <i class data-* aria-*> <select id class value label disabled data-* aria-* name size ng-*> <option id class aria-* data-* dir label lang name selected title value> <hr class> <drupal-entity data-*>'
       filter_html_help: true
-      filter_html_nofollow: true
+      filter_html_nofollow: false
   filter_align:
     id: filter_align
     provider: filter


### PR DESCRIPTION
This removes an automatically added rel="nofollow" attribute to every
<a> tag created within a WYSIWYG field using the Red Hat Approved text
format.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5460

### Verification Process

Go here: `/articles/build-run-colossal-cave-adventure-game`

Scroll down to the body of the article and find the link text Colossal Cave Adventure in the 3rd sentence of the article. Right click and Inspect Element on that link.

You should see this:

<img width="848" alt="developer-5460--no-rel-nofollow" src="https://user-images.githubusercontent.com/7155034/47119576-426c9980-d220-11e8-9b5b-94aa7ee03440.png">

There is no longer a rel="nofollow" attribute automatically added to every <a> tag in the body field of Articles.