### PR TITLE
version bump for dcp-checker

### DIFF
--- a/_tests/blc/dcp/Gemfile.lock
+++ b/_tests/blc/dcp/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: http://github.com/redhat-developer/dcp-checker
-  revision: 354577ff1b4e6382f031e8b9a7f81c143714c6c8
+  revision: 6fde4ee9c9ec78be6b6f6b18c3af8a6d8e018f91
   specs:
     dcp-checker (0.1.0)
       colorize
@@ -19,7 +19,7 @@ GEM
       ffi (>= 1.3.0)
     ffi (1.9.18)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.3)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     rounding (1.0.1)
@@ -28,7 +28,7 @@ GEM
       tilt (>= 1.3.3, < 2.1)
     temple (0.8.0)
     tilt (2.0.8)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
 
 PLATFORMS


### PR DESCRIPTION
### JIRA Issue Link
* No issue, just a version bump to dcp-checker, now ignoring `jbossdeveloper_archetype` and `jbossdeveloper_bom`. 

### Verification Process
* Nothing to review.