### PR TITLE
DEVELOPER-5633: Sitemap broken for product pages

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.sitemap.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.sitemap.inc
@@ -39,9 +39,58 @@ function product_node_sitemap_entries(&$links) {
   // this add all the sub pages to the list of links and unsets the one with the node entry.
   $callback = function ($product_node_link, $product_node_link_index) use (&$links) {
     $product = Node::load($links[$product_node_link_index]['meta']['entity_info']['id']);
-    $sub_pages = $product->field_product_pages->referencedEntities();
-    $entries = array_map('build_subpage_link_entry', $sub_pages,
-      array_fill(0, count($sub_pages), $links[$product_node_link_index]));
+
+    // The product page is using the new, assembly-based approach.
+    if ($product->hasField('field_use_new_product_page')
+      && !empty($product->field_use_new_product_page->value)
+      && $product->field_use_new_product_page->value == '1') {
+      /** @var \Drupal\Core\Config\ImmutableConfig $rhd_config */
+      $rhd_drupal_config = \Drupal::config('redhat_developers')->get('drupal');
+      $drupal_env = \Drupal::config('redhat_developers')->get('environment');
+      $url_product_name = $product->field_url_product_name->value;
+      $entries = [];
+
+      $base_url = ($drupal_env === 'pr')
+        ? "http://{$rhd_drupal_config['host']}:{$rhd_drupal_config['port']}"
+        : $rhd_drupal_config['host'];
+
+      // If there is content for the Overview subpage.
+      if (!empty($product->field_content->referencedEntities())) {
+        // Add a sitemap entry.
+        $overview = $links[$product_node_link_index];
+        $overview['path'] = "/products/$url_product_name/overview";
+        $overview['url'] = "$base_url/products/$url_product_name/overview";
+        $overview['alternate_urls']['en'] = "$base_url/products/$url_product_name/overview";
+        $entries[] = $overview;
+      }
+
+      // If there is content for the Getting Started subpage.
+      if (!empty($product->field_getting_started_content->referencedEntities())) {
+        // Add a sitemap entry.
+        $getting_started = $links[$product_node_link_index];
+        $getting_started['path'] = "/products/$url_product_name/getting-started";
+        $getting_started['url'] = "$base_url/products/$url_product_name/getting-started";
+        $getting_started['alternate_urls']['en'] = "$base_url/products/$url_product_name/getting-started";
+        $entries[] = $getting_started;
+      }
+
+      // If there is content for the Download subpage.
+      if (!empty($product->field_downloads_page_content->referencedEntities())) {
+        // Add a sitemap entry.
+        $download = $links[$product_node_link_index];
+        $download['path'] = "/products/$url_product_name/download";
+        $download['url'] = "$base_url/products/$url_product_name/download";
+        $download['alternate_urls']['en'] = "$base_url/products/$url_product_name/download";
+        $entries[] = $download;
+      }
+    }
+    // The product page is using the old, paragraph-based approach.
+    else {
+      $sub_pages = $product->field_product_pages->referencedEntities();
+      $entries = array_map('build_subpage_link_entry', $sub_pages,
+        array_fill(0, count($sub_pages), $links[$product_node_link_index]));
+    }
+
     $links = array_merge($links, $entries);
     $links[$product_node_link_index] = NULL;
   };

--- a/pr-build-steps.sh
+++ b/pr-build-steps.sh
@@ -38,5 +38,6 @@ else
 fi
 
 # Start the export process
+docker exec rhdpr${ghprbPullId}_drupal_1 drush cron
 ruby ./control.rb -e drupal-pull-request --export rhd@filemgmt.jboss.org:/stg_htdocs/it-rhd-stg[/pr/${ghprbPullId}/export] --no-decrypt --no-kill
 


### PR DESCRIPTION
This resolves an issue where the 'old', paragraph-based subpages were
being indexed for Product pages using the 'new, assembly-based Product
page design/approach. This commit provides a conditional to the
simple_sitemap hook that creates these entries for custom
subpages/routing for the product pages that will distinguish
appropriately between the product nodes using the paragraphs-based
approach and those using the new, assembly-based approach.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5633

### Verification Process

* The site export can execute successfully
* All product page scenarios are properly handled by the simple_sitemap

**Case 1: Product node using old, paragraphs-based approach**

/sitemap.xml should display a route for each of the paragraph subpages/subroutes defined on the Node edit form. For example, currently for Openshiftio, we have:

```
<url>
<loc>docker/products/openshiftio/overview</loc>
<lastmod>2018-08-17T23:07:03+00:00</lastmod>
<priority>0.5</priority>
</url>
<url>
<loc>docker/products/openshiftio/hello-world</loc>
<lastmod>2018-08-17T23:07:03+00:00</lastmod>
<priority>0.5</priority>
</url>
<url>
<loc>docker/products/openshiftio/docs-and-apis</loc>
<lastmod>2018-08-17T23:07:03+00:00</lastmod>
<priority>0.5</priority>
</url>
<url>
<loc>docker/products/openshiftio/community</loc>
<lastmod>2018-08-17T23:07:03+00:00</lastmod>
<priority>0.5</priority>
</url>
```

_The root is listed as docker here (above) because this was generated from my localhost_

**Case 2: Product node using new, assembly-based approach with referenced assembly for the Content, Download page and Getting Started page assembly fields**

/sitemap.xml should display 3 entries for this product with URLs like:

```
docker/products/openshiftio/overview
docker/products/openshiftio/getting-started
docker/products/openshiftio/download
```

**Case 3: Product node using the new, assembly-based approach with at least one of the following assembly fields being empty: Content, Download page and Getting Started page fields**

/sitemap.xml should contain entries for whichever assembly fields have value(s) and should **not** display an entry for an assembly field that does not have a value.