### PR TITLE
[DEVELOPER-5502] Updates to dynamic content list to support product page use case: New…

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.dynamic_content_list.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.dynamic_content_list.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: dynamic_content_list
 label: 'Dynamic Content List'
 description: 'A dynamically generated list of content from Wordpress and Drupal, along with Disqus comments and additional links.'
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nbig-heading|Big Heading|Show a large heading for this assembly"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.date_format.date_only.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.date_format.date_only.yml
@@ -1,0 +1,8 @@
+uuid: 7a5ea6d4-e3a2-4bcc-9431-c2a0e95364ce
+langcode: en
+status: true
+dependencies: {  }
+id: date_only
+label: 'Date only'
+locked: false
+pattern: m/d/Y

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -22,6 +22,16 @@ dependencies:
     - field.field.node.article.field_related_articles
     - field.field.node.article.field_short_description
     - field.field.node.article.field_tags
+    - field.field.node.article.field_tax_audience_segment
+    - field.field.node.article.field_tax_business_unit
+    - field.field.node.article.field_tax_campaign
+    - field.field.node.article.field_tax_lifecycle
+    - field.field.node.article.field_tax_product
+    - field.field.node.article.field_tax_product_line
+    - field.field.node.article.field_tax_project
+    - field.field.node.article.field_tax_promotion
+    - field.field.node.article.field_tax_region
+    - field.field.node.article.field_tax_stage
     - field.field.node.article.field_topics
     - image.style.large
     - node.type.article
@@ -42,6 +52,22 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_author_evangelist:
+    type: entity_reference_entity_view
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      view_mode: tile
+      link: false
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
   field_image:
     type: image
     weight: 1
@@ -95,7 +121,6 @@ hidden:
   body: true
   field_article_highlights: true
   field_article_type: true
-  field_author_evangelist: true
   field_author_name: true
   field_card_image: true
   field_content: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_list.field_drupal_term_filter.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.dynamic_content_list.field_drupal_term_filter.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - assembly.assembly_type.dynamic_content_list
     - field.storage.assembly.field_drupal_term_filter
+    - taxonomy.vocabulary.product
+    - taxonomy.vocabulary.tags
     - taxonomy.vocabulary.topics
 id: assembly.dynamic_content_list.field_drupal_term_filter
 field_name: field_drupal_term_filter
@@ -20,10 +22,12 @@ settings:
   handler: 'default:taxonomy_term'
   handler_settings:
     target_bundles:
+      product: product
+      tags: tags
       topics: topics
     sort:
       field: name
       direction: asc
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: product
 field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
@@ -125,21 +125,24 @@ class DynamicContentFeedBuild extends AssemblyBuildBase implements AssemblyBuild
     }
 
     $valid_node_types = [
-      'video_resource'
+      'video_resource',
+      'article',
     ];
 
-    $query = \Drupal::database()->select('node__field_topics', 't');
-    $query->fields('t', ['entity_id']);
-    $query->condition('t.field_topics_target_id', $terms, 'in');
-    $query->leftJoin('node', 'n', 'n.nid = t.entity_id');
+    $query = \Drupal::database()->select('taxonomy_index', 't');
+    $query->fields('t', ['nid']);
+    $query->condition('t.tid', $terms, 'in');
+    $query->leftJoin('node', 'n', 'n.nid = t.nid');
     $query->condition('n.type', $valid_node_types, 'in');
+    $query->join('node_field_data', 'nfd', 'n.nid = nfd.nid');
+    $query->condition('nfd.status', 1);
     $query->range(0, $count);
-    $query->orderBy('t.entity_id', 'desc');
+    $query->orderBy('nfd.created', 'desc');
     $results = $query->execute();
 
     $nodes = [];
     foreach ($results as $result) {
-      $node_id = $result->entity_id;
+      $node_id = $result->nid;
       $nodes[$node_id] = Node::load($node_id);
     }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_dynamic_content_list.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_dynamic_content_list.scss
@@ -18,16 +18,14 @@
     text-align: center;
     margin-top: 0;
     margin-bottom: 35px;
-    font-weight: bold;
-    font-size: 21px;
+    font-weight: 500;
   }
