### PR TITLE
[DEVELOPER-5768] Add URL Alias for Content Creator

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
@@ -39,6 +39,7 @@ permissions:
   - 'create rhd_microsite content'
   - 'create rhd_solution_overview content'
   - 'create topic content'
+  - 'create url aliases'
   - 'create video_resource content'
   - 'edit any article content'
   - 'edit any assembly_page content'


### PR DESCRIPTION
In DEVELOPER-5664, I removed the permission for Content Creators to
add/edit URL aliases. This was part of an effort to reduce clutter on
Node edit forms. At the time, I thought that the URL aliases for all
nodes were being generated automatically by Pathauto. That is not the
case, so this was a regression.

Furthermore, now that we are using Compose and the URL alias field is
not on the main page causing visual bloat, I do not think that this is
adding to UX clutter.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5768

### Verification Process

* Log into an account that has the Content Creator role (and not other roles like the Content Admin or Administrator roles)
* Go to any node edit/create form like: `/node/add/assembly_page`
* Click on the Settings tab
* You should see a URL Alias tab. Click on it to reveal the URL Alias form input and enter some dummy value for the URL alias
* Fill out any required fields with dummy content
* Persist the form and ensure that you can successfully create the node