### PR TITLE
Featured Articles Assembly Type

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.featured_articles.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.featured_articles.yml
@@ -1,0 +1,9 @@
+uuid: 3f21afe9-f690-4208-bd91-1092a40051cc
+langcode: en
+status: true
+dependencies: {  }
+id: featured_articles
+label: 'Featured Articles'
+description: ''
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_articles.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_articles.default.yml
@@ -1,0 +1,40 @@
+uuid: adc70108-b60d-47e5-b35d-6d46f100f14b
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.featured_articles
+    - field.field.assembly.featured_articles.field_articles
+id: assembly.featured_articles.default
+targetEntityType: assembly
+bundle: featured_articles
+mode: default
+content:
+  field_articles:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  moderation_state: true
+  user_id: true
+  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
@@ -1,0 +1,33 @@
+uuid: 25ee8539-75d8-4f10-b2cc-ba7f4d6e5e26
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.featured_articles
+    - field.field.assembly.featured_articles.field_articles
+  module:
+    - fences
+id: assembly.featured_articles.default
+targetEntityType: assembly
+bundle: featured_articles
+mode: default
+content:
+  field_articles:
+    weight: 0
+    label: visually_hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings:
+      fences:
+        fences_field_tag: div
+        fences_field_classes: ''
+        fences_field_item_tag: div
+        fences_field_item_classes: ''
+        fences_label_tag: div
+        fences_label_classes: ''
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.card.yml
@@ -1,9 +1,9 @@
-uuid: 0b4960c5-1879-4514-a680-0fd07e71dd46
+uuid: 10127e2e-c144-4eec-93be-012f76d4e28a
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.tile
+    - core.entity_view_mode.node.card
     - field.field.node.article.body
     - field.field.node.article.field_article_highlights
     - field.field.node.article.field_article_type
@@ -33,27 +33,23 @@ dependencies:
     - field.field.node.article.field_tax_region
     - field.field.node.article.field_tax_stage
     - field.field.node.article.field_topics
-    - image.style.large
     - node.type.article
   module:
     - fences
-    - image
+    - metatag
+    - options
     - user
 _core:
   default_config_hash: Gw6G97v6mM5MCkYyf8y-loKVxpZ22a0TDykKhheqCzc
-id: node.article.tile
+id: node.article.card
 targetEntityType: node
 bundle: article
-mode: tile
+mode: card
 content:
-  field_image:
-    type: image
+  field_article_type:
     weight: 0
-    region: content
     label: hidden
-    settings:
-      image_style: large
-      image_link: ''
+    settings: {  }
     third_party_settings:
       fences:
         fences_field_tag: none
@@ -61,6 +57,55 @@ content:
         fences_field_item_tag: none
         fences_field_item_classes: ''
         fences_label_tag: none
+        fences_label_classes: ''
+    type: list_default
+    region: content
+  field_author_evangelist:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: tile
+      link: false
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: entity_reference_entity_view
+    region: content
+  field_meta_tags:
+    weight: 2
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
+    region: content
+  field_short_description:
+    weight: 3
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  published_at:
+    type: timestamp
+    weight: 4
+    region: content
+    label: visually_hidden
+    settings:
+      date_format: date_only
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings:
+      fences:
+        fences_field_tag: div
+        fences_field_classes: ''
+        fences_field_item_tag: div
+        fences_field_item_classes: ''
+        fences_label_tag: div
         fences_label_classes: ''
   workbench_moderation_control:
     weight: -20
@@ -71,20 +116,17 @@ hidden:
   body: true
   content_moderation_control: true
   field_article_highlights: true
-  field_article_type: true
-  field_author_evangelist: true
   field_author_name: true
   field_card_image: true
   field_content: true
   field_content_author: true
   field_difficulty: true
   field_hide_toc: true
+  field_image: true
   field_image_caption: true
   field_long_description: true
-  field_meta_tags: true
   field_read_time: true
   field_related_articles: true
-  field_short_description: true
   field_tags: true
   field_tax_audience_segment: true
   field_tax_business_unit: true
@@ -98,4 +140,3 @@ hidden:
   field_tax_stage: true
   field_topics: true
   links: true
-  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.card.yml
@@ -87,8 +87,19 @@ hidden:
   field_share_image: true
   field_short_description: true
   field_tags: true
