### PR TITLE
[DEVELOPER-5642] Curated Link Listing Assembly

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.curated_links.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.curated_links.yml
@@ -1,0 +1,9 @@
+uuid: a3d5f4ef-0c0e-444c-bbbf-08ff5987dd01
+langcode: en
+status: true
+dependencies: {  }
+id: curated_links
+label: 'Curated Links'
+description: 'An assembly that displays a list of curated links to wordpress posts and/or drupal nodes.'
+visual_styles: ''
+new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.curated_links.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.curated_links.default.yml
@@ -1,0 +1,83 @@
+uuid: 87cba934-4ba5-40ba-bbbc-35f9ceaca6b4
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - field.field.assembly.curated_links.field_audience_selection
+    - field.field.assembly.curated_links.field_content_list
+    - field.field.assembly.curated_links.field_navigation_title
+    - field.field.assembly.curated_links.field_title
+  module:
+    - entity_browser_entity_form
+    - inline_entity_form
+id: assembly.curated_links.default
+targetEntityType: assembly
+bundle: curated_links
+mode: default
+content:
+  field_audience_selection:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_content_list:
+    weight: 5
+    settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      override_labels: false
+      collapsible: false
+      collapsed: false
+      allow_duplicate: false
+    third_party_settings:
+      entity_browser_entity_form:
+        entity_browser_id: _none
+    type: inline_entity_form_complex
+    region: content
+  field_navigation_title:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_title:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  visual_styles:
+    type: options_select
+    multiple: true
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  moderation_state: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.curated_links.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.curated_links.default.yml
@@ -1,0 +1,37 @@
+uuid: b7f581af-e417-41a4-bf61-dc7a13dd6987
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - field.field.assembly.curated_links.field_audience_selection
+    - field.field.assembly.curated_links.field_content_list
+    - field.field.assembly.curated_links.field_navigation_title
+    - field.field.assembly.curated_links.field_title
+id: assembly.curated_links.default
+targetEntityType: assembly
+bundle: curated_links
+mode: default
+content:
+  field_content_list:
+    weight: 1
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  field_audience_selection: true
+  field_navigation_title: true
+  name: true
+  user_id: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_audience_selection.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_audience_selection.yml
@@ -1,0 +1,21 @@
+uuid: f9823dea-47d4-4b8e-9f16-926252c600ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - field.storage.assembly.field_audience_selection
+  module:
+    - options
+id: assembly.curated_links.field_audience_selection
+field_name: field_audience_selection
+entity_type: assembly
+bundle: curated_links
+label: 'Audience Selection'
+description: 'Check the user types above to show this assembly to. Leave unchecked to show for all users.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_content_list.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_content_list.yml
@@ -1,0 +1,32 @@
+uuid: 4e2b03a0-508e-4e23-a347-d03f3f5f212c
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - assembly.assembly_type.node_reference
+    - assembly.assembly_type.static_item
+    - assembly.assembly_type.wordpress_post_reference
+    - field.storage.assembly.field_content_list
+id: assembly.curated_links.field_content_list
+field_name: field_content_list
+entity_type: assembly
+bundle: curated_links
+label: 'Content List'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:assembly'
+  handler_settings:
+    target_bundles:
+      node_reference: node_reference
+      static_item: static_item
+      wordpress_post_reference: wordpress_post_reference
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: node_reference
+field_type: entity_reference

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_navigation_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_navigation_title.yml
@@ -1,0 +1,19 @@
+uuid: fd0e99b5-9f71-4567-a782-de92ff181af4
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - field.storage.assembly.field_navigation_title
+id: assembly.curated_links.field_navigation_title
+field_name: field_navigation_title
+entity_type: assembly
+bundle: curated_links
+label: 'Navigation Title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.curated_links.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 3144ac18-6ee9-4bd1-b44b-b6b4b15d0021
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.curated_links
+    - field.storage.assembly.field_title
+id: assembly.curated_links.field_title
+field_name: field_title
+entity_type: assembly
+bundle: curated_links
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
@@ -8,6 +8,7 @@ dependencies:
     - assembly.assembly_type.content_call_to_action
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_pull_quote
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.embedded_content
     - field.storage.node.field_content
     - node.type.article
