### PR TITLE
[RHDENG-2793] Ensured that composer fails if it cannot apply a patch

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -121,6 +121,7 @@
             ]
         },
         "enable-patching": true,
+        "composer-exit-on-patch-failure": true,
         "patches": {
           "drupal/core": {
             "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch"


### PR DESCRIPTION
Composer fails silently if it cannot apply a patch. This is a very strange default and pretty dangerous as it means we could build Drupal without our required patches applied. Instead Composer should fail if it cannot apply a patch meaning that we do not build a version of Drupal that is not what we expect.

### JIRA Issue Link
* https://issues.jboss.org/browse/RHDENG-2793

### Verification Process

* Add the following patch to composer.json in your local development:

```
"patches": {
          "drupal/core": {
            "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch",
            "Composer should fail": "https://foo.com/no/patch/here.patch"
          },
          "drupal/inline_entity_form": {
            "Support entity reference revisions": "https://www.drupal.org/files/issues/support_entity_revision-2367235-92.patch"
          }
        }
```

* Run composer update and notice that whilst Composer warns about not being able to apply the patch, it carries on quite happily.

* Try the same thing in the branch for this PR and notice that Composer now exits and fails to build.