-
-  .container {
-    @include desktop-large {
-      max-width: 1002px;
+  &.big-heading .header {
+    font-size: 18px;
+    @include tablet-portrait {
+      font-size: 38px;
     }
   }
-
   .grid {
     display: grid;
     grid-gap: $gutter $gutter;
@@ -48,9 +46,7 @@
     list-style-type: none;
     &>li {
       margin: 0;
-      @include tablet-portrait {
-        border-bottom: 1px dashed #242424;
-      }
+      border-bottom: 1px dashed #CCC;
       &:last-child {
         border-bottom: none;
       }
@@ -58,15 +54,8 @@
     padding: 0;
     margin: 0;
     display: grid;
-    grid-gap: $gutter $gutter;
-    grid-template-columns: 1fr 1fr;
-
-    @include tablet-portrait {
-      grid-template-columns: 1fr;
-      grid-gap: 0;
-      margin-top: -30px; // teaser top margin
-    }
-
+    grid-gap: 0;
+    grid-template-columns: 1fr;
   }
 
   .disqus {
@@ -155,11 +144,22 @@
     grid-row-start: -1;
   }
 
+  p {
+    margin: 0 0 1em 0;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
   @include tablet-portrait {
     grid-template-rows: unset;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 35% auto;
+    align-items: start;
     max-width: 100%;
     margin: 1.75rem 0;
+    .text-content {
+      grid-row: 1;
+      grid-column: 2;
+    }
   }
   .rhd-play-button {
     padding: .5rem 1rem;
@@ -176,6 +176,24 @@
       left: -0.15rem;
     }
   }
+
+  .author.short-teaser {
+    text-align: left;
+    margin-top: 10px;
+    .field--name-field-headshot {
+      display: inline-block;
+      vertical-align: middle;
+      img {
+        width: 52px;
+        display: block;
+      }
+    }
+    .author-name {
+      background: transparent;
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
 }
 
 .rhd-list-entry--comment-link {
@@ -189,58 +207,34 @@
 }
 
 .rhd-list-entry--title {
-  font-size: 14px;
-  line-height: 1.3;
-  margin-bottom: 8px;
+  font-size: 18px;
+  margin-bottom: 10px;
+  margin-top: 0;
   font-weight: bold;
   & > a {
-    color: #000;
     text-decoration: none;
-  }
-
-  @include tablet-portrait {
-    display: block;
-    font-size: 26px;
-    margin-top: 0;
   }
 }
 
 .rhd-list-entry--summary {
-  display: none;
   font-size: 14px;
   color: #424242;
-
-  @include tablet-portrait {
-    display: block;
-  }
 }
 
 .rhd-list-entry--date {
   display: block;
-  color: #333;
+  color: #808080;
   font-size: 14px;
-  font-weight: 700;
-  margin-bottom: 6px;
+  margin: 10px 0;
 }
 
 .rhd-list-entry--image {
   position: relative;
-  justify-self: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
+  margin-bottom: 10px;
   @include tablet-portrait {
-    height: unset;
-    display: inherit;
-  }
-
-  &>img {
-    max-height: 90px;
-
-    @include tablet-portrait {
-      max-height: unset;
-      max-width: 180px;
-    }
+    grid-column: 1;
+    grid-row: 1;
+    margin-bottom: 0;
   }
 }
+

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--teaser.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--teaser.html.twig
@@ -1,18 +1,24 @@
-<div class="row">
-  {% set content_class = (content.field_image|render) ? 'medium-18' : 'small-24' %}
-
-  {% if content.field_image|render %}
-    <div class="article-teaser-image columns medium-6">
-      {{ content.field_image }}
+{% set classes = [
+    'rhd-list-entry',
+] %}
+{{ attach_library('classy/node') }}
+<article{{ attributes.addClass(classes) }}>
+    <div class="text-content">
+        <h3 class="rhd-list-entry--title"><a href="{{ url }}">{{ label }}</a></h3>
+        <div class="rhd-list-entry--date">{{ node.createdtime|format_date('date_only') }}</div>
+        <div class="rhd-list-entry--summary">
+        {% if content.field_long_description|render %}
+          <p>{{content.field_long_description}}</p>
+        {% elseif content.field_short_description|render %}
+          <p>{{content.field_short_description}}</p>
+        {% endif %}
+        {{ content|without('field_long_description', 'field_short_description', 'field_image') }}
+        <div class="rhd-list-entry--comment-link"><a href="{{ url }}#comments"><span class="fa fa-comment"></span> Leave a comment</a></div>
+        </div>
     </div>
-  {% endif %}
-
-  <div class="article-teaser-content columns {{ content_class }}">
-    <h5><a href="{{ url }}">{{ label }}</a></h5>
-    {% if content.field_long_description|render %}
-      <p>{{content.field_long_description}}</p>
-    {% elseif content.field_short_description|render %}
-      <p>{{content.field_short_description}}</p>
+    {% if content.field_image|render %}
+        <div class="rhd-list-entry--image">
+          {{ content.field_image }}
+        </div>
     {% endif %}
-  </div>
-</div>
+</article>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--code-snippet.html.twig~developer-5432
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--code-snippet.html.twig~developer-5432
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file assembly.html.twig
+ * Default theme implementation to present Assembly data.
+ *
+ * This template is used when viewing Assembly pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_assembly()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass('assembly') }}>
+  {% if code %}
+    <pre><code>{{ code }}</code></pre>
+  {% endif %}
+</div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--teaser.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/video-resource/node--video-resource--teaser.html.twig
@@ -8,6 +8,7 @@
     <h3 {{ title_attributes.addClass(['rhd-list-entry--title']) }}><a {{ content_attributes }} href="{{ url }}">{{ label }}</a></h3>
     {{ title_suffix }}
     <div {{ content_attributes.addClass('rhd-list-entry--summary') }}>{{ content.field_short_description }}</div>
+    <div class="rhd-list-entry--comment-link"><a href="{{ url }}#comments"><span class="fa fa-comment"></span> Leave a comment</a></div>
   </div>
   {% if video_thumbnail_url %}
     <div class="rhd-list-entry--image">
@@ -17,5 +18,4 @@
       <div class="rhd-play-button"><span>►</span></div>
     </div>
   {% endif %}
-  <div class="rhd-list-entry--comment-link"><a href="{{ url }}#comments"><span class="fa fa-comment"></span> Leave a comment</a></div>
 </article>


### PR DESCRIPTION
Updates to the dynamic content list assembly to support the product resources use case. 

* Reworks the visual styles of the dynamic content feed based on the mocks.
* Enables articles in the dynamic content and dynamic content feed assemblies.
* Enables more vocabularies on the dynamic content feed to support pulling content related to products (product and product line purpose attributes, tags)
* Adds a visual style to support larger heading format ("Big heading")

An important note: this approach enables a few new vocabularies as filters on the dynamic content list assembly, but it is not prescriptive in what taxonomy strategy should actually be used to identify content related to products. My assumption is that the product purchase attribute is the best fit long term, but not content currently uses that term, so content managers will have to backfill. 

In an effort to ease the transition, Drupal tags and topics are also enabled, but these are not likely to be preferred moving forward as a means of classifying which content is relevant to a product.

Images are not assigned on some articles -- when those articles are pulled into a dynamic content list, the space for the image will be empty. Backfill images as needed to avoid weirdness.

<strong>Missing work:</strong> This PR does not solve the "video list" sidebar requirement of the issue.

### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5502

### Verification Process
* Visit the homepage, kubernetes, service mesh etc to validate the new format for the dynamic content feed looks good.
* Identify wordpress content that has tags appropriate to pull content related to a specific product, and note the tags.
* Identify drupal content that should be included in a sample product resources assembly, and note and/or update the terms involved. Content authors can use the product or product line purpose attributes, tags, or topics.
* On a sample page (a product page with the product content PR available, or any landing page simply as a demo): 
  * create a new dynamic content list (or edit an existing one)
  * Validate the visual style "Big Heading" Indeed makes the headings big
  * Select filters from the drupal term filter and wordpress tags to select which content should appear
  * Complete any other items in the assembly
  * Save all that and validate that the assembly & page look as expected.
* Author bios are inheriting the new article format. View a few author pages to verify those are acceptable.