@@ -32,6 +33,7 @@ settings:
       content_call_to_action: content_call_to_action
       content_image: content_image
       content_pull_quote: content_pull_quote
+      curated_links: curated_links
       embedded_content: embedded_content
     sort:
       field: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
@@ -7,6 +7,7 @@ dependencies:
     - assembly.assembly_type.call_to_action
     - assembly.assembly_type.collection
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.eloqua_form_embed
@@ -47,6 +48,7 @@ settings:
       call_to_action: call_to_action
       collection: collection
       static_content_band: static_content_band
+      curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
@@ -8,6 +8,7 @@ dependencies:
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_with_image
     - assembly.assembly_type.cta_form
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.featured_articles
@@ -49,6 +50,7 @@ settings:
       content: content
       content_image: content_image
       static_content_band: static_content_band
+      curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.call_to_action
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.featured_articles
     - assembly.assembly_type.product_download_hero
     - assembly.assembly_type.product_download_list
@@ -29,6 +30,7 @@ settings:
   handler_settings:
     target_bundles:
       call_to_action: call_to_action
+      curated_links: curated_links
       featured_articles: featured_articles
       product_download_hero: product_download_hero
       product_download_list: product_download_list

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - assembly.assembly_type.call_to_action
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.featured_articles
@@ -38,6 +39,7 @@ settings:
     target_bundles:
       call_to_action: call_to_action
       static_content_band: static_content_band
+      curated_links: curated_links
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
       featured_articles: featured_articles

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
@@ -8,6 +8,7 @@ dependencies:
     - assembly.assembly_type.call_to_action
     - assembly.assembly_type.collection
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.events_hero
@@ -45,11 +46,12 @@ settings:
       call_to_action: call_to_action
       collection: collection
       static_content_band: static_content_band
+      curated_links: curated_links
+      featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
       events_hero: events_hero
       featured_evangelists: featured_evangelists
