### PR TITLE
[DEVELOPER-5589] Product drafts are not accessible to anonymous users

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.routing.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.routing.yml
@@ -12,7 +12,7 @@ rhd_assemblies.products_downloads:
     _controller: '\Drupal\rhd_assemblies\Controller\ProductsDownloadsController::content'
     _title_callback: '\Drupal\rhd_assemblies\Controller\ProductsDownloadsController::getTitle'
   requirements:
-    _permission: 'access content'
+    _permission: 'access content, view product revisions'
 
 rhd_assemblies.products_getting_started:
   path: '/products/{product_url_name}/getting-started'
@@ -20,4 +20,4 @@ rhd_assemblies.products_getting_started:
     _controller: '\Drupal\rhd_assemblies\Controller\ProductsGettingStartedController::content'
     _title_callback: '\Drupal\rhd_assemblies\Controller\ProductsGettingStartedController::getTitle'
   requirements:
-    _permission: 'access content'
+    _permission: 'access content, view product revisions'

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.routing.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.routing.yml
@@ -5,7 +5,7 @@ rhd_common.main_page_controller:
     _title_callback: '\Drupal\rhd_common\Controller\ProductPageController::getPageTitle'
     _entity_view: 'product.full'
   requirements:
-    _permission: 'access content'
+    _permission: 'access content, view product revisions'
 rhd_common.product_overview:
   path: '/products/{product_code}'
   defaults:
@@ -14,5 +14,4 @@ rhd_common.product_overview:
     _entity_view: 'product.full'
     sub_page: 'overview'
   requirements:
-    _permission: 'access content'
-
+    _permission: 'access content, view product revisions'


### PR DESCRIPTION
This commit fixes a long-standing issue where Product drafts,
particularly due to our custom routing implementation could be accessed
by anonymous users.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5589

### Verification Process

##### View an existing Product page

Do this:

* Log in as an administrator
* View an existing Product node that has an unpublished Draft
** You may have to create a test draft in this PR environment to test this

You should see this:

* You should see the unpublished draft as you would expect

Do this:

* Open an incognito window
* Visit the same Product node you just visited

You should see this:

* You should view either whatever the last published state of the Product node is OR, if one does not exist, then your request will be denied due to permissions and you will see the message "You are not authorized to access this page."

##### Create a Product node and view it

Do this:

* Log in as an administrator
* Create a product node and fill out any required fields and set the moderation state to 'Draft', submit the form and view the newly created Product node/draft

You should see this:

* You should see the unpublished draft as you would expect

Do this:

* Open an incognito window
* Visit the same Product node you just visited

You should see this:

* Your request will be denied due to permissions and you will see the message "You are not authorized to access this page."