### PR TITLE
DEVELOPER-5780 - Add Visual Style Field to Events Hero

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.events_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.events_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: events_hero
 label: 'Events Hero'
 description: ''
-visual_styles: ''
+visual_styles: "events-hero--dark|Dark|Displays a dark background image for the hero.\r\nevents-hero--light|Light|Displays a light background image for the hero.\r\n"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_download_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_download_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: product_download_hero
 label: 'Product Download Hero'
 description: ''
-visual_styles: "product-hero--dark|Dark|Displays a dark background image for the hero.\r\nproduct-hero--dark-centered|Dark centered|Displays a dark background with centered content.\r\nproduct-hero--light|Light|Displays a dark background image for the hero.\r\nproduct-hero--light-centered|Light centered|Displays a light background with centered content.\r\nproduct-hero--slim|Slim|Displays a vertically slimmer hero."
+visual_styles: "product-hero--dark|Dark|Displays a dark background image for the hero.\r\nproduct-hero--dark-centered|Dark centered|Displays a dark background with centered content.\r\nproduct-hero--light|Light|Displays a light background image for the hero.\r\nproduct-hero--light-centered|Light centered|Displays a light background with centered content.\r\nproduct-hero--slim|Slim|Displays a vertically slimmer hero."
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_hero.default.yml
@@ -34,7 +34,7 @@ content:
     region: content
   field_background_image:
     type: entity_browser_file
-    weight: 8
+    weight: 10
     settings:
       entity_browser: image_browser
       field_widget_edit: true
@@ -43,18 +43,10 @@ content:
       preview_image_style: thumbnail
       open: true
       selection_mode: selection_append
+      field_widget_replace: false
     region: content
     third_party_settings: {  }
   field_primary_event:
-    weight: 4
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
-  field_secondary_events:
     weight: 6
     settings:
       match_operator: CONTAINS
@@ -63,8 +55,17 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_secondary_events:
+    weight: 8
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   field_sidebar_link:
-    weight: 7
+    weight: 9
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -72,7 +73,7 @@ content:
     type: link_default
     region: content
   field_sidebar_title:
-    weight: 5
+    weight: 7
     settings:
       size: 60
       placeholder: ''
@@ -80,7 +81,7 @@ content:
     type: string_textfield
     region: content
   field_title:
-    weight: 3
+    weight: 5
     settings:
       size: 60
       placeholder: ''
@@ -89,7 +90,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
@@ -104,12 +105,17 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  visual_styles:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   moderation_state: true
   user_id: true
-  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_events-hero.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_events-hero.scss
@@ -173,7 +173,7 @@
         .author-name {
           align-self: center;
           grid-column: span 2;
-          color: $blue;
+          color: $blue !important;
           background-color: transparent;
           > .field--name-title {
             background-color: $white;
@@ -189,6 +189,20 @@
           }
         }
       }
+    }
+  }
+  &.events-hero--light {
+    background-color: $white;
+    background-image: url('https://developers.redhat.com/images/design/product-hero-light.png');
+    h1, h2, h3, h4, h5, h6, p, div {
+      color: $gray-8;
+    }
+  }
+  &.events-hero--dark {
+    background-color: $black;
+    background-image: url('/images/Event-HeroBackground.png');
+    h1, h2, h3, h4, h5, h6, p {
+      color: $white;
     }
   }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_product_hero.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_product_hero.scss
@@ -47,14 +47,14 @@
 
   &.product-hero--dark {
     background-image: url('https://developers.redhat.com/images/design/product-hero-dark.png');
-    h1, p, a, span {
+    h1,h2, h3, p, a, span {
       color: $white;
     }
   }
   &.product-hero--dark-centered {
     background-image: url('https://developers.redhat.com/images/design/product-hero-dark.png');
     text-align: center;
-    h1, p, a, span {
+    h1, h2, h3, p, a, span {
       color: $white;
     }
    .grid {


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5780 - Add Visual Style Field to Events Hero
](https://issues.jboss.org/browse/DEVELOPER-5780)

Added light/dark visual styles to the Events Hero Assembly.

### Verification Process
1. Go to http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37914/devnation/edit
2. Select a the light visual style
3. Go back to http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37914/devnation and the events hero should have a light background image with dark type
4. Repeat selecting the dark visual style
5. The hero should have a dark background image with white type