### PR TITLE
[MWES-2944] Use Data Images from Managed Platform Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,13 @@ The scripts assume you can run the `docker` command WITHOUT sudo.
 Mac: Docker compose will have been installed as part of the Docker for Mac install.
 Linux: Follow the instructions to install the latest docker-compose [here] (https://github.com/docker/compose/releases)
 
-### Register at DockerHub
+### Request Access to the Project Data Images
 
-The project uses private Docker repositories for certain images and to access these you will need to register at [DockerHub](https://hub.docker.com). Once you have registered, give your
-username to a member of the project team who can grant you access privileges on the private repositories for the project
+The project uses private Docker repositories for certain images and to access these you will need to ask a RHDP team member with sufficient
+privileges to add your account. 
 
-Additionally you need to ensure that the Docker daemon on your local machine is authenticated with your new DockerHub account. To do this run the following:
-
-```
-docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-```
-
-For the above, replace `$DOCKER_HUB_USERNAME` and `$DOCKER_HUB_PASSWORD` with your account details.
+Please read the [following documentation](https://mojo.redhat.com/docs/DOC-1192810-developersredhatcom-giving-a-dev-team-member-access-to-data-images) on the steps required to get
+access to the internal data image repositories for this project.
 
 ### Sanity test
 At this point you must be able to run the following commands without error:

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   # Drupal production data
   drupal_data:
-   image: redhatdeveloper/drupal-data-lite:latest
+   image: docker-registry.engineering.redhat.com/developers/drupal-data:latest
    volumes:
     - /var/www/drupal/web/config/active
     - /var/www/drupal/web/sites/default/files

--- a/_docker/environments/drupal-pull-request/docker-compose.yml
+++ b/_docker/environments/drupal-pull-request/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   # Drupal production data
   drupal_data:
-   image: redhatdeveloper/drupal-data-lite:latest
+   image: docker-registry.engineering.redhat.com/developers/drupal-data:latest
    volumes:
     - /var/www/drupal/web/config/active
     - /var/www/drupal/web/sites/default/files

--- a/_docker/environments/drupal-staging/docker-compose.yml
+++ b/_docker/environments/drupal-staging/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   # Drupal production data
   drupal_data:
-    image: redhatdeveloper/drupal-data:latest
+    image: docker-registry.engineering.redhat.com/developers/drupal-data:latest
     volumes:
       - /var/www/drupal/web/config/active
       - /var/www/drupal/web/sites/default/files


### PR DESCRIPTION
This PR updates the PR environment, local dev environment and legacy stage environment to use data images generated from the Managed Platform deployment of Drupal and hosted within the internal Red Hat IT managed Docker Registry.

**THIS MUST NOT BE MERGED UNTIL MANAGED PLATFORM DEPLOYMENT IS LIVE**

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2944

### Verification Process

* Ensure that the build goes green.
