### PR TITLE
DEVELOPER-5745 - Remove use of old SSO bridge

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/rhdp-search/rhdp-search-result.ts
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/rhdp-search/rhdp-search-result.ts
@@ -10,7 +10,7 @@ export default class RHDPSearchResult extends HTMLElement {
 
     get url() {
         const stage = window.location.href.indexOf('stage') >= 0 || window.location.href.indexOf('developers') < 0 ? '.stage' : '';
-        return !this.premium ? this._url : `https://broker${stage}.redhat.com/partner/drc/userMapping?redirect=${encodeURIComponent(this._url)}`;
+        return !this.premium ? this._url : `https://developers${stage}.redhat.com/partner/drc/userMapping?redirect=${encodeURIComponent(this._url)}`;
     }
 
     set url(val) {


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5745

### Verification Process
Go to this URL: `/search/?t=openshift&f=type~article` and hover over the links. They should reflect the new SSO bridge using download manager rather than the old one (old one would start with `broker.`)