### PR TITLE
[DEVELOPER-5614] Adds typechecking to page preprocessing

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -229,7 +229,7 @@ function rhdp_preprocess_page(&$variables) {
 
   $node = isset($variables['node']) ? $variables['node'] : FALSE;
 
-  if ($node) {
+  if ($node && get_class($node) === 'Drupal\node\Entity\Node') {
     $alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $node->id());
 
     if ($alias == '/') {
@@ -238,7 +238,7 @@ function rhdp_preprocess_page(&$variables) {
   }
 
   // Pull out assemblies to page level for solp.
-  if ($node && $node->getType() == 'landing_page_single_offer') {
+  if ($node && get_class($node) === 'Drupal\node\Entity\Node' && $node->getType() == 'landing_page_single_offer') {
     foreach (['hero'] as $field) {
       $fieldname = 'field_' . $field;
       if (isset($node->$fieldname)) {


### PR DESCRIPTION
This commit adds a typechecking to the $node variables, ensuring it is
the Node class before operating on it, within the page preprocessor in
rhdp.theme. Prior to this commit, this lack of typechecking resulted in
a fatal error that made it impossible to view entity revisions.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5614

### Verification Process

* If you visit any node Revisions page (ex. /finservices/openbanking/revisions), you should be able to successfully click on one of the timestamps (ex. 01/04/2019 - 07:44) to successfully view the revision
