### PR TITLE
Developer 5505 followup

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -2440,7 +2440,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/beryllium",
-                "reference": "bc161a677871a12c2edf8989dbfb3078983802fa"
+                "reference": "baaeb045f5fcdcde93c0d7bfb25d244ff0bf6c35"
             },
             "require": {
                 "drupal/core": "~8.0",
@@ -2453,7 +2453,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x-dev",
-                    "datestamp": "1543243680",
+                    "datestamp": "1551366484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -2483,7 +2483,7 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/beryllium"
             },
-            "time": "2019-02-26T17:47:39+00:00"
+            "time": "2019-03-18T21:57:07+00:00"
         },
         {
             "name": "drupal/blazy",
@@ -15071,7 +15071,6 @@
                 "mock",
                 "xunit"
             ],
-            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.image_browser
     - field.field.node.assembly_page.field_hide_title
     - field.field.node.assembly_page.field_meta_tags
     - field.field.node.assembly_page.field_sections
@@ -103,13 +104,13 @@ content:
     type: entity_browser_file
     weight: 7
     settings:
-      preview_image_style: thumbnail
+      entity_browser: image_browser
+      field_widget_remove: true
       open: true
       selection_mode: selection_append
-      field_widget_replace: false
-      entity_browser: null
+      preview_image_style: thumbnail
       field_widget_edit: true
-      field_widget_remove: true
+      field_widget_replace: false
       view_mode: default
     region: fields
     third_party_settings: {  }


### PR DESCRIPTION
A couple small followup issues from the compose merge:

* Fixes the entity browser widget used for share images on page nodes
* Updates beryllium to fix the width on entity browser modal dialogs