### PR TITLE
[DEVELOPER-5595] Adds CTA to Content field on Product nodes

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.call_to_action
     - assembly.assembly_type.content
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_with_image
@@ -44,6 +45,7 @@ settings:
   handler_settings:
     target_bundles:
       cta_form: cta_form
+      call_to_action: call_to_action
       content: content
       content_image: content_image
       static_content_band: static_content_band


### PR DESCRIPTION
This adds the CTA assembly type as a reference-able assembly from the
Content field on the Product content type.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5595

### Verification Process

* An editor can now reference CTA assemblies from the Content field on Product nodes