### PR TITLE
Published At Config Not Captured

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -327,6 +327,12 @@ content:
     weight: 14
     third_party_settings: {  }
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
@@ -169,6 +169,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 3

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
@@ -206,6 +206,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
@@ -333,6 +333,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -277,6 +277,12 @@ content:
     weight: 11
     third_party_settings: {  }
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
@@ -228,6 +228,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
@@ -234,6 +234,12 @@ content:
     third_party_settings: {  }
     type: moderation_state_default
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
@@ -269,6 +269,12 @@ content:
     third_party_settings: {  }
     type: moderation_state_default
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.landing_page_single_offer.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.landing_page_single_offer.default.yml
@@ -183,6 +183,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 3

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
@@ -262,6 +262,12 @@ content:
     weight: 17
     region: content
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
@@ -284,6 +284,12 @@ content:
     third_party_settings: {  }
     type: moderation_state_default
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
@@ -208,6 +208,12 @@ content:
     weight: 9
     region: content
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
@@ -225,6 +225,12 @@ content:
     weight: 11
     region: content
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -180,6 +180,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -322,6 +322,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   title:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.image.media_library.yml
@@ -15,6 +15,16 @@ targetEntityType: media
 bundle: image
 mode: media_library
 content:
+  created:
+    label: hidden
+    type: timestamp
+    weight: 0
+    region: content
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
   thumbnail:
     type: image
     region: content
@@ -23,6 +33,13 @@ content:
       image_style: thumbnail
       image_link: ''
     weight: 0
+    third_party_settings: {  }
+  uid:
+    label: hidden
+    type: author
+    weight: 0
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_media_in_library: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.video.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.media.video.media_library.yml
@@ -15,6 +15,16 @@ targetEntityType: media
 bundle: video
 mode: media_library
 content:
+  created:
+    label: hidden
+    type: timestamp
+    weight: 0
+    region: content
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
   thumbnail:
     type: image
     region: content
@@ -23,6 +33,13 @@ content:
       image_style: thumbnail
       image_link: ''
     weight: 0
+    third_party_settings: {  }
+  uid:
+    label: hidden
+    type: author
+    weight: 0
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_media_in_library: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
@@ -278,3 +278,4 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.short_teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.short_teaser.yml
@@ -84,3 +84,4 @@ hidden:
   field_tax_stage: true
   field_topics: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -119,3 +119,4 @@ hidden:
   field_tax_stage: true
   field_topics: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
@@ -53,4 +53,5 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.default.yml
@@ -193,3 +193,4 @@ hidden:
   field_twitter: true
   field_youtube: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
@@ -310,4 +310,5 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.teaser.yml
@@ -123,4 +123,5 @@ hidden:
   field_topics: true
   field_web_reader_url: true
   links: true
+  published_at: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
@@ -188,3 +188,4 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.teaser.yml
@@ -104,3 +104,4 @@ hidden:
   field_tax_stage: true
   field_topics: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.default.yml
@@ -148,3 +148,4 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
@@ -176,3 +176,4 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.default.yml
@@ -242,3 +242,4 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.landing_page_single_offer.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.landing_page_single_offer.default.yml
@@ -75,3 +75,4 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.default.yml
@@ -182,4 +182,5 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.teaser.yml
@@ -106,3 +106,4 @@ hidden:
   field_tax_stage: true
   field_topics: true
   field_value_proposition: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
@@ -162,3 +162,4 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.default.yml
@@ -127,4 +127,5 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.default.yml
@@ -151,4 +151,5 @@ hidden:
   field_tax_promotion: true
   field_tax_region: true
   field_tax_stage: true
+  published_at: true
   scheduled_update: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
@@ -67,3 +67,4 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.video_resource.default.yml
@@ -263,4 +263,5 @@ hidden:
   field_tax_region: true
   field_tax_stage: true
   links: true
+  published_at: true
   workbench_moderation_control: true


### PR DESCRIPTION
Some configuration, on many different entities, has been added or
modified to support the new Published At module and functionality. This
config has not yet been captured in our config .yml files. This is a
result of executing `drush config-export` against the current state of
the upstream/master branch.

I believe that everyone will have issues with config importing and
exporting until this is merged into master.

### JIRA Issue Link
* n/a

### Verification Process

##### Hanging config changes locally
Do this:

* Check out `master` locally and make sure it is up-to-date with the latest state of `upstream/master`

Go here:

http://127.0.0.1:8888/admin/config/development/configuration

You should see this:

![127 0 0 1_8888_admin_config_development_configuration](https://user-images.githubusercontent.com/7155034/48151848-313f0780-e277-11e8-8aa8-53b4ad0b4678.png)

##### No hanging config in PR environment

Go here:

http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37712/admin/config/development/configuration

You should see this:

<img width="1252" alt="pr2712-no-config-changes" src="https://user-images.githubusercontent.com/7155034/48151823-1d93a100-e277-11e8-9efa-d2a93815914c.png">
