### PR TITLE
[DEVELOPER-5704] Conditionally hide title Pages

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - entity_browser.browser.image_browser
+    - field.field.node.assembly_page.field_hide_title
     - field.field.node.assembly_page.field_meta_tags
     - field.field.node.assembly_page.field_sections
     - field.field.node.assembly_page.field_share_image
@@ -42,7 +43,7 @@ third_party_settings:
         - field_tax_region
         - field_tax_stage
       parent_name: ''
-      weight: 9
+      weight: 11
       format_type: details
       format_settings:
         label: 'Purpose Attributes'
@@ -62,14 +63,21 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_hide_title:
+    weight: 5
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_meta_tags:
-    weight: 6
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_sections:
-    weight: 4
+    weight: 6
     settings:
       form_mode: default
       override_labels: true
@@ -88,7 +96,7 @@ content:
     region: content
   field_share_image:
     type: entity_browser_file
-    weight: 5
+    weight: 7
     settings:
       entity_browser: image_browser
       field_widget_edit: true
@@ -168,26 +176,26 @@ content:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
-    weight: 7
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default
     region: content
   path:
     type: path
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 3
+    weight: 4
     region: content
     settings:
       size: 60
@@ -203,7 +211,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.assembly_page.field_hide_title
     - field.field.node.assembly_page.field_meta_tags
     - field.field.node.assembly_page.field_sections
     - field.field.node.assembly_page.field_share_image
@@ -40,6 +41,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
 hidden:
+  field_hide_title: true
   field_meta_tags: true
   field_share_image: true
   field_tax_audience_segment: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_hide_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_hide_title.yml
@@ -1,0 +1,23 @@
+uuid: 77f09ce4-fd7e-49c5-ad1c-92eadaab186e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_title
+    - node.type.assembly_page
+id: node.assembly_page.field_hide_title
+field_name: field_hide_title
+entity_type: node
+bundle: assembly_page
+label: 'Hide Title'
+description: 'If this field is checked, then the title will be hidden on the Page (not the Teaser view mode though).'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--assembly-page--full.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/node/node--assembly-page--full.html.twig
@@ -1,0 +1,121 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+{%
+  set title_tag = page ? 'h1' : 'h2'
+%}
+{{ attach_library('classy/node') }}
+<article{{ attributes.addClass(classes) }}>
+  {% if not is_front %}
+    {% if node.field_hide_title is not empty and node.field_hide_title.value == '1' %}
+      {# field_hide_title is unchecked/false, so we will not display the title. #}
+    {% else %}
+      {# field_hide_title is checked/true, so we will display the title. #}
+      <div class="container">
+        {{ title_prefix }}
+        <h1{{ title_attributes }}>{{ label }}</h1>
+        {{ title_suffix }}
+      </div>
+    {% endif %}
+  {% endif %}
+
+  {% if content.field_hero|render %}
+  {{ content.field_hero }}
+  {% endif %}
+
+  {% if display_submitted %}
+    <footer class="node__meta">
+      {{ author_picture }}
+      <div{{ author_attributes.addClass('node__submitted') }}>
+        {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
+        {{ metadata }}
+      </div>
+    </footer>
+  {% endif %}
+
+  <div{{ content_attributes.addClass('node__content row') }}>
+    {{ content|without('field_sections', 'field_hero') }}
+  </div>
+
+  {{ content.field_sections }}
+
+</article>


### PR DESCRIPTION
This creates a new boolean field on the Page content type, and makes
adds a node--assembly-page--full Twig template, which allows editors to
conditionally hide the Title field on Page nodes via a checkbox field
directly beneath the Title field on the node edit form.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5704

### Verification Process

* Open the Drupal PR environment and log in using your admin/editor credentials
* Open `/finservices/openbanking` and `/finservices/openbanking/edit` in two tabs
* You should notice that the page title on the Open Banking page displays (as it does on Prod for example)
* On the edit form, you should see a new checkbox field 'Hide Title' directly below the Title field
* Check this Hide Title checkbox and submit the form to save your changes
* Refresh the Open Banking page: `/finservices/openbanking`
* You should see that the page title is now no longer displayed