### PR TITLE
[DEVELOPER-5550] Consistent DB names in Dev and PR environments

### DIFF
--- a/_docker/environments/drupal-dev-local-dcp/docker-compose.yml
+++ b/_docker/environments/drupal-dev-local-dcp/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       - MYSQL_USER=drupal
       - MYSQL_PASSWORD=drupal
-      - MYSQL_DATABASE=drupal
+      - MYSQL_DATABASE=rhd_mysql
       - MYSQL_ROOT_PASSWORD=superdupersecret
     expose:
       - "3306"

--- a/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
+++ b/_docker/environments/drupal-dev-local-dcp/rhd.settings.yml
@@ -19,4 +19,4 @@ database:
   port: '3306'
   username: 'drupal'
   password: 'drupal'
-  name: 'drupal'
+  name: 'rhd_mysql'

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - MYSQL_USER=drupal
       - MYSQL_PASSWORD=drupal
-      - MYSQL_DATABASE=drupal
+      - MYSQL_DATABASE=rhd_mysql
       - MYSQL_ROOT_PASSWORD=superdupersecret
     expose:
       - "3306"

--- a/_docker/environments/drupal-dev/rhd.settings.php
+++ b/_docker/environments/drupal-dev/rhd.settings.php
@@ -19,7 +19,7 @@ if (file_exists(__DIR__ . '/rhd.settings.yml')) {
 }
 
 $databases['default']['default'] = array (
-  'database' => 'drupal',
+  'database' => 'rhd_mysql',
   'username' => 'drupal',
   'password' => 'drupal',
   'prefix' => 'lightning_',

--- a/_docker/environments/drupal-dev/rhd.settings.yml
+++ b/_docker/environments/drupal-dev/rhd.settings.yml
@@ -24,7 +24,7 @@ database:
   port: '3306'
   username: 'drupal'
   password: 'drupal'
-  name: 'drupal'
+  name: 'rhd_mysql'
 dtm_code: https://www.redhat.com/dtm-staging.js
 sentry_track: false
 sentry_script: 'https://cdn.ravenjs.com/3.24.0/raven.min.js'

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - MYSQL_USER=drupal
       - MYSQL_PASSWORD=drupal
-      - MYSQL_DATABASE=drupal
+      - MYSQL_DATABASE=rhd_mysql
       - MYSQL_ROOT_PASSWORD=superdupersecret
     volumes:
       - ./mariadb/my.cnf:/etc/mysql/my.cnf

--- a/_docker/environments/drupal-pull-request/rhd.settings.php
+++ b/_docker/environments/drupal-pull-request/rhd.settings.php
@@ -12,7 +12,7 @@ $settings['install_profile'] = 'standard';
 $config_directories['sync'] = 'sites/default/files/config_BbPlfGDu86LJqlRwhA9RbCf38VZMDijNF-owvfhuzVL73hk7BtWwy3kfIlqKLXeiSgTA-MHeVw/sync';
 
 $databases['default']['default'] = array (
-  'database' => 'drupal',
+  'database' => 'rhd_mysql',
   'username' => 'drupal',
   'password' => 'drupal',
   'prefix' => 'lightning_',

--- a/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
+++ b/_docker/environments/drupal-pull-request/rhd.settings.yml.erb
@@ -18,7 +18,7 @@ database:
   port: '3306'
   username: 'drupal'
   password: 'drupal'
-  name: 'drupal'
+  name: 'rhd_mysql'
 rhd_base_url: "rhdp-jenkins-slave.lab4.eng.bos.redhat.com:<%= ENV['DRUPAL_HOST_PORT'] %>"
 rhd_final_base_url: "developers-pr.stage.redhat.com/pr/<%= ENV['ghprbPullId'] %>/export"
 dtm_code: "https://www.redhat.com/dtm-staging.js"

--- a/setup_local_drupal.sh
+++ b/setup_local_drupal.sh
@@ -21,7 +21,7 @@ php <<'DBCHECK'
 $conn = NULL;
 while ($conn === NULL) {
     try {
-        $conn = new PDO('mysql:host=docker;dbname=drupal', 'drupal', 'drupal');
+        $conn = new PDO('mysql:host=docker;dbname=rhd_mysql', 'drupal', 'drupal');
         $conn->query('SELECT 1;');
     } catch (PDOException $exception) {
         sleep(5);


### PR DESCRIPTION
The outage this morning was caused by a DB migration accidentally targeting the wrong DB name. This worked in `dev` and `pr` environments because the database was named correctly for the migration. However once it got to `prod` the migration failed because the DB there has a different name.

This PR ensures that all environments use a consistent DB name so that any migrations not targeting the correct database should fail in PR environment

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5550

### Verification Process

* This build should go completely green
* Access the Drupal interface and see that it's connected to the `rhd_mysql` database