### PR TITLE
[DEVELOPER-5679] Add all assemblies to new world

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.article.field_content.yml
@@ -3,13 +3,43 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.all_products_listing
+    - assembly.assembly_type.blog_posts
+    - assembly.assembly_type.call_to_action
     - assembly.assembly_type.code_snippet
+    - assembly.assembly_type.collection
     - assembly.assembly_type.content
     - assembly.assembly_type.content_call_to_action
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_pull_quote
+    - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
+    - assembly.assembly_type.dynamic_content_feed
+    - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.eloqua_form_embed
     - assembly.assembly_type.embedded_content
+    - assembly.assembly_type.events_hero
+    - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
+    - assembly.assembly_type.featured_articles
+    - assembly.assembly_type.featured_evangelists
+    - assembly.assembly_type.featured_products
+    - assembly.assembly_type.featured_resources
+    - assembly.assembly_type.hero
+    - assembly.assembly_type.learning_paths
+    - assembly.assembly_type.node_reference
+    - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.product_categories
+    - assembly.assembly_type.product_comparison_table
+    - assembly.assembly_type.rich_text
+    - assembly.assembly_type.rich_text_columns
+    - assembly.assembly_type.sign_up_hero
+    - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
+    - assembly.assembly_type.video_hero
+    - assembly.assembly_type.videos
+    - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_content
     - node.type.article
   module:
@@ -28,13 +58,43 @@ settings:
   handler: 'default:assembly'
   handler_settings:
     target_bundles:
+      all_products_listing: all_products_listing
+      blog_posts: blog_posts
+      cta_form: cta_form
+      call_to_action: call_to_action
       code_snippet: code_snippet
+      collection: collection
       content: content
       content_call_to_action: content_call_to_action
       content_image: content_image
       content_pull_quote: content_pull_quote
+      static_content_band: static_content_band
       curated_links: curated_links
+      featured_products: featured_products
+      dynamic_content_feed: dynamic_content_feed
+      dynamic_content_list: dynamic_content_list
+      eloqua_form_embed: eloqua_form_embed
       embedded_content: embedded_content
+      events_hero: events_hero
+      events_list: events_list
+      product_categories: product_categories
+      feature: feature
+      featured_articles: featured_articles
+      featured_evangelists: featured_evangelists
+      featured_resources: featured_resources
+      hero: hero
+      learning_paths: learning_paths
+      node_reference: node_reference
+      on_page_navigation: on_page_navigation
+      product_comparison_table: product_comparison_table
+      rich_text: rich_text
+      rich_text_columns: rich_text_columns
+      content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      static_item: static_item
+      video_hero: video_hero
+      videos: videos
+      wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none
     auto_create: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.assembly_page.field_sections.yml
@@ -4,21 +4,31 @@ status: true
 dependencies:
   config:
     - assembly.assembly_type.all_products_listing
+    - assembly.assembly_type.blog_posts
     - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.code_snippet
     - assembly.assembly_type.collection
+    - assembly.assembly_type.content
+    - assembly.assembly_type.content_call_to_action
+    - assembly.assembly_type.content_image
+    - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
     - assembly.assembly_type.eloqua_form_embed
+    - assembly.assembly_type.embedded_content
     - assembly.assembly_type.events_hero
     - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
     - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_evangelists
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.learning_paths
+    - assembly.assembly_type.node_reference
     - assembly.assembly_type.on_page_navigation
     - assembly.assembly_type.product_categories
     - assembly.assembly_type.product_comparison_table
@@ -26,7 +36,10 @@ dependencies:
     - assembly.assembly_type.rich_text_columns
     - assembly.assembly_type.sign_up_hero
     - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
     - assembly.assembly_type.video_hero
+    - assembly.assembly_type.videos
+    - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_sections
     - node.type.assembly_page
   module:
@@ -46,29 +59,42 @@ settings:
   handler_settings:
     target_bundles:
       all_products_listing: all_products_listing
+      blog_posts: blog_posts
+      cta_form: cta_form
       call_to_action: call_to_action
+      code_snippet: code_snippet
       collection: collection
+      content: content
+      content_call_to_action: content_call_to_action
+      content_image: content_image
+      content_pull_quote: content_pull_quote
       static_content_band: static_content_band
       curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
       eloqua_form_embed: eloqua_form_embed
+      embedded_content: embedded_content
       events_hero: events_hero
       events_list: events_list
       product_categories: product_categories
+      feature: feature
       featured_articles: featured_articles
       featured_evangelists: featured_evangelists
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths
+      node_reference: node_reference
       on_page_navigation: on_page_navigation
       product_comparison_table: product_comparison_table
       rich_text: rich_text
       rich_text_columns: rich_text_columns
       content_with_image: content_with_image
       sign_up_hero: sign_up_hero
+      static_item: static_item
       video_hero: video_hero
+      videos: videos
+      wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none
     auto_create: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_content.yml
@@ -3,29 +3,45 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.all_products_listing
+    - assembly.assembly_type.blog_posts
     - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.code_snippet
+    - assembly.assembly_type.collection
     - assembly.assembly_type.content
