### PR TITLE
[MWES-2910] Updates configuration checks for trailing_slash

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/src/Controller/ProductPageController.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/src/Controller/ProductPageController.php
@@ -141,7 +141,10 @@ class ProductPageController extends ControllerBase {
       // programmatically generated Product sub-page routes to this module's
       // config below in the while statement.
       $trailing_slash_settings = $this->configFactory->getEditable('trailing_slash.settings');
-      $trailing_slash_enabled = $trailing_slash_settings->get('enabled');
+      // This immutable config variable will respect config overrides. The
+      // config object returned from getEditable (above) will not.
+      $trailing_slash_settings_immutable = $this->configFactory->get('trailing_slash.settings');
+      $trailing_slash_enabled = $trailing_slash_settings_immutable->get('enabled');
 
       if ($trailing_slash_enabled === TRUE) {
         $page_links = [];
@@ -203,7 +206,9 @@ class ProductPageController extends ControllerBase {
           // trailing_slash.settings.path config item.
           $url = Url::fromUri("internal:/products/$product_code/$sub_page_url_string/");
           $url_string = $url->toString();
-          $trailing_slash_paths = $trailing_slash_settings->get('paths');
+          // We have to use $trailing_slash_settings_immutable to ensure config
+          // overrides are respected.
+          $trailing_slash_paths = $trailing_slash_settings_immutable->get('paths');
           $trailing_slash_settings->set('paths', $trailing_slash_paths . "\n$url_string");
           $title = t(strpos($sub_page_paragraph->field_overview_url->value, 'Hello') === FALSE ?
             $sub_page_paragraph->field_overview_url->value :


### PR DESCRIPTION
I forgot that there are 2 'types' of config objects in Drupal 8, and
only 1 of those support config overrides. I was using the mutable config
object to check trailing_slash config key/values, but the mutable config
objects do not respect config overrides, which was discovered as an
issue once this went to MP. I have now changed the code so that I'm only
using the mutable object to inject URLs into the trailing_slash
settings, and instead using the immutable object to retrieve
trailing_slash config key/values.

### JIRA Issue Link
* n/a

### Verification Process

* Create a config override: `$config['trailing_slash.settings']['enabled'] = TRUE`
* This should resolve the trailing slash issues for the Product pages we were experiencing on the MP stage deployment