### PR TITLE
[DEVELOPER-5660] Homepage header fixes

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_content_with_image.scss
@@ -5,6 +5,9 @@
     text-align: left;
     padding: 100px 0;
   }
+  h2 {
+    font-size: 50px;
+  }
   .header {
     text-align: center;
     margin-bottom: 16px;


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5660 - Homepage H1/H2 adjustments](https://issues.jboss.org/browse/DEVELOPER-5660)

- Updates H2 style in rich text with image assembly to match the styles of the previously used H1 header.

### Verification Process
- H2 header in the first hero on homepage (Rich Text with Image - Homepage Most Valuable Products) should be sized: 50px.