### PR TITLE
[DEVELOPER-5792] Exported dangling Katacoda configuration from production

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.default.yml
@@ -54,6 +54,7 @@ content:
     region: content
 hidden:
   body: true
+  content_moderation_control: true
   langcode: true
   links: true
   published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.teaser.yml
@@ -32,6 +32,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  content_moderation_control: true
   field_katacoda_course_audience: true
   field_katacoda_course_lessons: true
   field_katacoda_course_url_slug: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
@@ -60,5 +60,6 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
+  content_moderation_control: true
   langcode: true
   published_at: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.teaser.yml
@@ -32,6 +32,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  content_moderation_control: true
   field_katacoda_embed_id: true
   field_katacoda_scenario_author: true
   field_katacoda_scenario_time: true


### PR DESCRIPTION
This PR is simply a fresh `drush cex` using the most recent production data dump to ensure that we capture the currently dangling Katacoda configuration changes.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5792

### Verification Process

* The build should go green
* Visit the configuration synchronisation screen in Drupal and ensure there are no changes left to import