### PR TITLE
[MWES-2463] Integrate Drupal with Akamai Fast Purge API

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -61,7 +61,8 @@
         "drupal/session_limit": "^1.0@beta",
         "drupal/seckit": "1.1",
         "drupal/login_security": "1.5",
-        "drupal/restui": "1.16"
+        "drupal/restui": "1.16",
+        "drupal/akamai": "3.0-alpha3"
     },
     "require-dev": {
         "drupal/drupal-extension": "3.4.1",
@@ -139,6 +140,9 @@
           "drupal/openid_connect": {
             "Change Keycloak LoginForm button text": "patches/openid_connect/change-keycloak-button-text.patch",
             "Add logging to openid_connect to support SSO debug": "patches/openid_connect/openid_connect.module-logging.patch"
+          },
+          "drupal/akamai": {
+            "Change text on the button to refresh content in Akamai": "patches/akamai/change-button-text.patch"
           }
         }
     }

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ea15d1bc361bdde1f7ed86585eeed8e",
+    "content-hash": "dd8c4439dfb88fe7d8bec3412f239e70",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -81,6 +81,117 @@
             ],
             "description": "The best of Drupal, curated by Acquia",
             "time": "2019-01-16T22:23:25+00:00"
+        },
+        {
+            "name": "akamai-open/edgegrid-auth",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/akamai/AkamaiOPEN-edgegrid-php.git",
+                "reference": "7ff4d64153cf432bacfa3ffd70393bea3a930f36"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/akamai/AkamaiOPEN-edgegrid-php/zipball/7ff4d64153cf432bacfa3ffd70393bea3a930f36",
+                "reference": "7ff4d64153cf432bacfa3ffd70393bea3a930f36",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.9",
+                "kherge/box": "^2.5",
+                "phpunit/phpunit": "~4.7",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "suggest": {
+                "akamai-open/edgegrid-client": "Provide a fully featured HTTP client & CLI pre-configured with EdgeGrid authentication. (PHP 5.5+)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Akamai\\Open\\EdgeGrid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Davey Shafik",
+                    "email": "dshafik@akamai.com"
+                }
+            ],
+            "description": "Implements the Akamai {OPEN} EdgeGrid Authentication specified by https://developer.akamai.com/introduction/Client_Auth.html",
+            "homepage": "https://github.com/akamai-open/AkamaiOPEN-edgegrid-php",
+            "keywords": [
+                "Authentication",
+                "akamai",
+                "edgegrid",
+                "open"
+            ],
+            "time": "2017-09-01T07:02:30+00:00"
+        },
+        {
+            "name": "akamai-open/edgegrid-client",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/akamai/AkamaiOPEN-edgegrid-php-client.git",
+                "reference": "a368473f0f73fab96ffee03ee40d2f18694ff526"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/akamai/AkamaiOPEN-edgegrid-php-client/zipball/a368473f0f73fab96ffee03ee40d2f18694ff526",
+                "reference": "a368473f0f73fab96ffee03ee40d2f18694ff526",
+                "shasum": ""
+            },
+            "require": {
+                "akamai-open/edgegrid-auth": "^1.0.0",
+                "guzzlehttp/guzzle": "^6.1.1",
+                "league/climate": "~3.2",
+                "monolog/monolog": "^1.15",
+                "php": ">=5.5",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "apigen/apigen": "^4.0.0",
+                "friendsofphp/php-cs-fixer": "^1.9",
+                "kherge/box": "^2.5",
+                "phpunit/phpunit": "~4.7",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "bin": [
+                "bin/http"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Akamai\\Open\\EdgeGrid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Davey Shafik",
+                    "email": "dshafik@akamai.com"
+                }
+            ],
+            "description": "Implements the Akamai {OPEN} EdgeGrid Authentication specified by https://developer.akamai.com/introduction/Client_Auth.html",
+            "homepage": "https://github.com/akamai-open/AkamaiOPEN-edgegrid-php",
+            "keywords": [
+                "Authentication",
+                "akamai",
+                "client",
+                "edgegrid",
+                "open"
+            ],
+            "time": "2017-09-01T07:23:52+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -2086,6 +2197,109 @@
             }
         },
         {
+            "name": "drupal/akamai",
+            "version": "3.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/akamai",
+                "reference": "8.x-3.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/akamai-8.x-3.0-alpha3.zip",
+                "reference": "8.x-3.0-alpha3",
+                "shasum": "a6f74443717babbeb3c3daac13caf84ca58c96e5"
+            },
+            "require": {
+                "akamai-open/edgegrid-auth": "~1.0.1",
+                "akamai-open/edgegrid-client": "~1.0.0",
+                "drupal/core": "~8.5"
+            },
+            "require-dev": {
+                "drupal/key": "~1.8",
+                "drupal/purge": "3.0-beta8"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-alpha3",
+                    "datestamp": "1548627481",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                },
+                "patches_applied": {
+                    "Change text on the button to refresh content in Akamai": "patches/akamai/change-button-text.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Barrett",
+                    "homepage": "https://www.drupal.org/user/52745"
+                },
+                {
+                    "name": "Bluff",
+                    "homepage": "https://www.drupal.org/user/3535221"
+                },
+                {
+                    "name": "Cameron Tod",
+                    "homepage": "https://www.drupal.org/user/129588"
+                },
+                {
+                    "name": "Elijah Lynn",
+                    "homepage": "https://www.drupal.org/user/353190"
+                },
+                {
+                    "name": "WidgetsBurritos",
+                    "homepage": "https://www.drupal.org/user/2508346"
+                },
+                {
+                    "name": "bighappyface",
+                    "homepage": "https://www.drupal.org/user/2513682"
+                },
+                {
+                    "name": "febbraro",
+                    "homepage": "https://www.drupal.org/user/43670"
+                },
+                {
+                    "name": "jtsnow",
+                    "homepage": "https://www.drupal.org/user/171614"
+                },
+                {
+                    "name": "pobster",
+                    "homepage": "https://www.drupal.org/user/25159"
+                },
+                {
+                    "name": "tobby",
+                    "homepage": "https://www.drupal.org/user/154797"
+                }
+            ],
+            "description": "Cache Control integration with Akamai CDN. Akamai is a registered trademark of Akamai Technologies, Inc.",
+            "homepage": "https://github.com/d8-contrib-modules/akamai",
+            "keywords": [
+                "Akamai",
+                "CDN",
+                "Drupal",
+                "Purge"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/akamai"
+            }
+        },
+        {
             "name": "drupal/asciidoc",
             "version": "1.2.0",
             "source": {
@@ -2156,7 +2370,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1541691181",
+                    "datestamp": "1543440481",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -2279,7 +2493,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1549175284",
+                    "datestamp": "1549832280",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3349,12 +3563,20 @@
                     "role": "contributor"
                 },
                 {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
                     "name": "Primsi",
                     "homepage": "https://www.drupal.org/user/282629"
                 },
                 {
                     "name": "marcingy",
                     "homepage": "https://www.drupal.org/user/77320"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "samuel.mortenson",
@@ -5399,7 +5621,7 @@
                     "datestamp": "1532303581",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -6609,7 +6831,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1545483044",
+                    "datestamp": "1549962207",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6795,7 +7017,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.13",
-                    "datestamp": "1546204080",
+                    "datestamp": "1549832280",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6837,7 +7059,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.13",
-                    "datestamp": "1546204080",
+                    "datestamp": "1549832280",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8775,6 +8997,67 @@
             "time": "2018-11-11T12:22:26+00:00"
         },
         {
+            "name": "league/climate",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/climate.git",
+                "reference": "0d2fdbf8829f60f6ba6433df68d6f3fe1271b8e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/climate/zipball/0d2fdbf8829f60f6ba6433df68d6f3fe1271b8e6",
+                "reference": "0d2fdbf8829f60f6ba6433df68d6f3fe1271b8e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "psr/log": "^1.0",
+                "seld/cli-prompt": "^1.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.4",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^5.7.16"
+            },
+            "suggest": {
+                "ext-mbstring": "If ext-mbstring is not available you MUST install symfony/polyfill-mbstring"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\CLImate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Craig Duncan",
+                    "email": "git@duncanc.co.uk",
+                    "homepage": "https://github.com/duncan3dc",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Joe Tannenbaum",
+                    "email": "hey@joe.codes",
+                    "homepage": "http://joe.codes/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP's best friend for the terminal. CLImate allows you to easily output colored text, special formats, and more.",
+            "keywords": [
+                "cli",
+                "colors",
+                "command",
+                "php",
+                "terminal"
+            ],
+            "time": "2019-02-10T18:25:19+00:00"
+        },
+        {
             "name": "league/commonmark",
             "version": "0.15.7",
             "source": {
@@ -9224,6 +9507,84 @@
                 "html"
             ],
             "time": "2016-07-25T17:07:32+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2018-11-05T09:00:11+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -10000,6 +10361,54 @@
                 "phinx"
             ],
             "time": "2017-02-28T18:34:31+00:00"
+        },
+        {
+            "name": "seld/cli-prompt",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2017-03-18T11:32:45+00:00"
         },
         {
             "name": "solarium/solarium",
@@ -10893,7 +11302,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",

--- a/_docker/drupal/drupal-filesystem/patches/akamai/change-button-text.patch
+++ b/_docker/drupal/drupal-filesystem/patches/akamai/change-button-text.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Form/ClearUrlForm.php b/src/Form/ClearUrlForm.php
+index b985a97..e0d743a 100644
+--- a/src/Form/ClearUrlForm.php
++++ b/src/Form/ClearUrlForm.php
+@@ -62,7 +62,7 @@ class ClearUrlForm extends FormBase {
+     ];
+     $form['submit'] = [
+       '#type'  => 'submit',
+-      '#value' => $this->t('Refresh Akamai Cache'),
++      '#value' => $this->t('Refresh Page in Akamai'),
+     ];
+ 
+     return $form;

--- a/_docker/drupal/drupal-filesystem/web/config/sync/akamai.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/akamai.settings.yml
@@ -1,0 +1,28 @@
+version: v2
+disabled: false
+storage_method: file
+rest_api_url: 'https://xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx.luna.akamaiapis.net/'
+client_token: xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx
+client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+access_token: xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx
+edgerc_path: /credentials/akamai/edgerc
+edgerc_section: default
+basepath: 'https://developers.redhat.com'
+timeout: 5
+domain:
+  production: false
+  staging: true
+action_v2:
+  remove: true
+  invalidate: false
+action_v3:
+  delete: true
+  invalidate: false
+devel_mode: false
+mock_endpoint: 'https://akamaiopen2purgeccuproduction.docs.apiary.io'
+log_requests: true
+status_expire: 86400
+edge_cache_tag_header: false
+purge_urls_with_hostname: null
+_core:
+  default_config_hash: FS9IbMae7Ke5Vu9RLEwWkVYkOpV-CMthvHq9dVWQ1Hg

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.akamaicacheclear.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.akamaicacheclear.yml
@@ -1,0 +1,35 @@
+uuid: 419d62a1-64b8-4317-a2a0-befe74e7e470
+langcode: en
+status: true
+dependencies:
+  module:
+    - akamai
+    - user
+  theme:
+    - rhdp
+id: akamaicacheclear
+theme: rhdp
+region: rh_universal_header
+weight: -8
+provider: null
+plugin: akamai_cache_clear_block
+settings:
+  id: akamai_cache_clear_block
+  label: 'Akamai Cache Clear'
+  provider: akamai
+  label_display: '0'
+visibility:
+  user_role:
+    id: user_role
+    roles:
+      media_manager: media_manager
+      layout_manager: layout_manager
+      content_creator: content_creator
+      content_team: content_team
+      content_admin: content_admin
+      coding_resource_creator: coding_resource_creator
+      coding_resource_reviewer: coding_resource_reviewer
+      administrator: administrator
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
@@ -11,7 +11,7 @@ dependencies:
 id: universalheader
 theme: rhdp
 region: rh_universal_header
-weight: 0
+weight: -9
 provider: null
 plugin: 'system_menu_block:universal-header'
 settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
@@ -11,7 +11,7 @@ dependencies:
 id: useraccountmenu
 theme: rhdp
 region: rh_universal_header
-weight: 0
+weight: -7
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 module:
   admin_toolbar: 0
   admin_toolbar_tools: 0
+  akamai: 0
   alter_entity_autocomplete: 0
   article: 0
   asciidoc: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
@@ -149,6 +149,7 @@ readonlymode: 1.0.0
 lightning_media_audio: 3.5.0
 openid_connect: 1.0.0-beta5
 keycloak: 1.3.0
+akamai: 3.0.0-alpha3
 session_limit: 1.0.0-beta3
 ban: 8.6.7
 seckit: 1.1.0

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
@@ -1,0 +1,14 @@
+.akamai-clear-url-form {
+  margin: 0;
+
+  .form-item-message {
+    display: none;
+  }
+
+  .button {
+    font-size: 12px;
+    padding: 9px 20px;
+  }
+}
+
+

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_navigation.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_navigation.scss
@@ -24,7 +24,7 @@
   @include desktop-small {
     max-width: 1400px;
     grid-column-gap: 0;
-    grid-template-columns: 145px 1fr;
+    grid-template-columns: 145px 1fr 185px;
   }
   @media screen and (max-width: 991px) and (min-width: 768px) {
     max-width: none;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -65,6 +65,9 @@
 //drupal admin override
 @import "drupal-user-login-form";
 
+// Drupal Akamai cache clear block styles
+@import "akamai-block";
+
 // Curated Links assembly type
 @import "curated-links";
 

--- a/_docker/environments/drupal-dev/rhd.settings.php
+++ b/_docker/environments/drupal-dev/rhd.settings.php
@@ -32,7 +32,6 @@ $databases['default']['default'] = array (
 
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 $config_directories['sync'] = 'config/sync';
-$settings['install_profile'] = 'lightning';
 
 /* Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits */
 ini_set('memory_limit', '256M');
@@ -89,3 +88,10 @@ else {
     ]
   );
 }
+
+
+#
+# Set the Akamai network that purge requests should go to
+#
+$config['akamai.settings']['domain']['production'] = false;
+$config['akamai.settings']['domain']['staging'] = true;

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
-      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - /data/drupal/config/lightning:/var/www/drupal/web/config/active
       - /data/drupal-logs/lightning:/var/log/httpd

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
+      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - /data/drupal/files:/var/www/drupal/web/sites/default/files
       - /data/drupal/config/lightning:/var/www/drupal/web/config/active
       - /data/drupal-logs/lightning:/var/log/httpd

--- a/_docker/environments/drupal-production/docker-compose.yml
+++ b/_docker/environments/drupal-production/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "80:80"
     restart: 'unless-stopped'
     volumes:
+      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal/files:/var/www/drupal/web/sites/default/files

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     links:
       - drupalmysql
     volumes:
-      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - ./rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - ./rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
     volumes_from:

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     links:
       - drupalmysql
     volumes:
+      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - ./rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - ./rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
     volumes_from:

--- a/_docker/environments/drupal-pull-request/rhd.settings.php
+++ b/_docker/environments/drupal-pull-request/rhd.settings.php
@@ -8,7 +8,6 @@ if (file_exists(__DIR__ . '/rhd.settings.yml')) {
 
 $config['automated_cron.settings']['interval'] = 0;
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
-$settings['install_profile'] = 'standard';
 $config_directories['sync'] = 'sites/default/files/config_BbPlfGDu86LJqlRwhA9RbCf38VZMDijNF-owvfhuzVL73hk7BtWwy3kfIlqKLXeiSgTA-MHeVw/sync';
 
 $databases['default']['default'] = array (
@@ -77,3 +76,9 @@ else {
         ]
     );
 }
+
+#
+# Set the Akamai network that purge requests should go to
+#
+$config['akamai.settings']['domain']['production'] = false;
+$config['akamai.settings']['domain']['staging'] = true;

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "80:80"
     restart: 'unless-stopped'
     volumes:
+      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal-logs:/var/log/httpd

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - "80:80"
     restart: 'unless-stopped'
     volumes:
-      - /credentials/akamai/edgerc:/credentials/akamai/edgerc
       - /credentials/drupal/rhd.settings.yml:/var/www/drupal/web/sites/default/rhd.settings.yml
       - /credentials/drupal/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - /data/drupal-logs:/var/log/httpd


### PR DESCRIPTION
This PR brings integrates Drupal with the Akamai Fast Purge API allowing content editors to request clears of content in the Akamai Cache directly from Drupal.

Please note this functionality is **disabled** in PR and dev environments.

This PR adds a button to the top of the user navigation window when browsing content in Drupal. The button is titled "Refresh Page in Akamai". Clicking on this button will send a request to Akamai to clear the cache entry for the page being viewed. This mechanism gives content editors a way of immediately requesting changes to published.

**Note:** Until Drupal is running on Managed Platform, content editors are still reliant upon the export process running before their content will appear live on the site. I need to merge this functionality back into our current deployment so that they are in-sync before we go live on Managed Platform. 

By default, purges of content are directed at the `staging` Akamai `domain`. In our production configuration we use Drupal configuration overrides to purges to be sent to the `production` `domain`.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2463

### Verification Process

* Log in to Drupal
  * There should be no dangling configuration changes to import
  * Navigate to `admin/config/akamai/config` in Drupal and ensure:
    * CCU Credentials are stored in `.edgerc` at `/credentials/akamai/edgerc`
    * CCU version is `CCUv2`
    * Clearing action is `Remove`
    * Base Path is `https://developers.redhat.com`
    * Domain is `Staging`
* Navigate to  a content page in Drupal and click on `Refresh Page in Akamai` button
  * Ensure you get an error about not `edgerc` not existing.
    

