### PR TITLE
Removes the typehinting from www_ddo function

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -439,7 +439,7 @@ function rhdp_preprocess_node(array &$variables) {
 /**
  * Creates a digital data object (DDO) for Adobe Dynamic Tag Management (DTM).
  */
-function redhat_www_ddo_default(Node $node) {
+function redhat_www_ddo_default($node) {
   $request = \Drupal::request();
   $siteerror = \Drupal::configFactory()->get('system.site')->get('page.404');
   $errorType = "";


### PR DESCRIPTION
This removes some typehinting that I added earlier to the www_ddo helper
function in rhdp.theme. Apparently, sometimes NULL can also be passed
into this function. This seems inadvertent, but it will throw an error.

### JIRA Issue Link
* n/a

### Verification Process
After visiting the homepage, you should not observe a typehint error for the www_ddo helper function in the Drupal watchdog logs `drush ws` or `/admin/reports/dblog`.