+  field_tax_audience_segment: true
+  field_tax_business_unit: true
+  field_tax_campaign: true
+  field_tax_lifecycle: true
+  field_tax_product: true
+  field_tax_product_line: true
+  field_tax_project: true
+  field_tax_promotion: true
+  field_tax_region: true
+  field_tax_stage: true
   field_thumbnail_url: true
   field_topics: true
   field_web_reader_url: true
   links: true
+  published_at: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.tile.yml
@@ -107,4 +107,5 @@ hidden:
   field_topics: true
   field_web_reader_url: true
   links: true
+  published_at: true
   workbench_moderation_control: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.card.yml
@@ -35,6 +35,17 @@ hidden:
   field_resource_type: true
   field_source_link: true
   field_tags: true
+  field_tax_audience_segment: true
+  field_tax_business_unit: true
+  field_tax_campaign: true
+  field_tax_lifecycle: true
+  field_tax_product: true
+  field_tax_product_line: true
+  field_tax_project: true
+  field_tax_promotion: true
+  field_tax_region: true
+  field_tax_stage: true
   field_technologies: true
   field_version: true
   links: true
+  published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_articles.field_articles.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.featured_articles.field_articles.yml
@@ -1,0 +1,28 @@
+uuid: 8078685d-9364-4c85-9239-1f5a170b190e
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.featured_articles
+    - field.storage.assembly.field_articles
+    - node.type.article
+id: assembly.featured_articles.field_articles
+field_name: field_articles
+entity_type: assembly
+bundle: featured_articles
+label: Articles
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
@@ -9,6 +9,7 @@ dependencies:
     - assembly.assembly_type.cta_form
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
@@ -49,6 +50,7 @@ settings:
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      featured_articles: featured_articles
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.call_to_action
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.featured_articles
     - assembly.assembly_type.product_download_hero
     - assembly.assembly_type.product_download_list
     - assembly.assembly_type.rich_text
@@ -28,6 +29,7 @@ settings:
   handler_settings:
     target_bundles:
       call_to_action: call_to_action
