### PR TITLE
Add Featured Articles to Page and Topic Page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
@@ -12,6 +12,7 @@ dependencies:
     - assembly.assembly_type.eloqua_form_embed
     - assembly.assembly_type.events_hero
     - assembly.assembly_type.events_list
+    - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_evangelists
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
@@ -54,6 +55,7 @@ settings:
       events_hero: events_hero
       events_list: events_list
       product_categories: product_categories
+      featured_articles: featured_articles
       featured_evangelists: featured_evangelists
       featured_resources: featured_resources
       hero: hero

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
@@ -11,6 +11,7 @@ dependencies:
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.events_hero
+    - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_evangelists
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
@@ -45,11 +46,12 @@ settings:
       call_to_action: call_to_action
       collection: collection
       static_content_band: static_content_band
+      featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
       events_hero: events_hero
+      featured_articles: featured_articles
       featured_evangelists: featured_evangelists
-      featured_products: featured_products
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths


### PR DESCRIPTION
This adds the Feature Articles assembly type as an available assembly
type to reference from the Sections (assembly reference) field on the Page and
Topic Page content types.

### JIRA Issue Link
* n/a

### Verification Process

Do this:

* Log in to your editor or admin account at /user/login in the Drupal PR environment

Go here:

/node/add/assembly_page

You should be able to reference Featured Article assemblies using the Sections field.

Go here:

/node/add/topic_page

You should be able to reference Featured Article assemblies using the Sections field.