### PR TITLE
[DEVELOPER-5478] Updated yum gpg URL to use HTTP rather than HTTPS

### DIFF
--- a/_docker/awestruct/Dockerfile
+++ b/_docker/awestruct/Dockerfile
@@ -9,12 +9,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-COPY mariadb/MariaDB.repo /etc/yum.repos.d/MariaDB.repo
-
-RUN yum install -y  \
-  pngquant \
-  MariaDB-client \
-  httrack
+RUN yum install -y pngquant
 
 RUN wget http://prdownloads.sourceforge.net/optipng/optipng-0.7.5.tar.gz?download && \
   mv optipng* optipng.tar.gz && \

--- a/_docker/awestruct/mariadb/MariaDB.repo
+++ b/_docker/awestruct/mariadb/MariaDB.repo
@@ -1,5 +1,0 @@
-[mariadb]
-name = MariaDB
-baseurl = http://yum.mariadb.org/10.1/centos6-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1

--- a/_docker/backup/Dockerfile
+++ b/_docker/backup/Dockerfile
@@ -3,11 +3,19 @@ FROM developer.redhat.com/ruby:2.4.0
 ARG http_proxy
 ARG https_proxy
 
-COPY mariadb/MariaDB.repo /etc/yum.repos.d/MariaDB.repo
+RUN { \
+       echo '[mariadb]'; \
+       echo 'name = MariaDB'; \
+       echo 'baseurl = http://yum.mariadb.org/10.1/centos6-amd64'; \
+       echo 'gpgkey=http://yum.mariadb.org/RPM-GPG-KEY-MariaDB'; \
+       echo 'gpgcheck=1'; \
+    } > /etc/yum.repos.d/MariaDB.repo
 
 RUN yum install -y \
     MariaDB-client \
-    && yum clean all
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
 RUN groupadd -g 1000 jenkins_developer
 RUN useradd -g jenkins_developer -m -s /bin/bash -u 1000 jenkins_developer
 USER jenkins_developer

--- a/_docker/backup/mariadb/MariaDB.repo
+++ b/_docker/backup/mariadb/MariaDB.repo
@@ -1,5 +1,0 @@
-[mariadb]
-name = MariaDB
-baseurl = http://yum.mariadb.org/10.1/centos6-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1


### PR DESCRIPTION
The yum.mariadb.org SSL certificate has expired meaning that Docker image builds fail. This update addresses the issue by importing the GPG key from the HTTP url instead.

This PR targets `stage` so that we can test things there before going into prod.

### JIRA Issue Link
* [DEVELOPER-5478](https://issues.jboss.org/browse/DEVELOPER-5478)

### Verification Process
- Build should go green