### PR TITLE
[DEVELOPER-5696] Fixed logic error with null-coalescing operator

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--video-resource--learning-path-card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/learning-path/node--video-resource--learning-path-card.html.twig
@@ -5,7 +5,7 @@
     access="member" 
     duration="{{ interval }}" 
     image="{{ learning_path_card['card_image_url']|default('https://images.unsplash.com/photo-1487537708572-3c850b5e856e?ixlib=rb-0.3.5&s=50ddd59eb6185b3805e29472a70c4096&auto=format&fit=crop&w=1052&q=80') }}"
-    level="{{(node.field_difficulty.value ?? 'unclassified')|capitalize}}" 
+    level="{{ ((node.field_difficulty.value is not empty) ? node.field_difficulty.value : 'unclassified')|capitalize }}" 
     title="{{node.title.value}}" 
     modified="{{node.changed.value|date('Y-m-d')}}" 
     author="{{node.field_author.value}}"


### PR DESCRIPTION
This resolves an issue with a null-coalescing operator on 2 lines, which
both use the |capitlize filter, in
node--video-resource--learning-path-card.html.twig. An empty array was
being evaluated by the null-coalescing operator, so that was passed to
the capitalize filter, which results in an error since the capitalize
filter requires a string param.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5696

### Verification Process

* Go here: http://localhost:8888/learn/reactive-meets-microservices
* View the logs and you should not see an error like "Warning: mb_substr() expects parameter 1 to be string, array given in twig_capitalize_string_filter()"
* The top-level node divs being output for Nodes without a value for the Level field should have an attribute like `level="Unclassified"`, whereas the ones with a value set should have an attribute like `level="Advanced"`