### PR TITLE
[DEVELOPER-5691] EloquaEmbedController Offset

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/src/Controller/EloquaEmbedController.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/src/Controller/EloquaEmbedController.php
@@ -23,7 +23,15 @@ class EloquaEmbedController {
         throw new NotFoundHttpException();
       }
       $field_url_array = $assembly->get('field_url')->getValue();
-      $redirect_url = ($field_url_array[0]['uri']) ? $field_url_array[0]['uri'] : FALSE;
+
+      // Verify that this array key isset before accessing it.
+      if (isset($field_url_array[0])) {
+        $redirect_url = ($field_url_array[0]['uri']) ? $field_url_array[0]['uri'] : FALSE;
+      }
+      else {
+        $redirect_url = FALSE;
+      }
+
       $build = [
         '#theme' => 'rhd_eloqua_embed_page',
         '#eloqua_json' => $eloqua_json,


### PR DESCRIPTION
This resolves a PHP notice that was spamming the logs due to trying to
access the undefined offset 0 in the ternary operator. To resolve it, I
am validating the the array isset for that key first in an if/else
statement.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5691

### Verification Process

* You can visit an eloqua embed form (ex. https://developers.redhat.com/rhd/rhd_eloqua_embed/5745) and you when you review the logs, you should not see an error like Notice: Undefined offset: 0 in Drupal\rhd_eloqua_embed\Controller\EloquaEmbedController->getForm()