+    - assembly.assembly_type.content_call_to_action
     - assembly.assembly_type.content_image
+    - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.content_with_image
     - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.eloqua_form_embed
+    - assembly.assembly_type.embedded_content
+    - assembly.assembly_type.events_hero
+    - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
     - assembly.assembly_type.featured_articles
+    - assembly.assembly_type.featured_evangelists
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.learning_paths
     - assembly.assembly_type.node_reference
     - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.product_categories
     - assembly.assembly_type.product_comparison_table
     - assembly.assembly_type.product_download_hero
     - assembly.assembly_type.product_download_list
     - assembly.assembly_type.product_try_it_hero
     - assembly.assembly_type.rich_text
     - assembly.assembly_type.rich_text_columns
+    - assembly.assembly_type.sign_up_hero
     - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
     - assembly.assembly_type.video_hero
+    - assembly.assembly_type.videos
     - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_content
     - node.type.product
@@ -45,16 +61,29 @@ settings:
   handler: 'default:assembly'
   handler_settings:
     target_bundles:
+      all_products_listing: all_products_listing
+      blog_posts: blog_posts
       cta_form: cta_form
       call_to_action: call_to_action
+      code_snippet: code_snippet
+      collection: collection
       content: content
+      content_call_to_action: content_call_to_action
       content_image: content_image
+      content_pull_quote: content_pull_quote
       static_content_band: static_content_band
       curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      eloqua_form_embed: eloqua_form_embed
+      embedded_content: embedded_content
+      events_hero: events_hero
+      events_list: events_list
+      product_categories: product_categories
+      feature: feature
       featured_articles: featured_articles
+      featured_evangelists: featured_evangelists
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths
@@ -67,7 +96,10 @@ settings:
       rich_text: rich_text
       rich_text_columns: rich_text_columns
       content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      static_item: static_item
       video_hero: video_hero
+      videos: videos
       wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_downloads_page_content.yml
@@ -3,14 +3,46 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.all_products_listing
+    - assembly.assembly_type.blog_posts
     - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.code_snippet
+    - assembly.assembly_type.collection
+    - assembly.assembly_type.content
+    - assembly.assembly_type.content_call_to_action
+    - assembly.assembly_type.content_image
+    - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
+    - assembly.assembly_type.dynamic_content_feed
+    - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.eloqua_form_embed
+    - assembly.assembly_type.embedded_content
+    - assembly.assembly_type.events_hero
+    - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
     - assembly.assembly_type.featured_articles
+    - assembly.assembly_type.featured_evangelists
+    - assembly.assembly_type.featured_products
+    - assembly.assembly_type.featured_resources
+    - assembly.assembly_type.hero
+    - assembly.assembly_type.learning_paths
+    - assembly.assembly_type.node_reference
+    - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.product_categories
+    - assembly.assembly_type.product_comparison_table
     - assembly.assembly_type.product_download_hero
     - assembly.assembly_type.product_download_list
+    - assembly.assembly_type.product_try_it_hero
     - assembly.assembly_type.rich_text
     - assembly.assembly_type.rich_text_columns
+    - assembly.assembly_type.sign_up_hero
+    - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
+    - assembly.assembly_type.video_hero
+    - assembly.assembly_type.videos
+    - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_downloads_page_content
     - node.type.product
   module:
@@ -29,14 +61,46 @@ settings:
   handler: 'default:assembly'
   handler_settings:
     target_bundles:
+      all_products_listing: all_products_listing
+      blog_posts: blog_posts
+      cta_form: cta_form
       call_to_action: call_to_action
+      code_snippet: code_snippet
+      collection: collection
+      content: content
+      content_call_to_action: content_call_to_action
+      content_image: content_image
+      content_pull_quote: content_pull_quote
+      static_content_band: static_content_band
       curated_links: curated_links
+      featured_products: featured_products
+      dynamic_content_feed: dynamic_content_feed
+      dynamic_content_list: dynamic_content_list
+      eloqua_form_embed: eloqua_form_embed
+      embedded_content: embedded_content
+      events_hero: events_hero
+      events_list: events_list
+      product_categories: product_categories
+      feature: feature
       featured_articles: featured_articles
+      featured_evangelists: featured_evangelists
+      featured_resources: featured_resources
+      hero: hero
+      learning_paths: learning_paths
+      node_reference: node_reference
+      on_page_navigation: on_page_navigation
       product_download_hero: product_download_hero
       product_download_list: product_download_list
+      product_comparison_table: product_comparison_table
+      product_try_it_hero: product_try_it_hero
       rich_text: rich_text
       rich_text_columns: rich_text_columns
       content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      static_item: static_item
+      video_hero: video_hero
+      videos: videos
+      wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none
     auto_create: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.product.field_getting_started_content.yml
@@ -3,22 +3,46 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.all_products_listing
+    - assembly.assembly_type.blog_posts
     - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.code_snippet
+    - assembly.assembly_type.collection
+    - assembly.assembly_type.content
+    - assembly.assembly_type.content_call_to_action
+    - assembly.assembly_type.content_image
+    - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.eloqua_form_embed
+    - assembly.assembly_type.embedded_content
+    - assembly.assembly_type.events_hero
+    - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
     - assembly.assembly_type.featured_articles
