### PR TITLE
[DEVELOPER-5839] Make Individual Scenario Default Meet Designs

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
@@ -12,7 +12,6 @@ dependencies:
   module:
     - field_layout
     - layout_discovery
-    - options
     - user
 third_party_settings:
   field_layout:
@@ -31,30 +30,6 @@ content:
     third_party_settings: {  }
     type: string
     region: content
-  field_katacoda_scenario_author:
-    weight: 4
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_katacoda_scenario_time:
-    weight: 2
-    label: hidden
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings: {  }
-    type: number_integer
-    region: content
-  field_katacoda_skill_level:
-    weight: 3
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
   links:
     weight: 0
     region: content
@@ -63,5 +38,8 @@ content:
 hidden:
   body: true
   content_moderation_control: true
+  field_katacoda_scenario_author: true
+  field_katacoda_scenario_time: true
+  field_katacoda_skill_level: true
   langcode: true
   published_at: true

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
@@ -347,3 +347,26 @@ $katacoda-grid-title-size:23px;
 				}
     }
 }
+
+.screen-size-note {
+  text-align: center;
+
+  @media(min-width: 812px) {
+    display: none;
+  }
+
+  &__logo {
+    display: block;
+    margin: 20px auto;
+  }
+}
+
+.katacoda-lesson {
+  @media(max-width: 812px) {
+    display: none;
+  }
+}
+
+.mobile-learn-more {
+  margin: 20px auto;
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_katacoda.scss
@@ -34,6 +34,7 @@ $xtra-small-screen-breakpoint:    480px;
 
 @mixin katacoda-grid-element() {
     grid-column: span 4;
+    grid-auto-rows: 1fr;
 
     @media (max-width:$medium-screen-breakpoint) {
         grid-column: span 6;
@@ -158,6 +159,13 @@ $katacoda-grid-title-size:23px;
     flex-flow: column;
     justify-content: space-between;
     position: relative;
+    height: 100%;
+
+    .node__content {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
 
     a {
         font-weight:700;
@@ -219,6 +227,8 @@ $katacoda-grid-title-size:23px;
     .lesson-link {
 
         text-align:center;
+        align-self: flex-end;
+        width: 100%;
 
         a {
             background:$red;
@@ -252,6 +262,13 @@ $katacoda-grid-title-size:23px;
     flex-flow: column;
     justify-content: space-between;
     background:$red;
+    height: 100%;
+
+    .node__content {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
 
     a {
         color:white;
@@ -324,6 +341,8 @@ $katacoda-grid-title-size:23px;
     .katacoda-course__cta {
 				text-align:center;
         padding: 0;
+        align-self: flex-end;
+        width: 100%;
 
         a {
             display:block;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/field--node--field-katacoda-embed-id.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/katacoda/field--node--field-katacoda-embed-id.html.twig
@@ -54,10 +54,7 @@
     For the best Katacoda experience, we recommend viewing this page on a larger screen size to complete the scenario.
   </p>
   <p>On a mobile device? No problem! Feel free to explore the courses we offer.</p>
-  <a href="{{ base_url }}/courses" class="mobile-learn-more" alt="Visit Katacoda Courses">Visit Katacoda Courses</a>
+  <a href="{{ base_url }}/courses" class="button mobile-learn-more" alt="Visit Katacoda Courses">Visit Katacoda Courses</a>
 
-  <img src="{{ base_url }}/themes/custom/rhdp/images/design/katacoda/katacodalogo.png" title="Katacoda" />
+  <img src="{{ base_url }}/themes/custom/rhdp/images/design/katacoda/katacodalogo.png" title="Katacoda" class="screen-size-note__logo" />
 </div>
-  
-    
-  


### PR DESCRIPTION
These changes make the Katacoda Individual Scenario node Default view
mode meet the designs from Gina.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5839

### Business/UX Stakeholder(s)

* Gina and Joe

### Verification Process

#### Katacoda iframe is displayed on Katacoda Individual Scenario routes for viewports > 812px

Go here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37936/courses/openshift/getting-started-openshift

Do this:

* Make your viewport > 812px

You should see this:

* You should see the Katacoda scenario (iframe)
* If you scroll down, you should *not* see "Sorry for the inconvenience" and the Katacoda logo like this:

<img width="1194" alt="Screen Shot 2019-05-07 at 9 54 54 AM" src="https://user-images.githubusercontent.com/7155034/57318011-39ed8a80-70ae-11e9-9907-9b110df94bbf.png">

#### "Sorry for the inconvenience" displayed on Katacoda Individual Scenario routes for viewports < 812px

Do this:

* Make your viewport < 812px

You should see this:

<img width="703" alt="Screen Shot 2019-05-07 at 9 56 01 AM" src="https://user-images.githubusercontent.com/7155034/57318081-5a1d4980-70ae-11e9-88ba-b5ffdd6aabdb.png">

#### Katacoda Course card heights are consistent within grid

Go here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37936/courses

You should see this:

* Within each row in the grid, cards are a consistent height 

NOTE: Currently, on our PR environments, the /courses route displays "404: You've found something, but not the page you're looking for." This will be resolved once the database image is fetched from Prod, but I assume that automated process must be disable during Summit for some reason.

#### Katacoda Individual Scenario card heights are consistent within grid

Go here: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37936/courses/openshift

You should see this:

* Within each row in the grid, cards are a consistent height 