### PR TITLE
Remove Product Features assembly from Articles

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
@@ -9,7 +9,6 @@ dependencies:
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.embedded_content
-    - assembly.assembly_type.product_comparison_table
     - field.storage.node.field_content
     - node.type.article
   module:
@@ -34,7 +33,6 @@ settings:
       content_image: content_image
       content_pull_quote: content_pull_quote
       embedded_content: embedded_content
-      product_comparison_table: product_comparison_table
     sort:
       field: _none
     auto_create: false


### PR DESCRIPTION
This removes the Product Features assembly type as an option from the
Content entity reference revisions field on the Articles content type.
Gina has requested we removed this assembly type as an option on this
content type until we implement some changes to the styling of the
Product Features component that will allow it to be displayed more
functionality in situations with less width.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5576

### Verification Process

* The Product Features assembly type is not available from the assembly reference field on Article nodes