### PR TITLE
This adds a boolean to check if the thumbnail__target_id field, fetch…

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/connectors.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/connectors.js
@@ -150,7 +150,7 @@ app.connectors = {
 
             // Set the img_path_thumb to the DCP thumbnail endpoint, and set the
             // fallback image to the thumbnail on static.jboss.org.
-            props.img_path_thumb = props.thumbnail__target_id;
+            props.img_path_thumb = (typeof props.thumbnail__target_id !== 'undefined' && props.thumbnail__target_id !== '') ? props.thumbnail__target_id : "https://static.jboss.org/connectors/" + props.id + "_" + thumbnailSize + ".png";
             props.fallback_img = "https://static.jboss.org/connectors/" + props.id + "_" + thumbnailSize + ".png";
 
             //If no 'long description', use the short one (before it is truncated)


### PR DESCRIPTION
…ed from the DCP endpoint, is undefined or empty. If it is, it serves a fallback image from static.jboss.org.

Tiffany pointed out in the issue that this merged PR: https://github.com/redhat-developer/developers.redhat.com/pull/2679 was not solving the issue as I anticipated. I misunderstood how the front-end part of this component works.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5422

### Verification Process

* Upload an image to the newly created Connector Image field on any Connector node.
* DCP should pick this up and serve it back to us in the endpoint we are retrieving data from.
* On the Connectors page (https://developers.redhat.com/products/fuse/connectors/), you should see the image you uploaded display for the Connector you just edited.
* If an image has not been uploaded to this newly created Connector Image field for any given Connector, then a fallback image should be displayed from static.jboss.org. However, there are maybe 15-20 connectors that also do not currently have fallback images.

Screenshot from my local:

![127 0 0 1_8888_products_fuse_connectors_](https://user-images.githubusercontent.com/7155034/47318193-43c30b00-d600-11e8-95eb-a17b291dd3a9.png)
