### PR TITLE
[DEVELOPER-5664] URL Alias permissions changes

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_admin.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_admin.yml
@@ -29,6 +29,7 @@ permissions:
   - 'create node_embargo scheduled updates'
   - 'create sub_product content'
   - 'create upstream_projects content'
+  - 'create url aliases'
   - 'delete all assembly revisions'
   - 'delete any media'
   - 'delete any multiple_node_embargo scheduled updates'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
@@ -37,7 +37,6 @@ permissions:
   - 'create rhd_microsite content'
   - 'create rhd_solution_overview content'
   - 'create topic content'
-  - 'create url aliases'
   - 'create video_resource content'
   - 'edit any article content'
   - 'edit any assembly_page content'


### PR DESCRIPTION
Content Creators can no longer edit or view URL Aliases, but I added the
ability for Content Admin to view and edit URL Aliases. NOTE: Content
Admin already had the ability to Administer URL Aliases, so this is a
somewhat redundant change in that sense. I thought it made sense to give
the permission to Content Admin though in case a quick edit had to be
made.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5664

### Verification Process

##### What Content Creators currently see on Prod a node edit form

<img width="1641" alt="screen shot 2019-02-13 at 6 46 41 pm" src="https://user-images.githubusercontent.com/7155034/52759839-3b814800-2fc2-11e9-8b80-0541001fb3d5.png">
<img width="1643" alt="screen shot 2019-02-13 at 6 46 47 pm" src="https://user-images.githubusercontent.com/7155034/52759840-3b814800-2fc2-11e9-8af0-e54b01e87fea.png">

##### What Content Creators see with in this PR environment

<img width="1643" alt="screen shot 2019-02-13 at 6 48 34 pm" src="https://user-images.githubusercontent.com/7155034/52759836-37552a80-2fc2-11e9-9b05-2ff6e2361247.png">
