### PR TITLE
[MWES-2461] Activate seckit, login_security and REST UI modules for Drupal

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -60,7 +60,8 @@
         "drupal/readonlymode": "^1.0",
         "drupal/session_limit": "^1.0@beta",
         "drupal/seckit": "1.1",
-        "drupal/login_security": "1.5"
+        "drupal/login_security": "1.5",
+        "drupal/restui": "1.16"
     },
     "require-dev": {
         "drupal/drupal-extension": "3.4.1",

--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -58,7 +58,9 @@
         "drupal/twig_tweak": "^2.1",
         "drupal/imagecache_external": "1.x-dev#901b9b0a9cfd728e76da016b56757a24fc45fde0",
         "drupal/readonlymode": "^1.0",
-        "drupal/session_limit": "^1.0@beta"
+        "drupal/session_limit": "^1.0@beta",
+        "drupal/seckit": "1.1",
+        "drupal/login_security": "1.5"
     },
     "require-dev": {
         "drupal/drupal-extension": "3.4.1",
@@ -66,7 +68,7 @@
         "behat/mink-goutte-driver": "1.2.1",
         "jcalderonzumba/gastonjs": "1.0.3",
         "drupal/coder": "8.2.12",
-        "mikey179/vfsStream": "1.6.5",
+        "mikey179/vfsstream": "1.6.5",
         "phpunit/phpunit": "4.8.36",
         "symfony/css-selector": "2.8.45",
         "behat/behat": "3.5.0",

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb2ad6375d233e350f886ff09376280f",
+    "content-hash": "5ea15d1bc361bdde1f7ed86585eeed8e",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -2879,7 +2879,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0",
-                    "datestamp": "1493401742",
+                    "datestamp": "1549603381",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6272,6 +6272,65 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "http://cgit.drupalcode.org/redirect"
+            }
+        },
+        {
+            "name": "drupal/restui",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/restui",
+                "reference": "8.x-1.16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/restui-8.x-1.16.zip",
+                "reference": "8.x-1.16",
+                "shasum": "60d2c7ecf6bb439e528c367753df9c94684b8894"
+            },
+            "require": {
+                "drupal/core": "^8.2.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.16",
+                    "datestamp": "1541330284",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "-enzo-",
+                    "homepage": "https://www.drupal.org/user/294937"
+                },
+                {
+                    "name": "clemens.tolboom",
+                    "homepage": "https://www.drupal.org/user/125814"
+                },
+                {
+                    "name": "juampynr",
+                    "homepage": "https://www.drupal.org/user/682736"
+                },
+                {
+                    "name": "klausi",
+                    "homepage": "https://www.drupal.org/user/262198"
+                }
+            ],
+            "description": "Provides a user interface to manage REST resources",
+            "homepage": "https://www.drupal.org/project/restui",
+            "support": {
+                "source": "http://cgit.drupalcode.org/restui"
             }
         },
         {

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ec7eaa67bfca2eb8f2007b100976840",
+    "content-hash": "fb2ad6375d233e350f886ff09376280f",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -1949,7 +1949,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.15",
-                    "datestamp": "1547038684",
+                    "datestamp": "1549478497",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2796,7 +2796,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0",
-                    "datestamp": "1493401742",
+                    "datestamp": "1549603381",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3596,7 +3596,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.x-dev",
-                    "datestamp": "1549378684",
+                    "datestamp": "1549379580",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -4835,6 +4835,73 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/linkit",
                 "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
+            "name": "drupal/login_security",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/login_security",
+                "reference": "8.x-1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/login_security-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "f903d4335282a178f6c73bb4f580ac876852ba73"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.5",
+                    "datestamp": "1528723384",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cYu",
+                    "homepage": "https://www.drupal.org/user/202205"
+                },
+                {
+                    "name": "deekayen",
+                    "homepage": "https://www.drupal.org/user/972"
+                },
+                {
+                    "name": "deetergp",
+                    "homepage": "https://www.drupal.org/user/1134002"
+                },
+                {
+                    "name": "ilo",
+                    "homepage": "https://www.drupal.org/user/118449"
+                },
+                {
+                    "name": "jribeiro",
+                    "homepage": "https://www.drupal.org/user/1975716"
+                },
+                {
+                    "name": "shrop",
+                    "homepage": "https://www.drupal.org/user/14767"
+                }
+            ],
+            "description": "Enable security options in the login flow of the site.",
+            "homepage": "https://www.drupal.org/project/login_security",
+            "support": {
+                "source": "http://cgit.drupalcode.org/login_security"
             }
         },
         {
@@ -6526,6 +6593,70 @@
                 "source": "http://git.drupal.org/project/search_api_solr.git",
                 "issues": "https://www.drupal.org/project/issues/search_api_solr",
                 "irc": "irc://irc.freenode.org/drupal-search-api"
+            }
+        },
+        {
+            "name": "drupal/seckit",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/seckit",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/seckit-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "bf7756d1a6a2d64ff35147b7a464cbd7f1acffcc"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1539600180",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "badjava",
+                    "homepage": "https://www.drupal.org/user/83372"
+                },
+                {
+                    "name": "jweowu",
+                    "homepage": "https://www.drupal.org/user/152788"
+                },
+                {
+                    "name": "mcdruid",
+                    "homepage": "https://www.drupal.org/user/255969"
+                },
+                {
+                    "name": "p0deje",
+                    "homepage": "https://www.drupal.org/user/529960"
+                }
+            ],
+            "description": "SecKit provides Drupal with various security-hardening options.",
+            "homepage": "https://www.drupal.org/project/seckit",
+            "keywords": [
+                "Drupal",
+                "security"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/seckit",
+                "issues": "http://drupal.org/project/issues/seckit"
             }
         },
         {

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -7,6 +7,7 @@ module:
   assembly: 0
   author: 0
   automated_cron: 0
+  ban: 0
   basewidget: 0
   basic_auth: 0
   blazy: 0
@@ -79,6 +80,7 @@ module:
   lightning_workflow: 0
   link: 0
   linkit: 0
+  login_security: 0
   markdown: 0
   media: 0
   media_entity_instagram: 0
@@ -121,6 +123,7 @@ module:
   schemata: 0
   schemata_json_schema: 0
   search: 0
+  seckit: 0
   serialization: 0
   session_limit: 0
   shortcut: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -113,6 +113,7 @@ module:
   redhat_developers: 0
   redirect: 0
   rest: 0
+  restui: 0
   rhd_assemblies: 0
   rhd_common: 0
   rhd_disqus: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
@@ -153,3 +153,4 @@ session_limit: 1.0.0-beta3
 ban: 8.6.7
 seckit: 1.1.0
 login_security: 1.5.0
+restui: 1.16.0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
@@ -150,3 +150,6 @@ lightning_media_audio: 3.5.0
 openid_connect: 1.0.0-beta5
 keycloak: 1.3.0
 session_limit: 1.0.0-beta3
+ban: 8.6.7
+seckit: 1.1.0
+login_security: 1.5.0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/login_security.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/login_security.settings.yml
@@ -1,0 +1,21 @@
+track_time: 2
+user_wrong_count: 10
+host_wrong_count: 0
+host_wrong_count_hard: 0
+activity_threshold: 10
+disable_core_login_error: 0
+notice_attempts_available: 0
+last_login_timestamp: 1
+last_access_timestamp: 0
+user_blocked_notification_emails: 'rblake@redhat.com, lkoranda@redhat.com, probinso@redhat.com, jporter@redhat.com'
+login_activity_notification_emails: 'rblake@redhat.com, lkoranda@redhat.com, probinso@redhat.com, jporter@redhat.com'
+notice_attempts_message: 'You have used @user_current_count out of @user_block_attempts login attempts. After all @user_block_attempts have been used, you will be unable to login.'
+host_soft_banned: 'This host is not allowed to log in to @site. Please contact your site administrator.'
+host_hard_banned: 'The IP address @ip is banned at @site, and will not be able to access any of its content from now on. Please contact the site administrator.'
+user_blocked: 'The user @username has been blocked due to failed login attempts.'
+user_blocked_email_subject: 'Security action: The user @username has been blocked.'
+user_blocked_email_body: 'The user @username (@edit_uri) has been blocked at @site due to the amount of failed login attempts. Please check the logs for more information.'
+login_activity_email_subject: 'Security information: Unexpected login activity has been detected at @site.'
+login_activity_email_body: 'The configured threshold of @activity_threshold logins has been reached with a total of @tracking_current_count invalid login attempts. You should review your log information about login attempts at @site.'
+_core:
+  default_config_hash: DftMffb4je4TYBtv6tAjHrXDtW3HBZ85hU9mCFJpCgM

--- a/_docker/drupal/drupal-filesystem/web/config/sync/rest.resource.entity.node.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/rest.resource.entity.node.yml
@@ -16,7 +16,6 @@ configuration:
     - GET
     - POST
     - PATCH
-    - DELETE
   formats:
     - hal_json
   authentication:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/seckit.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/seckit.settings.yml
@@ -1,0 +1,49 @@
+seckit_xss:
+  csp:
+    checkbox: false
+    report-only: false
+    default-src: ''
+    script-src: ''
+    object-src: ''
+    img-src: ''
+    media-src: ''
+    frame-src: ''
+    frame-ancestors: ''
+    child-src: ''
+    font-src: ''
+    connect-src: ''
+    report-uri: /report-csp-violation
+    policy-uri: ''
+    style-src: ''
+  x_xss:
+    seckit_x_xss_option_disable: Disabled
+    seckit_x_xss_option_0: '0'
+    seckit_x_xss_option_1: 1;
+    seckit_x_xss_option_1_block: '1; mode=block'
+    select: 3
+seckit_csrf:
+  origin: false
+  origin_whitelist: ''
+seckit_clickjacking:
+  js_css_noscript: true
+  noscript_message: 'Sorry, you need to enable JavaScript to visit this website.'
+  x_frame: '1'
+  x_frame_allow_from: ''
+seckit_ssl:
+  hsts: true
+  hsts_subdomains: false
+  hsts_max_age: 2678400
+  hsts_preload: false
+seckit_ct:
+  expect_ct: false
+  max_age: 86400
+  report_uri: ''
+  enforce: false
+seckit_various:
+  from_origin: false
+  from_origin_destination: same
+  referrer_policy: false
+  referrer_policy_policy: no-referrer-when-downgrade
+  disable_autocomplete: false
+_core:
+  default_config_hash: tEkqVdaa812lro0-CjtQGv-aeFNZ088m1F3yAbuy8hQ


### PR DESCRIPTION
This PR installs and enables the `seckit`, `login_security` and `rest ui` modules for Drupal. Additionally it provides some default configuration values.

The purpose of enabling this modules is primarily to increase the security of our Drupal instance once it is live on the Internet directly. In particular:

* `login_security` - provides us with some additional security around brute force login attempts and also sends out notifications to admins when suspicious login attempts occur
* `seckit` - provides us with better options for controlling security of things like XSS scripting attacks
* `restui` - gives us a greater oversight of what REST endpoints we're exposing and the authentication for those endpoints. Also allows us to prevent specific HTTP methods against endpoints

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2461

### Verification Process

* Ensure that the build goes green
* Ensure that there is no dangling configuration to import on Drupal
* Verify that the DELETE HTTP method is not allowed against Node REST API by visiting `/admin/config/services/rest`
* Under `/admin/config/people/login_security` verify:
  * Tracking time period is `2` hours
  * A User is allowed 10 failed login attempts during that time
  * Attack detection begins after 10 failed login attempts
  * Emails are configured to be sent to certain Drupal admins

