### PR TITLE
[DEVELOPER-5823] Added background image field to assemblies

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_hero.default.yml
@@ -5,14 +5,17 @@ dependencies:
   config:
     - assembly.assembly_type.product_download_hero
     - entity_browser.browser.image_browser
+    - field.field.assembly.product_download_hero.field_background_image
     - field.field.assembly.product_download_hero.field_content
     - field.field.assembly.product_download_hero.field_image
     - field.field.assembly.product_download_hero.field_learn_more_link
     - field.field.assembly.product_download_hero.field_title
+    - image.style.thumbnail
   module:
     - entity_browser
     - field_layout
     - layout_discovery
+    - image
     - link
     - text
 third_party_settings:
@@ -24,6 +27,20 @@ targetEntityType: assembly
 bundle: product_download_hero
 mode: default
 content:
+  field_background_image:
+    type: entity_browser_file
+    weight: 26
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      field_widget_replace: false
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_content:
     weight: 4
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_try_it_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_try_it_hero.default.yml
@@ -5,15 +5,18 @@ dependencies:
   config:
     - assembly.assembly_type.product_try_it_hero
     - entity_browser.browser.image_browser
+    - field.field.assembly.product_try_it_hero.field_background_image
     - field.field.assembly.product_try_it_hero.field_content
     - field.field.assembly.product_try_it_hero.field_image
     - field.field.assembly.product_try_it_hero.field_learn_more_link
     - field.field.assembly.product_try_it_hero.field_title
     - field.field.assembly.product_try_it_hero.field_try_it_link
+    - image.style.thumbnail
   module:
     - entity_browser
     - field_layout
     - layout_discovery
+    - image
     - link
     - text
 third_party_settings:
@@ -25,6 +28,20 @@ targetEntityType: assembly
 bundle: product_try_it_hero
 mode: default
 content:
+  field_background_image:
+    type: entity_browser_file
+    weight: 26
+    settings:
+      entity_browser: image_browser
+      field_widget_edit: true
+      field_widget_remove: true
+      view_mode: default
+      preview_image_style: thumbnail
+      open: true
+      field_widget_replace: false
+      selection_mode: selection_append
+    region: content
+    third_party_settings: {  }
   field_content:
     weight: 4
     settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_download_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_download_hero.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - assembly.assembly_type.product_download_hero
+    - field.field.assembly.product_download_hero.field_background_image
     - field.field.assembly.product_download_hero.field_content
     - field.field.assembly.product_download_hero.field_image
     - field.field.assembly.product_download_hero.field_learn_more_link
@@ -25,6 +26,22 @@ targetEntityType: assembly
 bundle: product_download_hero
 mode: default
 content:
+  field_background_image:
+    weight: 4
+    label: hidden
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: image
+    region: content
   field_content:
     weight: 1
     label: hidden

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_try_it_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.product_try_it_hero.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - assembly.assembly_type.product_try_it_hero
+    - field.field.assembly.product_try_it_hero.field_background_image
     - field.field.assembly.product_try_it_hero.field_content
     - field.field.assembly.product_try_it_hero.field_image
     - field.field.assembly.product_try_it_hero.field_learn_more_link
@@ -26,6 +27,22 @@ targetEntityType: assembly
 bundle: product_try_it_hero
 mode: default
 content:
+  field_background_image:
+    weight: 5
+    label: hidden
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings:
+      fences:
+        fences_field_tag: none
+        fences_field_classes: ''
+        fences_field_item_tag: none
+        fences_field_item_classes: ''
+        fences_label_tag: none
+        fences_label_classes: ''
+    type: image
+    region: content
   field_content:
     weight: 1
     label: hidden

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_download_hero.field_background_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_download_hero.field_background_image.yml
@@ -1,0 +1,38 @@
+uuid: 8f952748-5812-492b-9b8c-503a317c6ed0
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.product_download_hero
+    - field.storage.assembly.field_background_image
+  module:
+    - image
+id: assembly.product_download_hero.field_background_image
+field_name: field_background_image
+entity_type: assembly
+bundle: product_download_hero
+label: 'Background image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_try_it_hero.field_background_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.product_try_it_hero.field_background_image.yml
@@ -1,0 +1,38 @@
+uuid: eed5352d-9bfe-4798-a5ac-00416156d1fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.product_try_it_hero
+    - field.storage.assembly.field_background_image
+  module:
+    - image
+id: assembly.product_try_it_hero.field_background_image
+field_name: field_background_image
+entity_type: assembly
+bundle: product_try_it_hero
+label: 'Background image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5823 - Add background image field to assemblies](https://issues.jboss.org/browse/DEVELOPER-5823)

### Verification Process
Content creator should be able to add a background image to the Product Download assembly and the Product Try-it assembly.

### UX APPROVED