### PR TITLE
DEVELOPER-5765 - Updated related articles view

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.default.yml
@@ -35,12 +35,12 @@ dependencies:
     - image.style.article_floated
     - node.type.article
   module:
-    - compose
     - entity_reference_revisions
     - fences
     - field_layout
     - image
     - interval
+    - layout_discovery
     - link
     - metatag
     - options
@@ -212,7 +212,7 @@ content:
     weight: 17
     label: hidden
     settings:
-      view_mode: short_teaser
+      view_mode: card
       link: false
     third_party_settings:
       fences:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
@@ -430,29 +430,35 @@
   margin-bottom: 16px;
 }
 
-#rhd-article .related-articles {
-  h5 {
-    font-weight: normal;
-    font-size: 16px;
-    line-height: 24px;
+#rhd-article .cards-wrapper {
+  display: grid;
+  grid-template-columns: repeat(3,1fr);
+  grid-gap: 4rem;
+  margin-top: 2rem;
+  
+  @media screen and (max-width: 1240px){
+    grid-template-columns: repeat(2,1fr);
+  }
+  
+  @media screen and (max-width: 768px){
+    grid-template-columns: repeat(1,1fr);
+    grid-gap: 2rem;
+  }
+  
+  .featured-article {
     margin: 0;
-    @include tablet-landscape {
-      font-size: 24px;
-      line-height: 37px;
-      margin-top: 16px;
-      margin-bottom: 12px;
+    border-top: 1px solid $gray-2;
+    font-size: 1rem;
+    p.article-card-type {
+      font-size: 1rem;
+    }
+    @media screen and (max-width: 1240px) and (min-width: 768px) {
+      .card-authors .field--name-field-headshot {
+        display: inline;
+      }
     }
   }
-  p {
-    margin-top: 0;
-    margin-bottom: 25px;
-    font-size: 14px;
-    line-height: 20px;
-    color: $dark-gray;
-    @include tablet-landscape {
-      margin-top: 14px;
-      margin-bottom: 50px;
-    }
-
+  .article-card-content {
+    line-height: 1.5;
   }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_articles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_articles.scss
@@ -1,5 +1,7 @@
-.assembly-type-featured_articles {
-
+.assembly-type-featured_articles,
+.related-articles {
+  padding-bottom: 2rem;
+  padding-top: 3rem;
   h2 {
     text-align: center;
     margin-bottom: 50px;
@@ -22,10 +24,10 @@
     justify-content: center;
   }
 
-  .article-type {
+  .article-card-type {
     text-transform: uppercase;
   }
-  .article-content {
+  .article-card-content {
     height: 300px;
     .field--name-field-short-description {
       overflow: hidden;
@@ -46,7 +48,7 @@
     font-weight: 600;
     margin: 15px 0;
   }
-  .authors {
+  .card-authors {
     .field--name-field-headshot {
       display: inline;
       float: left;
@@ -79,7 +81,7 @@
     white-space: nowrap;
     overflow: hidden;
   }
-  .article-info {
+  .article-card-info {
     bottom: 30px;
     width: 100%;
     min-height: 55px;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article--card.html.twig
@@ -67,22 +67,22 @@ other methods (such as node.delete) will result in an exception.
 #}
 
 <div{{ attributes.addClass(["featured-article"]) }}>
-  <div class="article-content">
+  <div class="article-card-content">
     {% if content.field_article_type|render %}
-      <p class="article-type"><i class="far fa-newspaper"></i> {{ content.field_article_type }} {% if node.field_article_type[0].value != 'article' %}Article {% endif %}</p>
+      <p class="article-card-type"><i class="far fa-newspaper"></i> {{ content.field_article_type }} {% if node.field_article_type[0].value != 'article' %}Article {% endif %}</p>
     {% endif %}
     {{ title_prefix }}
       <p{{ title_attributes.addClass(["tile-title"]) }}><a href="{{ url }}">{{ label }}</a></p>
     {{ title_suffix }}
     <div{{ content_attributes.addClass(article_classes) }}>{{ content.field_short_description }}</div>
   </div>
-  <div class="article-info">
+  <div class="article-card-info">
     {% if content.field_author_evangelist|render %}
-      <div class="authors">
+      <div class="card-authors">
         {{ content.field_author_evangelist }}
       </div>
     {% elseif content.field_content_author|render %}
-      <div class="authors no-image">
+      <div class="card-authors no-image">
         <div class="authors-inner">
           <div class="author short-teaser">
             <span class="author-name">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/articles/node--article.html.twig
@@ -191,13 +191,11 @@ other methods (such as node.delete) will result in an exception.
         </div>
     </div>
     {% if content.field_related_articles|render %}
-    <div class="row related-articles">
-        <div class="medium-7 large-6 columns">
-            <h4 class="related-article-header">Related Articles</h4>
-        </div>
-        <div class="medium-17 large-18 columns related-articles">
+    <div class="related-articles">
+        <h4 class="related-article-header">Related Articles</h4>
+        <div class="cards-wrapper">
             {{ content.field_related_articles }}
-        </div>
+        </div>  
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5765 - Article Content Type: Related articles view mode update](https://issues.jboss.org/browse/DEVELOPER-5765)

Per my discussion with Gina, the card style used on Featured Articles will be reused for Related Articles in any article page.

### Verification Process
1. Go to http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37894/node/205615
2. The related articles at the bottom should be displayed in a card style, without the black border at the top.