### PR TITLE
[DEVELOPER-5820] Dynamic Content List Assembly

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
@@ -92,55 +92,64 @@ class DynamicContentFeedBuild extends AssemblyBuildBase implements AssemblyBuild
 
   protected function getWordpressPosts(EntityInterface $entity, $count) {
     $category_filters = $entity->get('field_category_filter')->getValue();
-    if (empty($category_filters)) {
-      return [];
-    }
-
     $categories = [];
+
     if (!empty($category_filters)) {
       foreach ($category_filters as $category_filter) {
         $categories[] = $category_filter['value'];
       }
     }
 
-    if (count($categories)) {
-      $posts = \Drupal::service('rhd_assemblies.wordpress_api')->getContentByCategory($categories, $count);
-      return $posts;
-    }
+    $posts = \Drupal::service('rhd_assemblies.wordpress_api')->getContentByCategory($categories, $count);
 
-    return [];
+    return $posts;
   }
 
   protected function getDrupalNodes(EntityInterface $entity, $count) {
     $term_filters = $entity->get('field_drupal_term_filter')->getValue();
-    if (empty($term_filters)) {
-      return [];
-    }
-
     $terms = [];
+    $valid_node_types = [
+      'video_resource',
+      'article',
+    ];
+
     if (!empty($term_filters)) {
       foreach ($term_filters as $term_filter) {
         $terms[] = $term_filter['target_id'];
       }
     }
 
-    $valid_node_types = [
-      'video_resource',
-      'article',
-    ];
+    if (!empty($terms)) {
+      $query = \Drupal::database()->select('taxonomy_index', 't');
+      $query->fields('t', ['nid']);
+      $query->condition('t.tid', $terms, 'in');
+      $query->leftJoin('node', 'n', 'n.nid = t.nid');
+      $query->condition('n.type', $valid_node_types, 'in');
+      $query->join('node_field_data', 'nfd', 'n.nid = nfd.nid');
+      $query->condition('nfd.status', 1);
+      $query->range(0, $count);
+      $query->orderBy('nfd.created', 'desc');
+      $results = $query->execute();
+    }
+    else {
+      $query = \Drupal::entityQuery('node')
+          ->condition('status', 1)
+          ->condition('type', $valid_node_types, 'in')
+          ->range(0, $count)
+          ->sort('created' , 'DESC');
 
-    $query = \Drupal::database()->select('taxonomy_index', 't');
-    $query->fields('t', ['nid']);
-    $query->condition('t.tid', $terms, 'in');
-    $query->leftJoin('node', 'n', 'n.nid = t.nid');
-    $query->condition('n.type', $valid_node_types, 'in');
-    $query->join('node_field_data', 'nfd', 'n.nid = nfd.nid');
-    $query->condition('nfd.status', 1);
-    $query->range(0, $count);
-    $query->orderBy('nfd.created', 'desc');
-    $results = $query->execute();
+      $results = $query->execute();
+
+      // Format results in an array of stdClasses with a nid attribute.
+      foreach ($results as $key => $result) {
+        $nid = $result;
+        $results[$key] = new \stdClass;
+        $results[$key]->nid = $nid;
+      }
+    }
 
     $nodes = [];
+
     foreach ($results as $result) {
       $node_id = $result->nid;
       $nodes[$node_id] = Node::load($node_id);

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -31,7 +31,7 @@ class WordpressApi implements RemoteContentApiInterface {
     // This URL bypasses Akamai. If, for some reason, we do not want to bypass
     // Akamai, change the value of this attribute to
     // 'https://developers.redhat.com/blog'.
-    $this->apiUrl = 'https://origin-developers.redhat.com/blog';
+    $this->apiUrl = 'https://developers.redhat.com/blog';
     $this->client = $client;
   }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -31,7 +31,7 @@ class WordpressApi implements RemoteContentApiInterface {
     // This URL bypasses Akamai. If, for some reason, we do not want to bypass
     // Akamai, change the value of this attribute to
     // 'https://developers.redhat.com/blog'.
-    $this->apiUrl = 'https://developers.redhat.com/blog';
+    $this->apiUrl = 'https://origin-developers.redhat.com/blog';
     $this->client = $client;
   }
 


### PR DESCRIPTION
This commit updates the Dynamic Content List Assembly to allow pulling
all latest content, ordered by most recent, from Drupal and Wordpress.
Currently, an editor has to specify some categories in order to get
results from Wordpress or Drupal. This makes it so that when no
categories are specified, the latest content is pulled from Drupal and
Wordpress.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5820

### Verification Process
* Go here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37920/node/add/assembly_page
* Add some value for the Title field
* Click on the dropdown of Assembly types in the Sections field
* Select Dynamic Content List
* Click Add new assembly
* Add values for the Name and Title fields
* Click on the Settings Tab
* Add a URL Alias
* Click Save to save the new Dynamic Content List assembly
* Click the blue Save button to save this new page
* Visit the page

You should see:

6 of the latest Wordpress and/or Drupal posts (whichever were most recently created). You can review my test page here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37920/test-assembly-page-0430190732

At the time I created my test page, these were the most recent posts:

![DynamicContentList](https://user-images.githubusercontent.com/7155034/56969700-93880f00-6b1a-11e9-8695-90d130e9d5e4.png)
