### PR TITLE
Fix Search form in Drupal

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/menu/menu--rhd-navigation.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/menu/menu--rhd-navigation.html.twig
@@ -56,7 +56,7 @@
     {% endfor %}
       <li class="rhd-nav-search">
         <div class="rhd-search-wrapper">
-          <form class="search-bar" accept-charset="utf-8" action="./search/" method="get" role="search" type="submit">
+          <form class="search-bar" accept-charset="utf-8" action="/search/" method="get" role="search" type="submit">
             <input class="user-search" type="text" placeholder="Search" id="search_list_text" name="t" maxlength="128" required="">
             <button type="submit" id="search-button"><i class="far fa-search"></i></button>
           </form>


### PR DESCRIPTION
This should fix the issue with the search form in Drupal. We should
thoroughly test how this change (albeit 1 character) impacts the search
functionality of the exported site.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5540

### Verification Process

* Search still works exactly as it currently is on the exported site
* The search now works within Drupal, which it currently does not for paths like `/products/fuse/connectors/` or any path that is multiple 'levels' deep