### PR TITLE
DEVELOPER-5493: Product pages unwanted border

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_get-started.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_get-started.scss
@@ -289,7 +289,9 @@ ul.toc {
       border-bottom: 0;
       margin: 0;
       &.active {
-        border-color: #BDBDBD;
+        border-left: 1px solid #BDBDBD;
+        border-top: 1px solid #BDBDBD;
+        border-right: 1px solid #BDBDBD;
         border-bottom: 1px solid #fff;
         position: relative;
         bottom: -1px;


### PR DESCRIPTION
This makes a very small change to remove some styles that were
unintentionally resulting in a border-bottom being applied to the
active tab in the Hello World! section of product pages.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5493

### Verification Process

* Go here: `/products/rhamt/hello-world`
* Click on Web Console to make that the active tab within the Hello World! section of this product page
* Observe that there is no gray bottom border on the active tab

### Before PR

<img width="632" alt="developer-5493--before" src="https://user-images.githubusercontent.com/7155034/47926993-57336900-de7f-11e8-83a9-00281b11bc4c.png">

### After PR

<img width="859" alt="developer-5493--after" src="https://user-images.githubusercontent.com/7155034/47927004-5bf81d00-de7f-11e8-9c8e-e575f0b4d526.png">
