### PR TITLE
DEVELOPER-5626: Learning Paths Invalid Render Array

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -415,6 +415,59 @@ function rhdp_preprocess_node(array &$variables) {
       ];
     }
   }
+
+  // Books content type and Learning Path Card view mode.
+  if ($node->getType() == 'books' && $variables['view_mode'] == 'learning_path_card') {
+    $variables['interval'] = '';
+    // Ensure the field value is not null.
+    if ($node->get('field_read_time')->getValue()) {
+      $read_time = $node->get('field_read_time')->getValue();
+      $variables['interval'] = $read_time[0]['interval'] . ' ' . $read_time[0]['period'];
+      // Make it plural if the interval is greater than 1.
+      if ($read_time[0]['interval'] > 1) {
+        $variables['interval'] .= 's';
+      }
+    }
+  }
+
+  // Cheat Sheet content type and Learning Path Card view mode.
+  if ($node->getType() == 'cheat_sheet' && $variables['view_mode'] == 'learning_path_card') {
+    // Ensure the field value is not null.
+    if ($node->get('field_read_time')->getValue()) {
+      $read_time = $node->get('field_read_time')->getValue();
+      $variables['interval'] = $read_time[0]['interval'] . ' ' . $read_time[0]['period'];
+      // Make it plural if the interval is greater than 1.
+      if ($read_time[0]['interval'] > 1) {
+        $variables['interval'] .= 's';
+      }
+    }
+  }
+
+  // RH Training Class content type and Learning Path Card view mode.
+  if ($node->getType() == 'rh_training_class' && $variables['view_mode'] == 'learning_path_card') {
+    // Ensure the field value is not null.
+    if ($node->get('field_completion_time')->getValue()) {
+      $completion_time = $node->get('field_completion_time')->getValue();
+      $variables['interval'] = $completion_time[0]['interval'] . ' ' . $completion_time[0]['period'];
+      // Make it plural if the interval is greater than 1.
+      if ($completion_time[0]['interval'] > 1) {
+        $variables['interval'] .= 's';
+      }
+    }
+  }
+
+  // Video Resource content type and Learning Path Card view mode.
+  if ($node->getType() == 'video_resource' && $variables['view_mode'] == 'learning_path_card') {
+    // Ensure the field value is not null.
+    if ($node->get('field_duration')->getValue()) {
+      $duration = $node->get('field_duration')->getValue();
+      $variables['interval'] = $duration[0]['interval'] . ' ' . $duration[0]['period'];
+      // Make it plural if the interval is greater than 1.
+      if ($duration[0]['interval'] > 1) {
+        $variables['interval'] .= 's';
+      }
+    }
+  }
 }
 
 /**

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/field--node--field-learning-path-content-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/field--node--field-learning-path-content-item.html.twig
@@ -47,6 +47,6 @@
 
 {% for item in items %}
 
-{{ item }}
+  <div{{ item.attributes }}>{{ item.content }}</div>
 
 {% endfor %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--books--learning-path-card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--books--learning-path-card.html.twig
@@ -3,7 +3,7 @@
 {# The replace the training-content class with one of the following, depending on the content: free-content, member-content, training-content #}
 <div{{ attributes.addClass(['dp-content-card', access ]) }} 
     access="member" 
-    duration="{{node.field_read_time.value}}" 
+    duration="{{ interval }}" 
     image="{{ learning_path_card['card_image_url']|default('https://images.unsplash.com/photo-1471970471555-19d4b113e9ed?ixlib=rb-0.3.5&s=968ae8186ef28dfb0c53da8e9708fe32&auto=format&fit=crop&w=800&q=80') }}"
     level="{{(node.field_difficulty.value ?? 'unclassified')|capitalize}}" 
     title="{{node.title.value}}" 
@@ -25,17 +25,12 @@
   <div class="card-info">
     <div class="card-details">
       <div class="dp-content-type {{ node.type.entity.get('type') }}">
-          <i class="fas fa-book"></i> {{node.type.entity.label}}
+        <i class="fas fa-book"></i> {{node.type.entity.label}}
       </div>
-      {% if node.field_read_time.value %}
+      {% if interval is not null and interval is not empty %}
       <div class="dp-duration">
-          <i class="far fa-clock"></i> 
-          {% for intvl in node.field_read_time|reverse %}
-            {# Verify that the array key exists before referencing it. #}
-            {% if intvl.interval is defined %}
-              {{ intvl.interval }} {{ intvl.period }}{% if intvl.interval > 1 %}s{% endif %}
-            {% endif %}
-          {% endfor %}
+        <i class="far fa-clock"></i> 
+        {{ interval }}
       </div>
       {% endif %}
       {% if node.field_difficulty.value %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--cheat-sheet--learning-path-card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--cheat-sheet--learning-path-card.html.twig
@@ -2,7 +2,7 @@
 {# The replace the training-content class with one of the following, depending on the content: free-content, member-content, training-content #}
 <div{{ attributes.addClass(['dp-content-card', access ]) }}
     access="member" 
-    duration="{{node.field_read_time.value}}" 
+    duration="{{ interval }}" 
     image="{{ learning_path_card['card_image_url']|default('https://images.unsplash.com/photo-1484480974693-6ca0a78fb36b?ixlib=rb-0.3.5&s=654b7c8ae262f6056711a8605532f3ad&auto=format&fit=crop&w=1352&q=80') }}"
     level="{{(node.field_difficulty.value ?? 'unclassified')|capitalize}}" 
     title="{{node.title.value}}" 
@@ -24,19 +24,17 @@
   <div class="card-info">
     <div class="card-details">
       <div class="dp-content-type {{ node.type.entity.get('type') }}">
-          <i class="far fa-map"></i> {{node.type.entity.label}}
+        <i class="far fa-map"></i> {{node.type.entity.label}}
       </div>
-      {% if node.field_read_time.value %}
+      {% if interval is not null and interval is not empty %}
       <div class="dp-duration">
-          <i class="far fa-clock"></i> 
-          {% for intvl in node.field_read_time|reverse %}
-          {{ intvl.interval }} {{ intvl.period }}{% if intvl.interval > 1 %}s{% endif %}
-          {% endfor %}
+        <i class="far fa-clock"></i> 
+        {{ interval }}
       </div>
       {% endif %}
       {% if node.field_difficulty.value %}
       <div class="dp-level">
-        {% if node.field_read_time.value %}
+        {% if interval is not null and interval is not empty %}
         &nbsp;|&nbsp;
         {% endif %}
         {{node.field_difficulty.value|capitalize}}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--rh-training-class--learning-path-card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--rh-training-class--learning-path-card.html.twig
@@ -3,7 +3,7 @@
 {# The replace the training-content class with one of the following, depending on the content: free-content, member-content, training-content #}
 <div{{ attributes.addClass(['dp-content-card', access ]) }} 
     access="member" 
-    duration="{{node.field_completion_time.value}}" 
+    duration="{{ interval }}" 
     image="{{ learning_path_card['card_image_url']|default('https://images.unsplash.com/photo-1500015139098-84b51c349a60?ixlib=rb-0.3.5&s=6d04d38ac0d81eb2414819cdea385912&auto=format&fit=crop&w=1050&q=80') }}"
     level="{{(node.field_level.value ?? 'unclassified')|capitalize}}" 
     title="{{node.title.value}}" 
@@ -24,19 +24,17 @@
   <div class="card-info">
     <div class="card-details">
       <div class="dp-content-type {{ node.type.entity.get('type') }}">
-          <i class="fas fa-laptop"></i> {{node.type.entity.label}}
+        <i class="fas fa-laptop"></i> {{node.type.entity.label}}
       </div>
-      {% if node.field_completion_time.value %}
+      {% if interval is not null and interval is not empty %}
       <div class="dp-duration">
-          <i class="far fa-clock"></i> 
-          {% for intvl in node.field_completion_time|reverse %}
-            {{ intvl.interval }} {{ intvl.period }}{% if intvl.interval > 1 %}s{% endif %}
-          {% endfor %}
+        <i class="far fa-clock"></i> 
+        {{ interval }}
       </div>
       {% endif %}
       {% if node.field_level.value %}
       <div class="dp-level">
-        {% if node.field_completion_time.value %}
+        {% if interval is not null and interval is not empty %}
         &nbsp;|&nbsp;
         {% endif %}
         {{node.field_level.value|capitalize}}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--video-resource--learning-path-card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--video-resource--learning-path-card.html.twig
@@ -3,7 +3,7 @@
 {#  The replace the training-content class with one of the following, depending on the content: free-content, member-content, training-content  #}
 <div{{ attributes.addClass(['dp-content-card', access ]) }} 
     access="member" 
-    duration="{{node.field_read_time.value}}" 
+    duration="{{ interval }}" 
     image="{{ learning_path_card['card_image_url']|default('https://images.unsplash.com/photo-1487537708572-3c850b5e856e?ixlib=rb-0.3.5&s=50ddd59eb6185b3805e29472a70c4096&auto=format&fit=crop&w=1052&q=80') }}"
     level="{{(node.field_difficulty.value ?? 'unclassified')|capitalize}}" 
     title="{{node.title.value}}" 
@@ -25,21 +25,17 @@
   <div class="card-info">
     <div class="card-details">
       <div class="dp-content-type {{ node.type.entity.get('type') }}">
-          <i class="fab fa-youtube"></i> {{node.type.entity.label}}
+        <i class="fab fa-youtube"></i> {{node.type.entity.label}}
       </div>
-      {% if node.field_duration %}
+      {% if interval is not null and interval is not empty %}
       <div class="dp-duration">
-          <i class="far fa-clock"></i> 
-          {% for intvl in node.field_duration|reverse %}
-            {% if intvl.period != "second" %}
-              {{ intvl.interval }} {{ intvl.period }}{% if intvl.interval > 1 %}s{% endif %}
-            {% endif %}
-          {% endfor %}
+        <i class="far fa-clock"></i> 
+        {{ interval }}
       </div>
       {% endif %}
       {% if node.field_difficulty.value %}
       <div class="dp-level">
-        {% if node.field_duration %}
+        {% if interval is not null and interval is not empty %}
         &nbsp;|&nbsp;
         {% endif %}
         {{node.field_difficulty.value|capitalize}}


### PR DESCRIPTION
This resolves some invalid render array errors with the Learning Paths
pages (/learn/*). The 'interval' and 'period' array keys were not truly
render array keys as we were attempting to use them in Twig, so I made
some additions to the node preprocessor to make the interval available
to the templates via PHP.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5626

### Verification Process

Go here: `/learn/microservices`

Then, go here: `/admin/reports/dblog` and you should see no errors in the log like this:

`User error: "period" is an invalid render array key in...`

or

`User error: "interval" is an invalid render array key in...`