### PR TITLE
[DEVELOPER-5758] Katacoda Breadcrumb Fix

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/node.type.katacoda_course.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/node.type.katacoda_course.yml
@@ -7,8 +7,8 @@ dependencies:
 third_party_settings:
   menu_ui:
     available_menus:
-      - main
-    parent: 'main:'
+      - katacoda-courses
+    parent: 'katacoda-courses:'
 name: 'Katacoda Course'
 type: katacoda_course
 description: 'A Katacoda Course is a collection of several Katacoda lessons'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/node.type.katacoda_individual_lesson.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/node.type.katacoda_individual_lesson.yml
@@ -7,8 +7,8 @@ dependencies:
 third_party_settings:
   menu_ui:
     available_menus:
-      - main
-    parent: 'main:'
+      - katacoda-courses
+    parent: 'katacoda-courses:'
 name: 'Katacoda Individual Lesson'
 type: katacoda_individual_lesson
 description: ''

--- a/_docker/drupal/drupal-filesystem/web/config/sync/system.menu.katacoda-courses.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/system.menu.katacoda-courses.yml
@@ -1,0 +1,8 @@
+uuid: a449b699-7382-414d-8e74-8ac032eb12aa
+langcode: en
+status: true
+dependencies: {  }
+id: katacoda-courses
+label: 'Katacoda Courses'
+description: 'Contains all of the Katacoda Courses and Katacoda Individual Scenarios and their structure'
+locked: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.katacoda_all_courses.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.katacoda_all_courses.yml
@@ -10,7 +10,7 @@ dependencies:
     - text
     - user
 id: katacoda_all_courses
-label: 'Katacoda All Courses'
+label: 'All Courses'
 module: views
 description: ''
 tag: ''
@@ -271,7 +271,7 @@ display:
           expose:
             label: ''
           granularity: second
-      title: 'Katacoda All Courses'
+      title: 'All Courses'
       header: {  }
       footer: {  }
       empty: {  }


### PR DESCRIPTION
To fix this issue with the missing intermediate breadcrumb link, we need
to add these pages, and their desired structure/nesting, to a menu. I
have created a new menu in Drupal that we can add this Katacoda content
to. When courses and individual scenarios are properly added to the
menu, this breadcrumb issue will be resolved.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5758

### Verification Process

* Go here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37913/courses/serverless
* Click on any of the Katacoda Individual Scenarios by using the Start buttons
* You should see the breadcrumbs at the top of the page properly list each step in navigation, for example: `Katacoda All Courses > Serverless Interactive Tutorials > Serverless: Simple Javascript Greeting Function`

Example: 

<img width="1158" alt="KatacodaBreadcrumbsCorrect" src="https://user-images.githubusercontent.com/7155034/56532922-93c94e80-650b-11e9-95e0-7bcb84bfefc6.png">
