### PR TITLE
Hotfix: Assembly Static Item Twig Tweak with()

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--static-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--static-item.html.twig
@@ -1,12 +1,14 @@
 <section{{ attributes.addClass('assembly') }}{{ audience_selection }}>
   <a href={{ content.field_url['#items'][0].uri }}>
-    <div class="tile-image">
-      <div class="image-table">
-        <div class="image-cell">
-          {{ content.field_image.0 | with('#image_style', 'static_item') }}
+    {% if content.field_image.0 %}
+      <div class="tile-image">
+        <div class="image-table">
+          <div class="image-cell">
+            {{ content.field_image.0 | with('#image_style', 'static_item') }}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <h3 class="tile-title">{{ content.field_title }}</h3>
   </a>
   {% if absolute_url and rhd_domain %}


### PR DESCRIPTION
If a the content image is NULL, this throws a fatal error currently
because the Twig Tweak with() is expecting an array.

### JIRA Issue Link
* n/a

### Verification Process

* A static item assembly type can be rendered without a fatal error when an image is not available (null)

### Background

* SJ is working on this Product page, converting it to the new Product page format, and she is receiving a fatal error here: http://rhdp-drupal.redhat.com/products/codeready-workspaces/getting-started
* You can see the error log here: http://rhdp-drupal.redhat.com/admin/reports/dblog/event/11440475