### PR TITLE
[URGENT] [DEVELOPER-5655] Full width video hero

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.video_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.video_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: video_hero
 label: 'Video Hero'
 description: ''
-visual_styles: ''
+visual_styles: 'full-width-video|Full width video|Video will take-up the entire section (full width video, and no title or description will be displayed)'
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_video-hero.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_video-hero.scss
@@ -80,3 +80,18 @@
     }
   }
 }
+
+.assembly-type-video_hero.full-width-video {
+  padding: 0;
+  background-color: transparent;
+  .container {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+  }
+  .background-image,
+  .content {
+    display: none;
+  }
+}


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5655 - Full width video hero](https://issues.jboss.org/browse/DEVELOPER-5655)

Updates to the Video Hero assembly:
- Added the "Full width video" that displays video edge-to-edge. No other content from the assembly shoul be displayed.

### Verification Process
I've added a full width video assembly to the bottom of this page: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37825/products/codeready-workspaces/overview