### PR TITLE
[DEVELOPER-5104] Added audience_segment to video taxonomy

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_video_resource_tags.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.video_resource.field_video_resource_tags.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_video_resource_tags
     - node.type.video_resource
+    - taxonomy.vocabulary.audience_segment
     - taxonomy.vocabulary.tags
 _core:
   default_config_hash: yO19oSy-9kcLG5Ug5S1PvufSBLs0ak0FWhylyCKM_Cw
@@ -22,9 +23,10 @@ settings:
   handler: 'default:taxonomy_term'
   handler_settings:
     target_bundles:
+      audience_segment: audience_segment
       tags: tags
     sort:
       field: _none
     auto_create: true
-    auto_create_bundle: ''
+    auto_create_bundle: audience_segment
 field_type: entity_reference


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5104 - DevNation Tech Talk Content Collection Page](https://issues.jboss.org/browse/DEVELOPER-5104)

Added the ability to tag video resources with audience segments (taxonomy) so videos can be used on Content Collection assemblies.

### Verification Process

1. Add an item to audience_segment in taxonomy
2. Go into any video resouce, and it should allow you to add the audience_segment you just created in the tag field