### PR TITLE
Remove Topics Page background style

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_topic-page.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_topic-page.scss
@@ -1,5 +1,0 @@
-.page-node-type-topic-page {
-  .rhd-masthead, .layout-container {
-    background-color: #F9F9F9;
-  }
-}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -6,7 +6,6 @@
 @import "container";
 @import "typography/typography";
 @import "patterns/patterns";
-@import "topic-page";
 @import "assembly/assembly";
 @import "foundation/foundation";
 @import "navigation";


### PR DESCRIPTION
This removes a background style that was being applied to the masthead
and layout containers on Topic Pages. @tiffanynolan  requested we remove
the style.

@tiffanynolan Please approve this change when the PR environment is available

### JIRA Issue Link
* n/a

### Verification Process

Go here: `/topics/linux`

You should not see this white background around the `div.layout-container` element

<img width="1137" alt="layoutcontainerbackgroundtopicspage" src="https://user-images.githubusercontent.com/7155034/48731499-05fed580-ebf2-11e8-8c0a-fb9156cbfae7.png">
