### PR TITLE
[MWES-2947] Fixed views for supporting DCP content indexing

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.user.user.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.user.user.default.yml
@@ -54,3 +54,4 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  name: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.books_rest_export.yml
@@ -17,7 +17,6 @@ dependencies:
     - field.storage.node.field_web_reader_url
     - node.type.books
   module:
-    - datetime
     - link
     - node
     - options
@@ -1135,9 +1134,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.cheat_sheets_rest_export.yml
@@ -707,9 +707,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.connectors_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.connectors_rest_export.yml
@@ -1199,7 +1199,8 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/connectors
       pager:
         type: none
@@ -1208,9 +1209,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.events_rest_query.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.events_rest_query.yml
@@ -1109,9 +1109,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.rest_products.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.rest_products.yml
@@ -680,7 +680,8 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/products
       pager:
         type: none
@@ -689,9 +690,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.taxonomy_tags_rest_export.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.taxonomy_tags_rest_export.yml
@@ -397,7 +397,8 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/taxonomy/tags
       pager:
         type: none
@@ -406,9 +407,8 @@ display:
       style:
         type: serializer
         options:
-          grouping: {  }
-          uses_fields: false
-          formats: {  }
+          formats:
+            json: json
       row:
         type: data_field
         options:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.video.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.video.yml
@@ -17,7 +17,6 @@ dependencies:
     - node.type.video_resource
   module:
     - datetime
-    - hal
     - interval
     - node
     - rest
@@ -991,14 +990,13 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/videos
       style:
         type: serializer
         options:
-          uses_fields: false
           formats:
-            hal_json: hal_json
             json: json
       defaults:
         style: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.vimeo_videos.yml
@@ -16,7 +16,6 @@ dependencies:
     - node.type.video_resource
   module:
     - datetime
-    - hal
     - interval
     - node
     - rest
@@ -997,7 +996,8 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/videos/vimeo
       pager:
         type: none
@@ -1007,7 +1007,6 @@ display:
         type: serializer
         options:
           formats:
-            hal_json: hal_json
             json: json
       row:
         type: data_field

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.youtube_videos.yml
@@ -16,7 +16,6 @@ dependencies:
     - node.type.video_resource
   module:
     - datetime
-    - hal
     - interval
     - node
     - rest
@@ -997,7 +996,8 @@ display:
     display_title: 'REST export'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       path: drupal/videos/youtube
       pager:
         type: none
@@ -1007,7 +1007,6 @@ display:
         type: serializer
         options:
           formats:
-            hal_json: hal_json
             json: json
       row:
         type: data_field


### PR DESCRIPTION
This PR makes an update to all views used by the DCP for content indexing to explicitly configure the `json` serializer. Without this none of the views work on the Managed Platform deployment of Drupal.

I do not know why this works on  the legacy Drupal deployment, but not on Managed Platform.

It also brings in some configuration that appears to have been changed in prod and not captured into Git.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2947

### Verification Process

* Ensure the build goes green
* Log in to Drupal and ensure there are no dangling configuration changes to import
* Ensure that the following URLs give you JSON output:
  * /drupal/books?_format=json
  * /drupal/events?_format=json
  * /drupal/cheat-sheets?_format=json
  * /drupal/connectors?_format=json
  * /drupal/videos?_format=json
  * /drupal/videos/vimeo?_format=json
  * /drupal/videos/youtube?_format=json
