### PR TITLE
[DEVELOPER-5653] Minor style fix for video resources

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_videos.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_videos.scss
@@ -75,11 +75,13 @@
       }
     }
   }
-  .field--name-field-speakers {
+  .field--name-field-speakers,
+  .field--name-field-speakers .field__item {
     display: inline-block;
   }
-  .field--name-field-speakers .field__items>.field__item:not(:only-child):not(:last-child) {
+  .field--name-field-speakers.field__items>.field__item:not(:only-child):not(:last-child) {
     &:after {
+      margin-left: -3px;
       content: ',';
     }
   }


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5653 - Broken style on video page](https://issues.jboss.org/browse/DEVELOPER-5653)

### Requirements
Style is broken when there are more than one speakers listed on a video resource page. See speakers on /videos/youtube/QYbXDp4Vu-8

### Verification Process
Visit a video page with more than one speaker ( /videos/youtube/QYbXDp4Vu-8 ), and check that the speakers' names are shown on the same line, separated by a comma.