+    - assembly.assembly_type.featured_evangelists
+    - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.learning_paths
+    - assembly.assembly_type.node_reference
     - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.product_categories
+    - assembly.assembly_type.product_comparison_table
     - assembly.assembly_type.product_download_hero
+    - assembly.assembly_type.product_download_list
     - assembly.assembly_type.product_try_it_hero
     - assembly.assembly_type.rich_text
     - assembly.assembly_type.rich_text_columns
+    - assembly.assembly_type.sign_up_hero
     - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
     - assembly.assembly_type.video_hero
+    - assembly.assembly_type.videos
+    - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_getting_started_content
     - node.type.product
   module:
@@ -37,22 +61,46 @@ settings:
   handler: 'default:assembly'
   handler_settings:
     target_bundles:
+      all_products_listing: all_products_listing
+      blog_posts: blog_posts
+      cta_form: cta_form
       call_to_action: call_to_action
+      code_snippet: code_snippet
+      collection: collection
+      content: content
+      content_call_to_action: content_call_to_action
+      content_image: content_image
+      content_pull_quote: content_pull_quote
       static_content_band: static_content_band
       curated_links: curated_links
+      featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      eloqua_form_embed: eloqua_form_embed
+      embedded_content: embedded_content
+      events_hero: events_hero
+      events_list: events_list
+      product_categories: product_categories
+      feature: feature
       featured_articles: featured_articles
+      featured_evangelists: featured_evangelists
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths
+      node_reference: node_reference
       on_page_navigation: on_page_navigation
       product_download_hero: product_download_hero
+      product_download_list: product_download_list
+      product_comparison_table: product_comparison_table
       product_try_it_hero: product_try_it_hero
       rich_text: rich_text
       rich_text_columns: rich_text_columns
       content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      static_item: static_item
       video_hero: video_hero
+      videos: videos
+      wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none
     auto_create: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
@@ -6,24 +6,40 @@ dependencies:
     - assembly.assembly_type.all_products_listing
     - assembly.assembly_type.blog_posts
     - assembly.assembly_type.call_to_action
+    - assembly.assembly_type.code_snippet
     - assembly.assembly_type.collection
+    - assembly.assembly_type.content
+    - assembly.assembly_type.content_call_to_action
+    - assembly.assembly_type.content_image
+    - assembly.assembly_type.content_pull_quote
     - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.cta_form
     - assembly.assembly_type.curated_links
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.dynamic_content_list
+    - assembly.assembly_type.eloqua_form_embed
+    - assembly.assembly_type.embedded_content
     - assembly.assembly_type.events_hero
+    - assembly.assembly_type.events_list
+    - assembly.assembly_type.feature
     - assembly.assembly_type.featured_articles
     - assembly.assembly_type.featured_evangelists
     - assembly.assembly_type.featured_products
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.learning_paths
+    - assembly.assembly_type.node_reference
     - assembly.assembly_type.on_page_navigation
+    - assembly.assembly_type.product_categories
+    - assembly.assembly_type.product_comparison_table
     - assembly.assembly_type.rich_text
     - assembly.assembly_type.rich_text_columns
+    - assembly.assembly_type.sign_up_hero
     - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.static_item
     - assembly.assembly_type.video_hero
     - assembly.assembly_type.videos
+    - assembly.assembly_type.wordpress_post_reference
     - field.storage.node.field_sections
     - node.type.topic_page
   module:
@@ -44,25 +60,41 @@ settings:
     target_bundles:
       all_products_listing: all_products_listing
       blog_posts: blog_posts
+      cta_form: cta_form
       call_to_action: call_to_action
+      code_snippet: code_snippet
       collection: collection
+      content: content
+      content_call_to_action: content_call_to_action
+      content_image: content_image
+      content_pull_quote: content_pull_quote
       static_content_band: static_content_band
       curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      eloqua_form_embed: eloqua_form_embed
+      embedded_content: embedded_content
       events_hero: events_hero
+      events_list: events_list
+      product_categories: product_categories
+      feature: feature
       featured_articles: featured_articles
       featured_evangelists: featured_evangelists
       featured_resources: featured_resources
       hero: hero
       learning_paths: learning_paths
+      node_reference: node_reference
       on_page_navigation: on_page_navigation
+      product_comparison_table: product_comparison_table
       rich_text: rich_text
       rich_text_columns: rich_text_columns
       content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      static_item: static_item
       video_hero: video_hero
       videos: videos
+      wordpress_post_reference: wordpress_post_reference
     sort:
       field: _none
     auto_create: false


### PR DESCRIPTION
This adds all assemblies to Assembly fields on new world content types.
I have not included the Product Download List, Product Download Hero and
Product Try-It Hero assembly types to non-Product assembly fields only
because they will not work without an id to pass to download manager and
fetch the data necessary to render the assembly.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5679

### Verification Process

All assembly types can be references from all assembly reference fields on the Product, Page, Topic and Article content types with the exception of the Product Download List, Product Download Hero and Product Try-It Hero assembly types on non-Product assembly fields.