### PR TITLE
[DEVELOPER-5646] Invalid Render Array Keys

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -989,7 +989,15 @@ function rhdp_library_info_alter(array &$libraries, $extension) {
   }
 }
 
+/**
+ * Implements hook_preprocess_views_view_fields().
+ */
 function rhdp_preprocess_views_view_fields(&$variables) {
+  // Properly validates and retrieves the URL and string values that will be
+  // used to render links in the connectors_rest_export views_view_fields Twig
+  // template.
+  //
+  // @see views-view-fields--connectors_rest_export--connectors_rest_export_block.html.twig
   if ($variables['view']->id() == 'connectors_rest_export') {
     if (isset($variables['row'])) {
       // Get the Connector Node object.
@@ -1017,6 +1025,7 @@ function rhdp_preprocess_views_view_fields(&$variables) {
       }
     }
 
+    // Set variables that will be used to render links in the Twig template.
     $variables['connector_link_1_url'] = isset($field_connector_link_1_url) ? $field_connector_link_1_url : null;
     $variables['connector_link_1_text'] = isset($field_connector_link_1_text) ? $field_connector_link_1_text : null;
     $variables['connector_link_2_url'] = isset($field_connector_link_2_url) ? $field_connector_link_2_url : null;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -988,3 +988,39 @@ function rhdp_library_info_alter(array &$libraries, $extension) {
     }
   }
 }
+
+function rhdp_preprocess_views_view_fields(&$variables) {
+  if ($variables['view']->id() == 'connectors_rest_export') {
+    if (isset($variables['row'])) {
+      // Get the Connector Node object.
+      $connector = $variables['row']->_entity;
+
+      // field_connector_link_1
+      if ($connector->hasField('field_connector_link_1') && !empty($connector->get('field_connector_link_1')[0])) {
+        $field_connector_link_1 = $connector->get('field_connector_link_1');
+        $field_connector_link_1_url = $field_connector_link_1[0]->getUrl()->toString();
+        $field_connector_link_1_text = $connector->get('field_connector_link_1_text')->value;
+      }
+
+      // field_connector_link_2
+      if ($connector->hasField('field_connector_link_2') && !empty($connector->get('field_connector_link_2')[0])) {
+        $field_connector_link_2 = $connector->get('field_connector_link_2');
+        $field_connector_link_2_url = $field_connector_link_2[0]->getUrl()->toString();
+        $field_connector_link_2_text = $connector->get('field_connector_link_2_text')->value;
+      }
+
+      // field_connector_details_url
+      if ($connector->hasField('field_connector_details_url') && !empty($connector->get('field_connector_details_url')[0])) {
+        $field_connector_details_url = $connector->get('field_connector_details_url');
+        $field_connector_details_url_link = $field_connector_details_url[0]->getUrl()->toString();
+
+      }
+    }
+
+    $variables['connector_link_1_url'] = isset($field_connector_link_1_url) ? $field_connector_link_1_url : null;
+    $variables['connector_link_1_text'] = isset($field_connector_link_1_text) ? $field_connector_link_1_text : null;
+    $variables['connector_link_2_url'] = isset($field_connector_link_2_url) ? $field_connector_link_2_url : null;
+    $variables['connector_link_2_text'] = isset($field_connector_link_2_text) ? $field_connector_link_2_text : null;
+    $variables['connector_details_url_link'] = isset($field_connector_details_url_link) ? $field_connector_details_url_link : null;
+  }
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/views/views-view-fields--connectors_rest_export--connectors_rest_export_block.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/views/views-view-fields--connectors_rest_export--connectors_rest_export_block.html.twig
@@ -29,6 +29,7 @@
  * @see template_preprocess_views_view_fields()
  */
 #}
+
 <li class="connector" data-connectorpriority="{{ row._entity.field_connector_priority.value }}" data-connectortitle="{{ row._entity.title.value }}">
   <a href="#" class="fn-open-connector">
     <img src="{{ fields.thumbnail__target_id.content }}" alt="logo" class="connector-logo">
@@ -42,11 +43,22 @@
       </div>
       <div class="large-17 columns">
         {{ fields.field_connector_short_descriptio.content }}
-        <p class="link_1_text">
-          <a href="{{ fields.field_connector_link_1_url.content }}" class="link_1">{{ fields.field_connector_link_1.content }}</a><br>
-          <a href="{{ fields.field_connector_link_2_url.content }}" class="link_2">{{ fields.field_connector_link_2.content }}</a>
-        </p>
-        <p class="docs-link-text">For more details, view the <a href="{{ row._entity.field_connector_details_url.value }}" class="docs-link">Product Documentation</a></p>
+
+        {% if (connector_link_1_url is not empty and connector_link_1_text is not empty) or (connector_link_2_url is not empty and connector_link_2_text is not empty) %}
+          <p class="link_1_text">
+            {% if (connector_link_1_url is not empty and connector_link_1_text is not empty) %}
+              <a href="{{ connector_link_1_url }}" class="link_1">{{ connector_link_1_text }}</a><br>
+            {% endif %}
+            {% if (connector_link_2_url is not empty and connector_link_2_text is not empty) %}
+              <a href="{{ connector_link_2_url }}" class="link_2">{{ connector_link_2_text }}</a>
+            {% endif %}
+          </p>
+        {% endif %}
+
+        {# Product documentation link #}
+        {% if connector_details_url_link is not empty %}
+          <p class="docs-link-text">For more details, view the <a href="{{ connector_details_url_link }}" class="docs-link">Product Documentation</a></p>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This resolves an issue that prevented the following links (and
associated link text) from displaying for every Connector:
field_connector_link_1, field_connector_link_1_text,
field_connector_link_2, field_connector_link_2_text and
field_connector_details_url.

We were not properly accessing these values anyway, but in addition to
that, we were not verifying that any value(s) existed for any of the
fields before trying to access them, which resulted in both nothing
being rendered and many errors being thrown in the logs any time the
Connectors page was visited.

I am now verifying values exist, in a preprocessor for the
views-view-fields, and then accessingt those values and setting them in
the $variables array before accessing them in the Twig template.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5646

### Verification Process

* Visit /products/fuse/connectors
* No errors like the following should be present in the logs:

User error: "title" is an invalid render array key in Drupal\Core\Render\Element::children() (line 97 of /var/www/drupal/web/core/lib/Drupal/Core/Render/Element.php) #0

(or for any other render array key)
