### PR TITLE
[DEVELOPER-5622] Product Category View Undefined Index Base

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.product_groups.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.product_groups.yml
@@ -511,15 +511,6 @@ display:
           required: true
           entity_type: taxonomy_term
           plugin_id: entity_reverse
-        field_product_category_image:
-          id: field_product_category_image
-          table: taxonomy_term__field_product_category_image
-          field: field_product_category_image
-          relationship: none
-          group_type: group
-          admin_label: 'field_product_category_image: Media'
-          required: false
-          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
     cache_metadata:


### PR DESCRIPTION
This error was a result of a missing handler (relationship) on the
product_groups View, which seemed to be some past image field. I removed
the relationship from the View and verified that the display of the View
remained the same. It did. I also verified that the error no longer was
logged. It was not.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5622

### Verification Process

Go here:

`/products`

and here:

`/product-testing`

Do this:

* Log in to your Drupal account and go to the logs `/admin/reports/dblog` and ensure there are no errors like `Notice: Undefined index: base in Drupal\views\Plugin\…` logged within the time you visited the two routes above.