### PR TITLE
[DEVELOPER-5817] Improve Katacodas Hero and Add Space to Duration

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.katacoda_individual_lesson.field_katacoda_scenario_time.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.katacoda_individual_lesson.field_katacoda_scenario_time.yml
@@ -19,5 +19,5 @@ settings:
   min: 1
   max: null
   prefix: ''
-  suffix: minutes
+  suffix: ''
 field_type: integer

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
@@ -102,17 +102,8 @@ $katacoda-grid-title-size:23px;
 .katacoda-hero {
     background:black;
     
-    
     .container {
-        padding-top:2em;
-        padding-bottom:2em;
-
-        height:470px;
-        max-height:470px;
         @include katacoda-grid-container();
-        background: url('../images/design/katacoda/rhd-katacoda-header-1410x940.jpg') no-repeat;
-        background-size: contain;
-        background-position: right;
 
         @media(max-width:$large-phone-breakpoint) {
             height:auto;
@@ -124,14 +115,17 @@ $katacoda-grid-title-size:23px;
             h1,h2,h3 {
                 color:white;
             }
+            h1 {
+              font-size: 36px;
+              font-weight: 700;
+            }
 
             // Katacoda Learn More Link in Hero
             a.katacoda-learn-more-link {
-                color:white;
-                display:block;
-                margin-top:2em;
-                &:hover {
-                    color:$gray-2;
+                color: $link-dark-background;
+
+                &:not(.button):hover {
+                    border-bottom: 1px solid #dcdcdc;
                 }
             }
         }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/node--katacoda-course.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/node--katacoda-course.html.twig
@@ -42,69 +42,24 @@
     {% endif %}
     
     <div{{ content_attributes.addClass('node__content') }}>
-        {% set base_url = render_var(url('<front>'))  %}
-          <div class="katacoda-hero individual-course">
+      <div class="katacoda-hero individual-course assembly has-background">
         <div class="container">
           <div class="content-area">
-              <h1>{{ katacoda_course_info.course_title |raw }}</h1>
-              {{ katacoda_course_info.course_description |raw }}
-              {% if (katacoda_course_info.course_read_more) is not empty %}
-                <a class="katacoda-learn-more-link" href="{{ katacoda_course_info.course_read_more }}" alt="Read More">Learn More ></a>
-              {% endif %}
+            <h1>{{ katacoda_course_info.course_title |raw }}</h1>
+            {{ katacoda_course_info.course_description |raw }}
+            {% if (katacoda_course_info.course_read_more) is not empty %}
+              <p><a class="katacoda-learn-more-link" href="{{ katacoda_course_info.course_read_more }}" alt="Read More">Learn More ></a></p>
+            {% endif %}
           </div>
          </div>
+          <div class="background" style="background-image: url(/{{ base_path ~ directory }}/images/design/katacoda/rhd-katacoda-header-1410x940.jpg);"></div>
         </div>
-        
         <div class="container">
           <div class="katacoda-lesson-grid">
             {{ content.field_katacoda_course_lessons }}
-            {#
-          {% for lesson in katacoda_course_info.courses %}
-              <div class="katacoda-lesson">
-                  <div class="info-outer">
-                      <div class="lesson--title">
-                          <a href="{{ base_url }}{{ lesson.lesson_path_alias }}">{{ lesson.title |raw }}</a>
-                      </div>
-                      <div class="lesson--time-level">
-                        {%	if lesson.scenario_time|render|trim is not empty %}
-                         <span class="time-clock"><img src="/{{ active_theme_path() }}/images/design/katacoda/clock.svg" /></span> {{ lesson.scenario_time }} minutes
-                        {% endif %}
-                        {% if (lesson.scenario_time|render|trim is not empty) and (lesson.skill_level|render|trim is not empty)  %}
-                         | 
-                        {% endif %}
-                        {% if lesson.skill_level|render|trim is not empty %}
-                          {{ lesson.skill_level }}
-                        {% endif %}
-                      </div>
-                      <div class="lesson--description">
-                              {{ lesson.description |raw }}
-                      </div>
-                      <div class="lesson--publish-meta">
-                        <p>
-                          Published {{ node.created.value|date('d M Y') }} by 
-                          {% if (lesson.display_author|render|trim) is not empty %}
-                             {{ lesson.display_author }}
-                            {% else %}
-                              {{ author_name }}
-                          {% endif %}
-                        </p>
-                        {{ user.name.0.value }}
-                      </div>
-                  </div>
-                  
-                  <div class="lesson-link">
-                          <a href="{{ base_url }}{{ lesson.lesson_path_alias }}">Start</a>
-                  </div>
-                  
-              
-              </div>
-          {% endfor %}
-          #}
           </div>
         </div>
-
-
+      </div>
     </div>
- 
   </article>
   

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/node--katacoda-individual-lesson--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/node--katacoda-individual-lesson--card.html.twig
@@ -105,7 +105,7 @@
         <h2{{ title_attributes }}><a href="{{ path('entity.node.canonical', {'node': node.nid.value}) }}">{{ node.title.value }}</a><h2/>
       </div>
       <div class="lesson--time-level">
-        <span class="time-clock fas fa-clock"></span> {{ scenario_time }}
+        <span class="time-clock fas fa-clock"></span> {{ scenario_time }} minutes
         {% if (scenario_time is not empty) and (skill_level is not empty)  %}
            | {{ skill_level }}
         {% endif %}


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5817

### Verification Process

##### Add space in duration of Katacoda Individual Scenario cards

Go here: `/courses/serverless`

You should see this:

* There should be a space between the minutes (Int value) and 'minutes' string in the Katacoda Individual Scenario cards

##### Make custom hero implementation on Katacoda Course page (default view mode) more closely match Rich Text with Image assembly type used to create hero on `/courses` route

Go here:  `/courses`
Go here:  `/courses/serverless` (open in another tab to compare)

You should see this:

* The two hero elements should very closely match
** The background image implementation should now be the same
** The padding should be the same or nearly the same between all the various elements
** The font size(s) and weight(s) should be the same


### Business/UX Stakeholder

* Gina