### PR TITLE
[DEVELOPER-5601] add extra field for background SVG to 'content with image' assembly

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content_with_image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content_with_image.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - entity_browser.browser.image_browser
     - field.field.assembly.content_with_image.field_audience_selection
     - field.field.assembly.content_with_image.field_background_image
+    - field.field.assembly.content_with_image.field_background_svg
     - field.field.assembly.content_with_image.field_content
     - field.field.assembly.content_with_image.field_image
     - field.field.assembly.content_with_image.field_image_link
@@ -14,6 +15,7 @@ dependencies:
     - field.field.assembly.content_with_image.field_title
   module:
     - entity_browser
+    - file
     - link
     - text
 id: assembly.content_with_image.default
@@ -40,6 +42,13 @@ content:
       selection_mode: selection_append
     region: content
     third_party_settings: {  }
+  field_background_svg:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
   field_content:
     weight: 8
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.content_with_image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.content_with_image.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - assembly.assembly_type.content_with_image
     - field.field.assembly.content_with_image.field_audience_selection
     - field.field.assembly.content_with_image.field_background_image
+    - field.field.assembly.content_with_image.field_background_svg
     - field.field.assembly.content_with_image.field_content
     - field.field.assembly.content_with_image.field_image
     - field.field.assembly.content_with_image.field_image_link
@@ -55,6 +56,7 @@ content:
 hidden:
   field_audience_selection: true
   field_background_image: true
+  field_background_svg: true
   field_image_link: true
   field_navigation_title: true
   name: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content_with_image.field_background_svg.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.content_with_image.field_background_svg.yml
@@ -1,0 +1,27 @@
+uuid: d48c5f1b-dd13-4468-86d4-853dbeb38b85
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.content_with_image
+    - field.storage.assembly.field_background_svg
+  module:
+    - file
+id: assembly.content_with_image.field_background_svg
+field_name: field_background_svg
+entity_type: assembly
+bundle: content_with_image
+label: 'Background SVG'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: svg
+  max_filesize: '512 KB'
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_background_svg.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.assembly.field_background_svg.yml
@@ -1,0 +1,23 @@
+uuid: 5eecaa7c-2519-4aa7-b102-c240d2871259
+langcode: en
+status: true
+dependencies:
+  module:
+    - assembly
+    - file
+id: assembly.field_background_svg
+field_name: field_background_svg
+entity_type: assembly
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -575,17 +575,29 @@ function rhdp_preprocess_assembly(&$variables) {
   $assembly = $variables['elements']['#assembly'];
   $type = $assembly->bundle();
   $variables['background_image_url'] = FALSE;
+  $image_value = FALSE;
+  $svg_value = FALSE;
 
   if ($assembly->hasField('field_background_image')) {
     $image_value = $assembly->get('field_background_image')->getValue();
-
-    if ($image_value) {
-      $file_id = $image_value[0]['target_id'];
-      $uri = File::load($file_id)->getFileUri();
-      $variables['background_image_url'] = ImageStyle::load('billboard')->buildUrl($uri);
-      $variables['attributes']->addClass('has-background');
-    }
   }
+
+  if ($assembly->hasField('field_background_svg')) {
+    $svg_value = $assembly->get('field_background_svg')->getValue();
+  }
+
+  if ($svg_value) {
+    $file_id = $svg_value[0]['target_id'];
+    $uri = File::load($file_id)->getFileUri();
+    $variables['background_image_url'] = file_create_url($uri);
+    $variables['attributes']->addClass('has-background');
+  } else if ($image_value) {
+    $file_id = $image_value[0]['target_id'];
+    $uri = File::load($file_id)->getFileUri();
+    $variables['background_image_url'] = ImageStyle::load('billboard')->buildUrl($uri);
+    $variables['attributes']->addClass('has-background');
+  }
+  
 
   if ($assembly->hasField('field_audience_selection')) {
     $field_audience_selection_values = $assembly->get('field_audience_selection')->getValue();


### PR DESCRIPTION
### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5601

### Verification Process
Edit the content for the homepage you should now see below the background image field an option to upload a background svg file.

if the SVG is present it will take priority over the background image field.

Once the file has been inserted the homepage hero should show the SVG.
