### PR TITLE
[DEVELOPER-5663] Disable Taxonomy Term Views Pages (not tags)

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.taxonomy_term.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.taxonomy_term.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.storage.node.field_image
     - field.storage.node.field_short_description
     - image.style.medium
+    - taxonomy.vocabulary.tags
   module:
     - image
     - node
@@ -136,10 +137,11 @@ display:
             type: 'entity:taxonomy_term'
             fail: 'not found'
           validate_options:
+            bundles:
+              tags: tags
             access: true
             operation: view
             multiple: 0
-            bundles: {  }
           break_phrase: false
           add_table: false
           require_value: false


### PR DESCRIPTION
This disables the View pages generated by the taxonomy_term View except
for the tags taxonomy terms/vocab.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5663

### Verification Process

Go here: /taxonomy/term/8725 (8725 is a taxonomy term id under the product_categories vocabulary)

You should see the RHDP 404 Page Not Found page/template.