### PR TITLE
[DEVELOPER-5590] Make author name blue if a link otherwise grey

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
@@ -297,6 +297,12 @@
         font-size: 14px;
         line-height: 22px;
         font-weight: bold;
+        color: $gray-6;
+      }
+      a {
+        .author-name {
+          color: $link;
+        }
       }
     }
     @include desktop-small {


### PR DESCRIPTION
### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5590

### Verification Process
for the new article pages the author name should now be #0066CC if it is a link to a profile otherwise it should be #424242.

an example of this page is here /articles/build-run-colossal-cave-adventure-game/