-      featured_products: featured_products
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/CuratedLinksBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/CuratedLinksBuild.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\rhd_assemblies\Plugin\AssemblyBuild;
+
+use Drupal\assembly\Entity\Assembly;
+use Drupal\assembly\Plugin\AssemblyBuildBase;
+use Drupal\assembly\Plugin\AssemblyBuildInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+
+/**
+ * Provides a curated list of links.
+ *
+ * @AssemblyBuild(
+ *   id = "curated_links",
+ *   types = { "curated_links" },
+ *   label = @Translation("Curated Links")
+ * )
+ */
+class CuratedLinksBuild extends AssemblyBuildBase implements AssemblyBuildInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    $parent_entity = $build['#parent']['entity'];
+    $content_list = $entity->get('field_content_list')->getValue();
+    $target_ids = [];
+    $build['links'] = [];
+
+    // Get the target ids of assemblies referenced from the Content List field.
+    foreach ($content_list as $content) {
+      $target_ids[] = $content['target_id'];
+    }
+
+    // Fetch the Assembly entities by their ids.
+    $assemblies = Assembly::loadMultiple($target_ids);
+
+    // Iterate over the assemblies and build the Link render arrays.
+    foreach ($assemblies as $assembly) {
+      $type = $assembly->bundle();
+
+      // Node Reference assembly type.
+      if ($type == 'node_reference') {
+        // Ensure we have a node id before retrieving the Node object with it.
+        if (!empty($assembly->get('field_node_reference')->getValue()[0]['target_id'])) {
+          // Get the node id and build the Node object from that id.
+          $nid = $assembly->get('field_node_reference')->getValue()[0]['target_id'];
+          $node = Node::load($nid);
+          // Retrieve the Link render array from the Node object.
+          $build['links'][] = $node->toLink()->toRenderable();
+        }
+      }
+      // Static Item assembly type.
+      else if ($type == 'static_item') {
+        // Ensure the Static Item title and URL fields are not empty before
+        // accessing them.
+        if (!empty($assembly->get('field_title')->getValue()[0]['value'])
+          && !empty($assembly->get('field_url')->getValue()[0]['uri'])) {
+          // Retrieve the title and build the URL.
+          $title = $assembly->get('field_title')->getValue()[0]['value'];
+          $url = Url::fromUri($assembly->get('field_url')->getValue()[0]['uri']);
+
+          // Build the Link render array.
+          $build['links'][] = [
+            '#title' => $title,
+            '#type' => 'link',
+            '#url' => $url
+          ];
+        }
+      }
+      // Wordpress Post Reference assembly type.
+      else if ($type == 'wordpress_post_reference') {
+        // Ensure we have the WP post id and title before accessing them.
+        if (!empty($assembly->get('field_post_reference')->getValue()[0]['target_id'])
+          && !empty($assembly->get('field_post_reference')->getValue()[0]['title'])) {
+          // Get the Wordpress post id and post title.
+          $target_id = $assembly->get('field_post_reference')->getValue()[0]['target_id'];
+          $title = $assembly->get('field_post_reference')->getValue()[0]['title'];
+          // Build the URL object to the Wordpress post.
+          $options = ['query' => ['p' => $target_id]];
+          $base_url = \Drupal::request()->getSchemeAndHttpHost();
+          $url = Url::fromUri("$base_url/blog", $options);
+
+          // Build the Link render array.
+          $build['links'][] = [
+            '#title' => $title,
+            '#type' => 'link',
+            '#url' => $url
+          ];
+        }
+      }
+    }
+  }
+
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_curated-links.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_curated-links.scss
@@ -1,0 +1,35 @@
+.curated-links {
+  @extend .container;
+  padding: 40px 15px;
+}
+
+.curated-links__list {
+  border-top: 1px solid #e9e9e9;
+  border-bottom: 1px solid #e9e9e9;
+  padding: 20px 0;
+  list-style: none;
+}
+
+.curated-links__list-item {
+  line-height: 40px;
+  padding-left: 12px;
+
+  @include desktop-small-and-down {
+    line-height: 24px;
+    margin-bottom: 8px;
+  }
+}
+
+.curated-links__list-item .fa-arrow-alt-circle-right {
+  color: #999;
+  height: 100%;
+  font-size: 8px;
+}
+
+.curated-links__list-item > a {
+  font-size: 20px;
+
+  @include desktop-small-and-down {
+    font-size: 14px;
+  }
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -65,6 +65,9 @@
 //drupal admin override
 @import "drupal-user-login-form";
 
+// Curated Links assembly type
+@import "curated-links";
+
 [data-rhd-grid="normal"] {
   display: flex;
   flex-direction: column;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--curated-links.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/assembly/assembly--curated-links.html.twig
@@ -1,0 +1,9 @@
+<div class="curated-links">
+  <h3 class="curated-links__title">{{ content.field_title }}</h3>
+
+  <ul class="curated-links__list fa-ul">
+    {% for link in elements.links %}
+      <li class="curated-links__list-item"><i class="fa-li far fa-arrow-alt-circle-right"></i> {{ link }}</li>
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
This creates a new assembly type: Curated Link (curated_link) and
includes the template and styling necessary to match the mock ups
provided by UX.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5642

### Verification Process

* You should be able to create a Curated Links assembly from the assembly reference fields on the following content types: Articles, Page, Product and Topic Pages
* You should be able to reference any of the following with the Curated Link assembly type: Node Reference, Static Item and Wordpress Post Reference

Curated Link assemblies should look like this:

**Mobile**
<img width="510" alt="screen shot 2019-02-07 at 3 31 49 pm" src="https://user-images.githubusercontent.com/7155034/52449824-834d2e80-2aed-11e9-861b-49f6d286174e.png">

**Desktop**
<img width="1257" alt="screen shot 2019-02-07 at 3 31 39 pm" src="https://user-images.githubusercontent.com/7155034/52449825-834d2e80-2aed-11e9-8767-f5431c316877.png">