+      featured_articles: featured_articles
       product_download_hero: product_download_hero
       product_download_list: product_download_list
       rich_text: rich_text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - assembly.assembly_type.content_with_image
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.learning_paths
@@ -39,6 +40,7 @@ settings:
       static_content_band: static_content_band
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      featured_articles: featured_articles
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_articles.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_articles.yml
@@ -1,0 +1,20 @@
+uuid: 416ea4be-4496-45d6-bec5-96152d6bebd5
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+    - node
+id: assembly.field_articles
+field_name: field_articles
+entity_type: assembly
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--card.html.twig
@@ -1,0 +1,117 @@
+{#
+/**
+* @file
+* Default theme implementation to display a node.
+*
+* Available variables:
+* - node: The node entity with limited access to object properties and methods.
+Only "getter" methods (method names starting with "get", "has", or "is")
+and a few common methods such as "id" and "label" are available. Calling
+other methods (such as node.delete) will result in an exception.
+* - label: The title of the node.
+* - content: All node items. Use {{ content }} to print them all,
+*   or print a subset such as {{ content.field_example }}. Use
+*   {{ content|without('field_example') }} to temporarily suppress the printing
+*   of a given child element.
+* - author_picture: The node author user entity, rendered using the "compact"
+*   view mode.
+* - metadata: Metadata for this node.
+* - date: Themed creation date field.
+* - author_name: Themed author name field.
+* - url: Direct URL of the current node.
+* - display_submitted: Whether submission information should be displayed.
+* - attributes: HTML attributes for the containing element.
+*   The attributes.class element may contain one or more of the following
+*   classes:
+*   - node: The current template type (also known as a "theming hook").
+*   - node--type-[type]: The current node type. For example, if the node is an
+*     "Article" it would result in "node--type-article". Note that the machine
+*     name will often be in a short form of the human readable label.
+*   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+*     teaser would result in: "node--view-mode-teaser", and
+*     full: "node--view-mode-full".
+*   The following are controlled through the node publishing options.
+*   - node--promoted: Appears on nodes promoted to the front page.
+*   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+*     teaser listings.
+*   - node--unpublished: Appears on unpublished nodes visible only to site
+*     admins.
+* - title_attributes: Same as attributes, except applied to the main title
+*   tag that appears in the template.
+* - content_attributes: Same as attributes, except applied to the main
+*   content tag that appears in the template.
+* - author_attributes: Same as attributes, except applied to the author of
+*   the node tag that appears in the template.
+* - title_prefix: Additional output populated by modules, intended to be
+*   displayed in front of the main title tag that appears in the template.
+* - title_suffix: Additional output populated by modules, intended to be
+*   displayed after the main title tag that appears in the template.
+* - view_mode: View mode; for example, "teaser" or "full".
+* - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+* - page: Flag for the full page state. Will be true if view_mode is 'full'.
+* - readmore: Flag for more state. Will be true if the teaser content of the
+*   node cannot hold the main body content.
+* - logged_in: Flag for authenticated user status. Will be true when the
+*   current user is a logged-in member.
+* - is_admin: Flag for admin user status. Will be true when the current user
+*   is an administrator.
+*
+* @see template_preprocess_node()
+*
+* @todo Remove the id attribute (or make it a class), because if that gets
+*   rendered twice on a page this is invalid CSS for example: two lists
+*   in different view modes.
+*
+* @ingroup themeable
+*/
+#}
+
+{% set article_classes = (hide_toc == TRUE) ? ["large-12", "medium-12", "medium-offset-7", "large-offset-6", "columns", "gsi", "fetch-toc", "article-content"] : [ "medium-17", "large-12", "columns", "gsi", "fetch-toc", "article-content"] %}
+<div{{ attributes.addClass(["container", "content"]).setAttribute("id", "rhd-article") }}>
+  <div class="row pre-body">
+    <div class="medium-24 columns">
+      {% if content.field_article_type|render %}
+        <p class="article-type">{{ content.field_article_type }}</p>
+      {% endif %}
+      <div class="article-info-wrapper">
+        <div class="article-info-left">
+          {{ title_prefix }}
+          <h1{{ title_attributes.setAttribute("id", "developer-materials") }}>{{ label }}</h1>
+          {{ title_suffix }}
+          <div class="gsi-meta article-info">
+            <ul class="date-info">
+              <li>
+                <span class="publish-date">Published: {{ node.createdtime|date('m/j/Y') }}</span>
+              </li>
+              {% if node.createdtime != node.changedtime %}
+                <li>
+                  <span class="changed-date">Last updated: {{ node.changedtime|date('m/j/Y') }}</span>
+                </li>
+              {% endif %}
+            </ul>
+          </div>
+        </div>
+        {% if content.field_author_evangelist|render %}
+          <div class="authors">
+            {{ content.field_author_evangelist }}
+          </div>
+        {% elseif content.field_content_author|render %}
+          <div class="authors no-image">
+            <div class="authors-inner">
+              <div class="author short-teaser">
+                <span class="author-name">
+                  {{ content.field_content_author }}
+                </span>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+      <div class="row body-row">
+        <div{{ content_attributes.addClass(article_classes) }}>
+          {{ content.field_short_description }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/field--assembly--field-articles--featured-articles.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/field--assembly--field-articles--featured-articles.html.twig
@@ -1,0 +1,80 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div class="field__items row">
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass('medium-8 column field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
This creates a Featured Articles assembly type and allows this assembly
type to be referenced from the Content, Downloads Page and Getting
Started Page fields on the Product content type. The Featured Articles
assembly type allows an editor to reference existing Articles to create
a collection of articles that are pertinent to the page/node that the
Featured Articles assembly is placed upon.

I have also created a custom template for node--article--card.html.twig
and field--assembly--field-articles-featured-articles.html.twig to start
the templating/layout for the FE work. The remaining FE work includes
any styling required to meet the InVision mockups (attached to JIRA
ticket).

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5520

### Verification Process

* There is a Featured Articles assembly type that can be referenced from the Content, Downloads and Getting Started fields of the Product content type
* The Featured Articles assembly type allows editors to reference an unlimited number of articles
* The Featured Articles assembly type displays using the Card view mode of the Article content type
* The following field(s) are presented in the templating layer:

1. Article Title (They should be able to overwrite the title if they want to display a different title on the card)
2. Type of article (i.e. how-to, opinion, etc.)
3. Short description of article
4. Author and author's avatar
5. Published date
6. Last updated date