### PR TITLE
[RHDENG-2643] Removed redirects for DCP integration

### DIFF
--- a/_docker/drupal/apache/drupal.conf
+++ b/_docker/drupal/apache/drupal.conf
@@ -2,35 +2,6 @@
 <VirtualHost *:80>
     DocumentRoot "/var/www/drupal/web"
 
-    RewriteEngine on
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/books$ /drupal/books?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/events$ /drupal/events?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/cheat-sheets$ /drupal/cheat-sheets?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/connectors$ /drupal/connectors?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/products$ /drupal/products?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/taxonomy/tags$ /drupal/taxonomy/tags?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/videos$ /drupal/videos?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/videos/vimeo$ /drupal/videos/vimeo?_format=json [L,R]
-
-    RewriteCond %{QUERY_STRING} ^$
-    RewriteRule ^/drupal/videos/youtube$ /drupal/videos/youtube?_format=json [L,R]
-
     <Directory "/var/www/drupal/web">
         Options Indexes FollowSymLinks
         AllowOverride All


### PR DESCRIPTION
This PR remove the redirects within the Drupal VirtualHost configuration that were added for DCP integration. These are now implemented directly at the DCP itself.

### JIRA Issue Link
* https://issues.jboss.org/browse/RHDENG-2643

### Verification Process

* The build should be green