### PR TITLE
Fix Keycloak Rewrite SRC Removal

### DIFF
--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -231,6 +231,8 @@ class ExportHtmlPostProcessor
 
   end
 
+
+
   #
   # Re-writes the action attribute of any form on the page where the action is pointing to the host from
   # which we have exported the HTML content
@@ -249,6 +251,19 @@ class ExportHtmlPostProcessor
 
   end
 
+  #
+  # The src of keycloak is being rewritten somewhere, not really sure where or how, this fixes it
+  #
+  def rewrite_keycloak_src(html_doc, html_file_name)
+    src_to_modify = html_doc.css('script[src*=keycloak]')
+    modified = false
+    src_to_modify.each do |src|
+      @log.info("\tModifying keycloak link #{src_to_modify.attr('src')} to '/auth/js/keycloak.js'")
+      src.attributes['src'].value = '/auth/js/keycloak.js'
+      modified = true
+    end
+    modified
+  end
 
   private :final_base_url_location, :locate_index_link_href,
           :rewrite_links_for_trailing_slash_url_structure,

--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -186,8 +186,9 @@ class ExportHtmlPostProcessor
 
       hide_drupal = remove_drupal_host_identifying_markup?(drupal_host, html_doc)
       rewrite_forms = rewrite_form_target_urls?(drupal_host, html_doc, html_file)
+      rewrite_keycloak_src = rewrite_keycloak_src(html_doc, html_file)
 
-      if hide_drupal || rewrite_forms
+      if hide_drupal || rewrite_forms || rewrite_keycloak_src
         @log.info("DOM in file '#{html_file}' has been modified, writing new file to disk.")
         File.open(html_file, 'w') do |file|
           file.write(html_doc.to_html)
@@ -269,7 +270,7 @@ class ExportHtmlPostProcessor
           :rewrite_links_for_trailing_slash_url_structure,
           :rewrite_form_target_urls?, :relocate_index_html,
           :remove_drupal_host_identifying_markup?,
-          :post_process_html_dom, :fetch_additional_static_resources
+          :post_process_html_dom, :rewrite_keycloak_src, :fetch_additional_static_resources
 
 end
 

--- a/_docker/lib/export/export_html_post_processor.rb
+++ b/_docker/lib/export/export_html_post_processor.rb
@@ -232,8 +232,6 @@ class ExportHtmlPostProcessor
 
   end
 
-
-
   #
   # Re-writes the action attribute of any form on the page where the action is pointing to the host from
   # which we have exported the HTML content


### PR DESCRIPTION
The rewrite_keycloak_src() function was removed in PR 2709. The Keycloak
Src is modified/broken at some point, and this method fixes it, so I
will add it back.

### JIRA Issue Link
* DEVELOPER-5453

### Verification Process

Keycloak works again on Prod.