### PR TITLE
[DEVELOPER-5840]: PSA-2019-05-07

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -57,13 +57,13 @@
     "require": {
         "drupal-composer/drupal-scaffold": "2.5.4",
         "cweagans/composer-patches": "1.6.5",
-        "acquia/lightning": "~3.2.6",
+        "acquia/lightning": "~3.3.1",
         "ckeditor/indentblock": "4.11.4",
         "drupal/admin_toolbar": "1.26",
         "drupal/assembly": "1.x-dev#94645cf6617d5f375ba2cc3c060df13c88e75d8b",
         "drupal/asciidoc": "1.2",
         "drupal/ckeditor_indentblock": "1.0-beta1",
-        "drupal/core": "8.6.15",
+        "drupal/core": "8.7.1",
         "drupal/content_moderation_edit_notify": "1.0",
         "drupal/content_moderation_notifications": "3.0-rc2",
         "drupal/editor_advanced_link": "1.4",
@@ -173,7 +173,7 @@
         "composer-exit-on-patch-failure": true,
         "patches": {
           "drupal/core": {
-            "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch",
+            "Fix entity reference view": "https://www.drupal.org/files/issues/2019-04-16/2174633-views-273.patch",
             "Fix add/remove group button in Bootstrap": "https://www.drupal.org/files/issues/2018-11-13/update_rearrange_filter_handler_variable_selectors-3013216-1.patch",
             "Add disabled layout to layout_discovery and use as default in field_layout": "https://gist.githubusercontent.com/rogeralloymagnetic/512807beab2e820009d463c2b0df85ac/raw/7fc841eec763fd2bf85d47bcfc99f4df47f52d60/fieldlayoutdisableddefault.patch"
           },

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54e562f20304ede067f6f3bddf55d32d",
+    "content-hash": "7640f541a74bb0dd46f1c520e7d4cfb3",
     "packages": [
         {
             "name": "acquia/lightning",
-            "version": "3.2.7",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acquia/lightning.git",
-                "reference": "5cec672efe4005912a01044ab3e1e6843cd2b74c"
+                "reference": "c80307fb0c35c68e082fae9531c7fe5641cf6aa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acquia/lightning/zipball/5cec672efe4005912a01044ab3e1e6843cd2b74c",
-                "reference": "5cec672efe4005912a01044ab3e1e6843cd2b74c",
+                "url": "https://api.github.com/repos/acquia/lightning/zipball/c80307fb0c35c68e082fae9531c7fe5641cf6aa7",
+                "reference": "c80307fb0c35c68e082fae9531c7fe5641cf6aa7",
                 "shasum": ""
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
-                "drupal/lightning_api": "^3.5",
-                "drupal/lightning_core": "^3.9",
+                "drupal/lightning_api": "^4.1",
+                "drupal/lightning_core": "^4.1",
                 "drupal/lightning_layout": "^1.7",
                 "drupal/lightning_media": "^3.8",
-                "drupal/lightning_workflow": "^3.5",
+                "drupal/lightning_workflow": "^3.6",
                 "oomphinc/composer-installers-extender": "^1.1"
             },
             "require-dev": {
@@ -83,7 +83,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "The best of Drupal, curated by Acquia",
-            "time": "2019-03-20T18:46:52+00:00"
+            "time": "2019-05-08T21:22:43+00:00"
         },
         {
             "name": "akamai-open/edgegrid-auth",
@@ -285,16 +285,16 @@
         },
         {
             "name": "bower-asset/jquery",
-            "version": "3.3.1",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jquery/jquery-dist.git",
-                "reference": "9e8ec3d10fad04748176144f108d7355662ae75e"
+                "reference": "15bc73803f76bc53b654b9fdbbbc096f56d7c03d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jquery/jquery-dist/zipball/9e8ec3d10fad04748176144f108d7355662ae75e",
-                "reference": "9e8ec3d10fad04748176144f108d7355662ae75e",
+                "url": "https://api.github.com/repos/jquery/jquery-dist/zipball/15bc73803f76bc53b654b9fdbbbc096f56d7c03d",
+                "reference": "15bc73803f76bc53b654b9fdbbbc096f56d7c03d",
                 "shasum": null
             },
             "type": "bower-asset",
@@ -1960,16 +1960,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "v1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38"
+                "reference": "3da7c9d125591ca83944f477e65ed3d7b4617c48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/3da7c9d125591ca83944f477e65ed3d7b4617c48",
+                "reference": "3da7c9d125591ca83944f477e65ed3d7b4617c48",
                 "shasum": ""
             },
             "require": {
@@ -2038,7 +2038,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2018-11-21T00:33:13+00:00"
+            "time": "2019-04-23T08:28:24+00:00"
         },
         {
             "name": "doctrine/reflection",
@@ -3039,16 +3039,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.6.15",
+            "version": "8.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "936456cdeac25c6bbd2f55b0d587239c6a81ba86"
+                "reference": "969f24810fb31eac71dd624de593f551bd6dc2a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/936456cdeac25c6bbd2f55b0d587239c6a81ba86",
-                "reference": "936456cdeac25c6bbd2f55b0d587239c6a81ba86",
+                "url": "https://api.github.com/repos/drupal/core/zipball/969f24810fb31eac71dd624de593f551bd6dc2a3",
+                "reference": "969f24810fb31eac71dd624de593f551bd6dc2a3",
                 "shasum": ""
             },
             "require": {
@@ -3057,7 +3057,7 @@
                 "doctrine/annotations": "^1.2",
                 "doctrine/common": "^2.5",
                 "easyrdf/easyrdf": "^0.9",
-                "egulias/email-validator": "^1.2",
+                "egulias/email-validator": "^2.0",
                 "ext-date": "*",
                 "ext-dom": "*",
                 "ext-filter": "*",
@@ -3074,6 +3074,7 @@
                 "guzzlehttp/guzzle": "^6.2.1",
                 "masterminds/html5": "^2.1",
                 "paragonie/random_compat": "^1.0|^2.0",
+                "pear/archive_tar": "^1.4",
                 "php": "^5.5.9|>=7.0.8",
                 "stack/builder": "^1.0",
                 "symfony-cmf/routing": "^1.4",
@@ -3081,7 +3082,7 @@
                 "symfony/console": "~3.4.0",
                 "symfony/dependency-injection": "~3.4.26",
                 "symfony/event-dispatcher": "~3.4.0",
-                "symfony/http-foundation": "~3.4.26",
+                "symfony/http-foundation": "~3.4.27",
                 "symfony/http-kernel": "~3.4.14",
                 "symfony/polyfill-iconv": "^1.0",
                 "symfony/process": "~3.4.0",
@@ -3092,7 +3093,7 @@
                 "symfony/validator": "~3.4.0",
                 "symfony/yaml": "~3.4.5",
                 "twig/twig": "^1.38.2",
-                "typo3/phar-stream-wrapper": "^2.0.1",
+                "typo3/phar-stream-wrapper": "^2.1.1",
                 "zendframework/zend-diactoros": "^1.1",
                 "zendframework/zend-feed": "^2.4"
             },
@@ -3144,6 +3145,7 @@
                 "drupal/core-transliteration": "self.version",
                 "drupal/core-utility": "self.version",
                 "drupal/core-uuid": "self.version",
+                "drupal/core-version": "self.version",
                 "drupal/datetime": "self.version",
                 "drupal/datetime_range": "self.version",
                 "drupal/dblog": "self.version",
@@ -3161,6 +3163,7 @@
                 "drupal/history": "self.version",
                 "drupal/image": "self.version",
                 "drupal/inline_form_errors": "self.version",
+                "drupal/jsonapi": "self.version",
                 "drupal/language": "self.version",
                 "drupal/layout_builder": "self.version",
                 "drupal/layout_discovery": "self.version",
@@ -3211,9 +3214,10 @@
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",
                 "behat/mink-selenium2-driver": "1.3.x-dev",
-                "drupal/coder": "^8.2.12",
+                "drupal/coder": "^8.3.1",
                 "jcalderonzumba/gastonjs": "^1.0.2",
                 "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
+                "justinrainbow/json-schema": "^5.2",
                 "mikey179/vfsstream": "^1.2",
                 "phpspec/prophecy": "^1.7",
                 "phpunit/phpunit": "^4.8.35 || ^6.5",
@@ -3246,21 +3250,20 @@
                         "core/lib/Drupal/Component/Serialization/composer.json",
                         "core/lib/Drupal/Component/Transliteration/composer.json",
                         "core/lib/Drupal/Component/Utility/composer.json",
-                        "core/lib/Drupal/Component/Uuid/composer.json"
+                        "core/lib/Drupal/Component/Uuid/composer.json",
+                        "core/lib/Drupal/Component/Version/composer.json"
                     ],
                     "recurse": false,
                     "replace": false,
                     "merge-extra": false
                 },
                 "patches_applied": {
-                    "Fix entity reference view": "https://www.drupal.org/files/issues/2018-03-09/drupal-use_view_output_for_entityreference_options-2174633-206.patch",
+                    "Fix entity reference view": "https://www.drupal.org/files/issues/2019-04-16/2174633-views-273.patch",
                     "Fix add/remove group button in Bootstrap": "https://www.drupal.org/files/issues/2018-11-13/update_rearrange_filter_handler_variable_selectors-3013216-1.patch",
                     "Add disabled layout to layout_discovery and use as default in field_layout": "https://gist.githubusercontent.com/rogeralloymagnetic/512807beab2e820009d463c2b0df85ac/raw/7fc841eec763fd2bf85d47bcfc99f4df47f52d60/fieldlayoutdisableddefault.patch",
-                    "2998335 - [regression] \\Drupal\\user\\ContextProvider\\CurrentUserContext broken for anonymous users": "https://www.drupal.org/files/issues/2018-10-04/2998335-currentusercontext-16.patch",
-                    "3032548 - ContentModerationRouteSubscriber assumes all parameters in an entity form route contain a 'type' key": "https://www.drupal.org/files/issues/2019-02-13/3032548-2.patch",
                     "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                     "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
-                    "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-02-26/2815221-115-8.6.x.patch",
+                    "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",
                     "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2018-10-12/1356276-531.patch",
                     "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
                 }
@@ -3286,7 +3289,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2019-04-17T20:00:11+00:00"
+            "time": "2019-05-08T16:00:55+00:00"
         },
         {
             "name": "drupal/crop",
@@ -4506,70 +4509,6 @@
             }
         },
         {
-            "name": "drupal/jsonapi",
-            "version": "2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/jsonapi.git",
-                "reference": "8.x-2.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/jsonapi-8.x-2.4.zip",
-                "reference": "8.x-2.4",
-                "shasum": "5f710c1c602378748fa3b21ceec0977de62359ed"
-            },
-            "require": {
-                "drupal/core": "^8.5.11"
-            },
-            "require-dev": {
-                "drupal/schemata": "1.x-dev#8325d172e1d6880aa24073f8f751ef089282cf9a",
-                "drupal/schemata_json_schema": "*",
-                "justinrainbow/json-schema": "^5.2"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-2.4",
-                    "datestamp": "1553177584",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
-                    "name": "dawehner",
-                    "homepage": "https://www.drupal.org/user/99340"
-                },
-                {
-                    "name": "e0ipso",
-                    "homepage": "https://www.drupal.org/user/550110"
-                },
-                {
-                    "name": "gabesullice",
-                    "homepage": "https://www.drupal.org/user/2287430"
-                }
-            ],
-            "description": "Provides a JSON API standards-compliant API for accessing and manipulating Drupal content and configuration entities.",
-            "homepage": "https://www.drupal.org/project/jsonapi",
-            "support": {
-                "source": "http://cgit.drupalcode.org/jsonapi"
-            }
-        },
-        {
             "name": "drupal/keycloak",
             "version": "1.3.0",
             "source": {
@@ -4685,25 +4624,24 @@
         },
         {
             "name": "drupal/lightning_api",
-            "version": "3.5.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/lightning_api.git",
-                "reference": "8.x-3.5"
+                "reference": "8.x-4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/lightning_api-8.x-3.5.zip",
-                "reference": "8.x-3.5",
-                "shasum": "5dde8f4709af8cc4c5fc409e2e549870496438f1"
+                "url": "https://ftp.drupal.org/files/projects/lightning_api-8.x-4.1.zip",
+                "reference": "8.x-4.1",
+                "shasum": "857787e05f5a886a7512e9230a1eb4a47a7ae722"
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
                 "drupal/consumers": "^1.9",
-                "drupal/core": "~8.0",
-                "drupal/jsonapi": "^2.3",
-                "drupal/lightning_core": "^2.14 || ^3.8 || ^4.0-alpha1",
+                "drupal/core": "*",
+                "drupal/lightning_core": "^4.0",
                 "drupal/openapi": "^1.0-beta2",
                 "drupal/openapi_ui_redoc": "^1.0",
                 "drupal/openapi_ui_swagger": "^1.0",
@@ -4713,18 +4651,17 @@
             },
             "require-dev": {
                 "acquia/lightning_dev": "dev-8.x-1.x",
-                "drupal/lightning_core": "*",
                 "drupal/schema_metatag": "^1.3"
             },
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-3.x": "3.x-dev",
-                    "dev-8.x-3.x": "3.x-dev"
+                    "dev-4.x": "4.x-dev",
+                    "dev-8.x-4.x": "4.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.5",
-                    "datestamp": "1552672085",
+                    "version": "8.x-4.1",
+                    "datestamp": "1556765584",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4758,7 +4695,10 @@
             "autoload": {
                 "psr-4": {
                     "Drupal\\Tests\\lightning_api\\": "tests/src"
-                }
+                },
+                "classmap": [
+                    "src/LightningApiServiceProvider.php"
+                ]
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "scripts": {
@@ -4800,29 +4740,29 @@
             "description": "Progressive decoupling? No problem.",
             "homepage": "https://www.drupal.org/project/lightning_api",
             "support": {
-                "source": "http://cgit.drupalcode.org/lightning_api"
+                "source": "https://git.drupalcode.org/project/lightning_api"
             }
         },
         {
             "name": "drupal/lightning_core",
-            "version": "3.9.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/lightning_core.git",
-                "reference": "8.x-3.9"
+                "reference": "8.x-4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/lightning_core-8.x-3.9.zip",
-                "reference": "8.x-3.9",
-                "shasum": "0b862c3194d2394ac19a53b63b679be1c35331e0"
+                "url": "https://ftp.drupal.org/files/projects/lightning_core-8.x-4.1.zip",
+                "reference": "8.x-4.1",
+                "shasum": "8dd8f0df5ee2064e60ba0e4a28fc6aea9cc8895b"
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
                 "drupal/acquia_connector": "^1.1",
-                "drupal/contact_storage": "^1.0",
-                "drupal/core": "~8.6.13",
+                "drupal/contact_storage": "1.0-beta9",
+                "drupal/core": "~8.7.1",
                 "drupal/metatag": "^1.8",
                 "drupal/pathauto": "^1.3",
                 "drupal/search_api": "^1.0",
@@ -4843,12 +4783,12 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-3.x": "3.x-dev",
-                    "dev-8.x-3.x": "3.x-dev"
+                    "dev-4.x": "4.x-dev",
+                    "dev-8.x-4.x": "4.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.9",
-                    "datestamp": "1553105284",
+                    "version": "8.x-4.1",
+                    "datestamp": "1557341581",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4884,12 +4824,13 @@
                     "npm-asset"
                 ],
                 "patches": {
+                    "drupal/contact_storage": {
+                        "3038668 - Fix tests following a change in Drupal 8.7.0: #2976035": "https://www.drupal.org/files/issues/2019-03-10/3038668-25.patch"
+                    },
                     "drupal/core": {
-                        "2998335 - [regression] \\Drupal\\user\\ContextProvider\\CurrentUserContext broken for anonymous users": "https://www.drupal.org/files/issues/2018-10-04/2998335-currentusercontext-16.patch",
-                        "3032548 - ContentModerationRouteSubscriber assumes all parameters in an entity form route contain a 'type' key": "https://www.drupal.org/files/issues/2019-02-13/3032548-2.patch",
                         "2869592 - Disabled update module shouldn't produce a status report warning": "https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch",
                         "2885441 - EntityReferenceAutocompleteWidget should define its size setting as an integer": "https://www.drupal.org/files/issues/2885441-2.patch",
-                        "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-02-26/2815221-115-8.6.x.patch",
+                        "2815221 - Add quickedit to the latest-revision route": "https://www.drupal.org/files/issues/2019-03-05/2815221-116.patch",
                         "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2018-10-12/1356276-531.patch",
                         "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch"
                     }
@@ -4942,7 +4883,7 @@
             "description": "Shared functionality for the Lightning distribution.",
             "homepage": "https://www.drupal.org/project/lightning_core",
             "support": {
-                "source": "http://cgit.drupalcode.org/lightning_core"
+                "source": "https://git.drupalcode.org/project/lightning_core"
             }
         },
         {
@@ -5216,24 +5157,24 @@
         },
         {
             "name": "drupal/lightning_workflow",
-            "version": "3.5.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/lightning_workflow.git",
-                "reference": "8.x-3.5"
+                "reference": "8.x-3.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/lightning_workflow-8.x-3.5.zip",
-                "reference": "8.x-3.5",
-                "shasum": "5d290862b9bde85a60b1388a069c75bba01a5ebc"
+                "url": "https://ftp.drupal.org/files/projects/lightning_workflow-8.x-3.6.zip",
+                "reference": "8.x-3.6",
+                "shasum": "cb2d4e7116cb209ce811f6820af95c7dc20ea5c4"
             },
             "require": {
                 "cweagans/composer-patches": "^1.6.4",
                 "drupal-composer/drupal-scaffold": "^2.0.0",
                 "drupal/core": "*",
                 "drupal/diff": "^1.0",
-                "drupal/lightning_core": "^3.8 || ^4.0-alpha1",
+                "drupal/lightning_core": "^3.9 || ^4.0-beta1",
                 "drupal/moderation_dashboard": "^1.0",
                 "drupal/moderation_sidebar": "^1.0",
                 "oomphinc/composer-installers-extender": "^1.1"
@@ -5252,8 +5193,8 @@
                     "dev-8.x-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.5",
-                    "datestamp": "1552917185",
+                    "version": "8.x-3.6",
+                    "datestamp": "1554389281",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5328,7 +5269,7 @@
             "description": "Tools to improve your content workflow.",
             "homepage": "https://www.drupal.org/project/lightning_workflow",
             "support": {
-                "source": "http://cgit.drupalcode.org/lightning_workflow"
+                "source": "https://git.drupalcode.org/project/lightning_workflow"
             }
         },
         {
@@ -6586,17 +6527,17 @@
         },
         {
             "name": "drupal/pathauto",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/pathauto.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "115d5998d7636a03e26c7ce34261b65809d53965"
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "ddfb047ae04ca2ddf475d65f6c09bceb44169e25"
             },
             "require": {
                 "drupal/core": "^8.5",
@@ -6609,8 +6550,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1536407884",
+                    "version": "8.x-1.4",
+                    "datestamp": "1554239887",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6642,7 +6583,7 @@
             "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
             "homepage": "https://www.drupal.org/project/pathauto",
             "support": {
-                "source": "http://cgit.drupalcode.org/pathauto"
+                "source": "https://git.drupalcode.org/project/pathauto"
             }
         },
         {
@@ -6882,17 +6823,17 @@
         },
         {
             "name": "drupal/schemata",
-            "version": "1.0.0-alpha5",
+            "version": "1.0.0-alpha6",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/schemata.git",
-                "reference": "8.x-1.0-alpha5"
+                "reference": "8.x-1.0-alpha6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/schemata-8.x-1.0-alpha5.zip",
-                "reference": "8.x-1.0-alpha5",
-                "shasum": "e7eddc8334a168d30cffaa968d478c84581369cf"
+                "url": "https://ftp.drupal.org/files/projects/schemata-8.x-1.0-alpha6.zip",
+                "reference": "8.x-1.0-alpha6",
+                "shasum": "3a9f035e708727922388664458cde6294f9ca05b"
             },
             "require": {
                 "drupal/core": "*"
@@ -6909,8 +6850,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-alpha5",
-                    "datestamp": "1537628284",
+                    "version": "8.x-1.0-alpha6",
+                    "datestamp": "1556654285",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -6985,7 +6926,7 @@
         },
         {
             "name": "drupal/schemata_json_schema",
-            "version": "1.0.0-alpha5",
+            "version": "1.0.0-alpha6",
             "require": {
                 "drupal/core": "~8.0",
                 "drupal/schemata": "self.version"
@@ -6996,8 +6937,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-alpha5",
-                    "datestamp": "1537628284",
+                    "version": "8.x-1.0-alpha6",
+                    "datestamp": "1556654285",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -7045,7 +6986,7 @@
             "description": "Provides a data models for entity types and bundles in JSON schema format.",
             "homepage": "https://www.drupal.org/project/schemata",
             "support": {
-                "source": "http://cgit.drupalcode.org/schemata"
+                "source": "https://git.drupalcode.org/project/schemata"
             }
         },
         {
@@ -7318,17 +7259,17 @@
         },
         {
             "name": "drupal/simple_oauth",
-            "version": "3.14.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_oauth.git",
-                "reference": "8.x-3.14"
+                "reference": "8.x-3.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_oauth-8.x-3.14.zip",
-                "reference": "8.x-3.14",
-                "shasum": "825f726e7f033150d4702ad773259ab7deb3fb6c"
+                "url": "https://ftp.drupal.org/files/projects/simple_oauth-8.x-3.15.zip",
+                "reference": "8.x-3.15",
+                "shasum": "2fb00dc960270cddb9403073f5165f9155304c89"
             },
             "require": {
                 "drupal/consumers": "^1.2",
@@ -7341,8 +7282,8 @@
                     "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.14",
-                    "datestamp": "1549832280",
+                    "version": "8.x-3.15",
+                    "datestamp": "1556659981",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7367,12 +7308,12 @@
             "description": "The Simple OAuth module for Drupal",
             "homepage": "https://www.drupal.org/project/simple_oauth",
             "support": {
-                "source": "http://cgit.drupalcode.org/simple_oauth"
+                "source": "https://git.drupalcode.org/project/simple_oauth"
             }
         },
         {
             "name": "drupal/simple_oauth_extras",
-            "version": "3.14.0",
+            "version": "3.15.0",
             "require": {
                 "drupal/core": "~8.0",
                 "drupal/simple_oauth": "self.version"
@@ -7383,8 +7324,8 @@
                     "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-3.14",
-                    "datestamp": "1549832280",
+                    "version": "8.x-3.15",
+                    "datestamp": "1556659981",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7408,7 +7349,7 @@
             "description": "OAuth2 extra access grants.",
             "homepage": "https://www.drupal.org/project/simple_oauth",
             "support": {
-                "source": "http://cgit.drupalcode.org/simple_oauth"
+                "source": "https://git.drupalcode.org/project/simple_oauth"
             }
         },
         {
@@ -8299,24 +8240,29 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "1.2.15",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "758a77525bdaabd6c0f5669176bd4361cb2dda9e"
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/758a77525bdaabd6c0f5669176bd4361cb2dda9e",
-                "reference": "758a77525bdaabd6c0f5669176bd4361cb2dda9e",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.3.3"
+                "php": ">= 5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.24"
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.35||^5.7||^6.0",
+                "satooshi/php-coveralls": "^1.0.1"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
             },
             "type": "library",
             "extra": {
@@ -8325,8 +8271,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Egulias\\": "src/"
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -8338,7 +8284,7 @@
                     "name": "Eduardo Gulias Davis"
                 }
             ],
-            "description": "A library for validating emails",
+            "description": "A library for validating emails against several RFCs",
             "homepage": "https://github.com/egulias/EmailValidator",
             "keywords": [
                 "email",
@@ -8347,7 +8293,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2018-09-25T20:59:41+00:00"
+            "time": "2018-12-04T22:38:24+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -9713,16 +9659,16 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "7.3.2",
+            "version": "7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "b71f382cd76e3f6905dfc53ef8148b3eebe1fd41"
+                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/b71f382cd76e3f6905dfc53ef8148b3eebe1fd41",
-                "reference": "b71f382cd76e3f6905dfc53ef8148b3eebe1fd41",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
+                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
                 "shasum": ""
             },
             "require": {
@@ -9786,7 +9732,7 @@
                 "secure",
                 "server"
             ],
-            "time": "2018-11-21T21:42:43+00:00"
+            "time": "2019-05-05T09:22:01+00:00"
         },
         {
             "name": "madcoda/php-youtube-api",
@@ -10266,6 +10212,218 @@
             "time": "2019-01-03T20:59:08+00:00"
         },
         {
+            "name": "pear/archive_tar",
+            "version": "1.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Archive_Tar.git",
+                "reference": "7e48add6f8edc3027dd98ad15964b1a28fd0c845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/7e48add6f8edc3027dd98ad15964b1a28fd0c845",
+                "reference": "7e48add6f8edc3027dd98ad15964b1a28fd0c845",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear-core-minimal": "^1.10.0alpha2",
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-bz2": "Bz2 compression support.",
+                "ext-xz": "Lzma2 compression support.",
+                "ext-zlib": "Gzip compression support."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Archive_Tar": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Vincent Blavet",
+                    "email": "vincent@phpconcept.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "greg@chiaraquartet.net"
+                },
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net"
+                }
+            ],
+            "description": "Tar file management class with compression support (gzip, bzip2, lzma2)",
+            "homepage": "https://github.com/pear/Archive_Tar",
+            "keywords": [
+                "archive",
+                "tar"
+            ],
+            "time": "2019-04-08T13:15:55+00:00"
+        },
+        {
+            "name": "pear/console_getopt",
+            "version": "v1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Console_Getopt.git",
+                "reference": "6c77aeb625b32bd752e89ee17972d103588b90c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Console_Getopt/zipball/6c77aeb625b32bd752e89ee17972d103588b90c0",
+                "reference": "6c77aeb625b32bd752e89ee17972d103588b90c0",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Console": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net",
+                    "role": "Helper"
+                },
+                {
+                    "name": "Andrei Zmievski",
+                    "email": "andrei@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Stig Bakken",
+                    "email": "stig@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/Console_Getopt",
+            "time": "2019-02-06T16:52:33+00:00"
+        },
+        {
+            "name": "pear/pear-core-minimal",
+            "version": "v1.10.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/pear-core-minimal.git",
+                "reference": "742be8dd68c746a01e4b0a422258e9c9cae1c37f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/742be8dd68c746a01e4b0a422258e9c9cae1c37f",
+                "reference": "742be8dd68c746a01e4b0a422258e9c9cae1c37f",
+                "shasum": ""
+            },
+            "require": {
+                "pear/console_getopt": "~1.4",
+                "pear/pear_exception": "~1.0"
+            },
+            "replace": {
+                "rsky/pear-core-min": "self.version"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "src/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@php.net",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Minimal set of PEAR core files to be used as composer dependency",
+            "time": "2019-03-13T18:15:44+00:00"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/8c18719fdae000b690e3912be401c76e406dd13b",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2015-02-10T20:07:52+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -10321,16 +10479,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -10368,7 +10526,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -11087,16 +11245,16 @@
         },
         {
             "name": "swagger-api/swagger-ui",
-            "version": "v3.21.0",
+            "version": "v3.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swagger-api/swagger-ui.git",
-                "reference": "b3a555f58974ad202ef2ad0d5bc793ceb9a8cc42"
+                "reference": "c38bf85e34ee46b2ad399b25c4c73668dc0d7e1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/b3a555f58974ad202ef2ad0d5bc793ceb9a8cc42",
-                "reference": "b3a555f58974ad202ef2ad0d5bc793ceb9a8cc42",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/c38bf85e34ee46b2ad399b25c4c73668dc0d7e1d",
+                "reference": "c38bf85e34ee46b2ad399b25c4c73668dc0d7e1d",
                 "shasum": ""
             },
             "type": "library",
@@ -11140,7 +11298,7 @@
                 "swagger",
                 "ui"
             ],
-            "time": "2019-03-02T06:24:24+00:00"
+            "time": "2019-04-13T01:40:36+00:00"
         },
         {
             "name": "symfony-cmf/routing",
@@ -11203,7 +11361,7 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -11323,7 +11481,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -11395,7 +11553,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -11451,16 +11609,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "dee85a9148399cdb2731603802842bcfd8afe5ab"
+                "reference": "be0feb3fa202aedfd8d1956f2dafd563fb13acbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/dee85a9148399cdb2731603802842bcfd8afe5ab",
-                "reference": "dee85a9148399cdb2731603802842bcfd8afe5ab",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/be0feb3fa202aedfd8d1956f2dafd563fb13acbf",
+                "reference": "be0feb3fa202aedfd8d1956f2dafd563fb13acbf",
                 "shasum": ""
             },
             "require": {
@@ -11518,11 +11676,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-16T11:13:42+00:00"
+            "time": "2019-04-20T15:32:49+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -11684,16 +11842,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "90454ad44c95d75faf3507d56388056001b74baf"
+                "reference": "fa02215233be8de1c2b44617088192f9e8db3512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/90454ad44c95d75faf3507d56388056001b74baf",
-                "reference": "90454ad44c95d75faf3507d56388056001b74baf",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fa02215233be8de1c2b44617088192f9e8db3512",
+                "reference": "fa02215233be8de1c2b44617088192f9e8db3512",
                 "shasum": ""
             },
             "require": {
@@ -11734,20 +11892,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-17T14:51:18+00:00"
+            "time": "2019-05-01T08:04:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "14fa41ccd38570b5e3120a3754bbaa144a15f311"
+                "reference": "586046f5adc6a08eaebbe4519ef18ad52f54e453"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/14fa41ccd38570b5e3120a3754bbaa144a15f311",
-                "reference": "14fa41ccd38570b5e3120a3754bbaa144a15f311",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/586046f5adc6a08eaebbe4519ef18ad52f54e453",
+                "reference": "586046f5adc6a08eaebbe4519ef18ad52f54e453",
                 "shasum": ""
             },
             "require": {
@@ -11823,7 +11981,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-17T15:57:07+00:00"
+            "time": "2019-05-01T13:03:24+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -12117,7 +12275,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -12231,7 +12389,7 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -12307,16 +12465,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "14b3221cc41dcfef404205f0060cda873f43a534"
+                "reference": "99aceeb3e10852b951b9cab57a2b83062db09efb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/14b3221cc41dcfef404205f0060cda873f43a534",
-                "reference": "14b3221cc41dcfef404205f0060cda873f43a534",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/99aceeb3e10852b951b9cab57a2b83062db09efb",
+                "reference": "99aceeb3e10852b951b9cab57a2b83062db09efb",
                 "shasum": ""
             },
             "require": {
@@ -12339,7 +12497,7 @@
                 "symfony/dependency-injection": "~3.2|~4.0",
                 "symfony/http-foundation": "~2.8|~3.0|~4.0",
                 "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "~3.1|~4.0",
+                "symfony/property-info": "^3.4.13|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -12382,20 +12540,20 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-11T05:44:34+00:00"
+            "time": "2019-04-27T21:20:35+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "aae26f143da71adc8707eb489f1dc86aef7d376b"
+                "reference": "301a5d627220a1c4ee522813b0028653af6c4f54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/aae26f143da71adc8707eb489f1dc86aef7d376b",
-                "reference": "aae26f143da71adc8707eb489f1dc86aef7d376b",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/301a5d627220a1c4ee522813b0028653af6c4f54",
+                "reference": "301a5d627220a1c4ee522813b0028653af6c4f54",
                 "shasum": ""
             },
             "require": {
@@ -12452,20 +12610,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-10T16:00:48+00:00"
+            "time": "2019-05-01T11:10:09+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "83da5259779aaf9dde220130e62b785f74e2ac49"
+                "reference": "cc3f577d8887737df4d77a4c0cc6e3c22164cea4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/83da5259779aaf9dde220130e62b785f74e2ac49",
-                "reference": "83da5259779aaf9dde220130e62b785f74e2ac49",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/cc3f577d8887737df4d77a4c0cc6e3c22164cea4",
+                "reference": "cc3f577d8887737df4d77a4c0cc6e3c22164cea4",
                 "shasum": ""
             },
             "require": {
@@ -12537,7 +12695,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2019-04-16T11:21:44+00:00"
+            "time": "2019-04-29T08:34:27+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -12617,7 +12775,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -12676,16 +12834,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.39.1",
+            "version": "v1.40.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec"
+                "reference": "35889516bbd6bbe46a600c2c33b03515df4a076e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec",
-                "reference": "23e7b6f0cfa1d7ba3de69f30d8e05cf957412fec",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/35889516bbd6bbe46a600c2c33b03515df4a076e",
+                "reference": "35889516bbd6bbe46a600c2c33b03515df4a076e",
                 "shasum": ""
             },
             "require": {
@@ -12700,7 +12858,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.39-dev"
+                    "dev-master": "1.40-dev"
                 }
             },
             "autoload": {
@@ -12738,20 +12896,20 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-04-16T17:12:57+00:00"
+            "time": "2019-04-29T14:12:28+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "b7a21f0859059ed5d9754af8c11f852d43762334"
+                "reference": "e438b0c78652b33407983eb29d215a1a3f68f6f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/b7a21f0859059ed5d9754af8c11f852d43762334",
-                "reference": "b7a21f0859059ed5d9754af8c11f852d43762334",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/e438b0c78652b33407983eb29d215a1a3f68f6f3",
+                "reference": "e438b0c78652b33407983eb29d215a1a3f68f6f3",
                 "shasum": ""
             },
             "require": {
@@ -12761,6 +12919,7 @@
                 "php": "^5.3.3|^7.0"
             },
             "require-dev": {
+                "ext-xdebug": "*",
                 "phpunit/phpunit": "^4.8.36"
             },
             "type": "library",
@@ -12781,7 +12940,7 @@
                 "security",
                 "stream-wrapper"
             ],
-            "time": "2019-03-01T17:43:52+00:00"
+            "time": "2019-05-05T17:30:51+00:00"
         },
         {
             "name": "vardot/blazy",

--- a/_docker/drupal/drupal-filesystem/scripts/drupal_install_checker.rb
+++ b/_docker/drupal/drupal-filesystem/scripts/drupal_install_checker.rb
@@ -108,7 +108,7 @@ class DrupalInstallChecker
 
   def drush_updb
     puts 'Executing drush updb...'
-    process_executor.exec!('/var/www/drupal/vendor/bin/drush', %w(-y --root=/var/www/drupal/web --entity-updates updb))
+    process_executor.exec!('/var/www/drupal/vendor/bin/drush', %w(-y --root=/var/www/drupal/web updb))
     drush_cache_rebuild
   end
 

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_account_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_account_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_footer.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_footer.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_main_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bartik_main_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_account_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_account_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_footer.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_footer.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_main_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_main_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_tools.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.beryllium_tools.yml
@@ -23,4 +23,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_account_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_account_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 2
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_footer.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_footer.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_main_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_main_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 2
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_tools.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.bootstrap_tools.yml
@@ -23,4 +23,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdfooter.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdfooter.yml
@@ -21,4 +21,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdnavigation.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdnavigation.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdnavigation_mobile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdnavigation_mobile.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_account_menu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_account_menu.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_footer.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_footer.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.topicnavigation.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.topicnavigation.yml
@@ -21,6 +21,7 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility:
   request_path:
     id: request_path

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalfooter.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalfooter.yml
@@ -21,4 +21,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.all_products_listing.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.all_products_listing.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.all_products_listing.field_navigation_title
     - field.field.assembly.all_products_listing.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - text
@@ -59,12 +58,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 7
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.blog_posts.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.blog_posts.default.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.assembly.blog_posts.field_category_filter
     - field.field.assembly.blog_posts.field_navigation_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - rhd_assemblies
@@ -48,12 +47,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 7
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.bonus_content_item.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.bonus_content_item.default.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.assembly.bonus_content_item.field_bonus_content_type
     - field.field.assembly.bonus_content_item.field_url
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -47,12 +46,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 6
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.bonus_content_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.bonus_content_list.default.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.assembly.bonus_content_list.field_content_list
     - field.field.assembly.bonus_content_list.field_title
   module:
-    - content_moderation
     - field_layout
     - inline_entity_form
     - layout_discovery
@@ -51,12 +50,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    type: moderation_state_default
-    weight: 5
-    settings: {  }
-    region: content
-    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.code_snippet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.code_snippet.default.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.assembly.code_snippet.field_code
     - field.field.assembly.code_snippet.field_programming_language
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
 third_party_settings:
@@ -46,12 +45,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 4
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.combo.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.combo.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.assembly.combo.field_content
     - field.field.assembly.combo.field_title
   module:
-    - content_moderation
     - entity_browser
     - field_layout
     - inline_entity_form
@@ -84,12 +83,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 9
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content_with_image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.content_with_image.default.yml
@@ -16,8 +16,8 @@ dependencies:
   module:
     - entity_browser
     - field_layout
-    - layout_discovery
     - file
+    - layout_discovery
     - link
     - text
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.events_list.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.events_list.field_event
     - field.field.assembly.events_list.field_navigation_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -60,12 +59,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 8
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.feature.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.feature.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.feature.field_release
     - field.field.assembly.feature.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -62,12 +61,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 8
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_articles.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_articles.default.yml
@@ -7,6 +7,9 @@ dependencies:
     - field.field.assembly.featured_articles.field_articles
     - field.field.assembly.featured_articles.field_navigation_title
     - field.field.assembly.featured_articles.field_title
+  module:
+    - field_layout
+    - layout_discovery
 third_party_settings:
   field_layout:
     id: layout_disabled

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_products.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.featured_products.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.assembly.featured_products.field_products
     - field.field.assembly.featured_products.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -69,12 +68,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 9
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.hero.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - field.field.assembly.hero.field_title
     - image.style.thumbnail
   module:
-    - content_moderation
     - field_layout
     - image
     - layout_discovery
@@ -70,12 +69,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 9
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.learning_paths.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.learning_paths.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.learning_paths.field_description
     - field.field.assembly.learning_paths.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -60,12 +59,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 8
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.on_page_navigation.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.on_page_navigation.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - assembly.assembly_type.on_page_navigation
     - field.field.assembly.on_page_navigation.field_audience_selection
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
 third_party_settings:
@@ -30,12 +29,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 4
-    region: content
-    settings: {  }
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_categories.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_categories.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.product_categories.field_navigation_title
     - field.field.assembly.product_categories.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - link
@@ -59,12 +58,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 7
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_comparison_table.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_comparison_table.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.product_comparison_table.field_sub_products
     - field.field.assembly.product_comparison_table.field_upstream_projects
   module:
-    - content_moderation
     - entity_browser_entity_form
     - field_group
     - field_layout
@@ -129,12 +128,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 6
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_hero.default.yml
@@ -10,12 +10,10 @@ dependencies:
     - field.field.assembly.product_download_hero.field_image
     - field.field.assembly.product_download_hero.field_learn_more_link
     - field.field.assembly.product_download_hero.field_title
-    - image.style.thumbnail
   module:
     - entity_browser
     - field_layout
     - layout_discovery
-    - image
     - link
     - text
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_download_list.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - assembly.assembly_type.product_download_list
     - field.field.assembly.product_download_list.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
 third_party_settings:
@@ -32,12 +31,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 5
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_try_it_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.product_try_it_hero.default.yml
@@ -11,12 +11,10 @@ dependencies:
     - field.field.assembly.product_try_it_hero.field_learn_more_link
     - field.field.assembly.product_try_it_hero.field_title
     - field.field.assembly.product_try_it_hero.field_try_it_link
-    - image.style.thumbnail
   module:
     - entity_browser
     - field_layout
     - layout_discovery
-    - image
     - link
     - text
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.rich_text_columns.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.rich_text_columns.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.assembly.rich_text_columns.field_navigation_title
     - field.field.assembly.rich_text_columns.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - text
@@ -68,12 +67,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 8
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.video_hero.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.video_hero.default.yml
@@ -16,7 +16,6 @@ dependencies:
     - field.field.assembly.video_hero.field_video_resource
   module:
     - compose
-    - content_moderation
     - entity_browser
     - field_group
     - field_layout
@@ -133,12 +132,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 13
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.videos.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.videos.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.assembly.videos.field_tags
     - field.field.assembly.videos.field_title
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
 third_party_settings:
@@ -59,12 +58,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 6
-    settings: {  }
-    third_party_settings: {  }
-    type: moderation_state_default
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.block_content.basic.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.block_content.basic.default.yml
@@ -44,13 +44,4 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 26
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.block_content.media_slideshow.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.block_content.media_slideshow.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - entity_browser.browser.media_browser
     - field.field.block_content.media_slideshow.field_slideshow_items
   module:
-    - content_moderation
     - entity_browser
     - field_layout
     - layout_discovery
@@ -50,11 +49,5 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
 hidden: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.audio_file.field_media_in_library
     - media.type.audio_file
   module:
-    - content_moderation
     - field_layout
     - file
     - layout_discovery
@@ -43,12 +42,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.media_browser.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.media.audio_file.field_media_in_library
     - media.type.audio_file
   module:
-    - content_moderation
     - field_layout
     - file
     - layout_discovery
@@ -44,12 +43,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.audio_file.media_library.yml
@@ -1,0 +1,37 @@
+uuid: 2c73b053-d5bf-4329-bdaa-f2f174d0cbde
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.audio_file.field_media_audio_file
+    - field.field.media.audio_file.field_media_in_library
+    - media.type.audio_file
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.audio_file.media_library
+targetEntityType: media
+bundle: audio_file
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_audio_file: true
+  field_media_in_library: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.default.yml
@@ -43,15 +43,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 2

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.media_browser.yml
@@ -36,15 +36,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.document.media_library.yml
@@ -1,0 +1,37 @@
+uuid: 30acbb76-2056-46dd-bc81-aca592f2612c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.document.field_document
+    - field.field.media.document.field_media_in_library
+    - media.type.document
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.document.media_library
+targetEntityType: media
+bundle: document
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_document: true
+  field_media_in_library: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.file.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.file.default.yml
@@ -42,15 +42,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: -5

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.file.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.file.media_library.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.media.file.field_media_in_library
     - media.type.file
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
 third_party_settings:
@@ -28,12 +27,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.image.image
     - media.type.image
   module:
-    - content_moderation
     - field_layout
     - layout_discovery
     - path
@@ -32,12 +31,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_browser.yml
@@ -56,15 +56,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 3

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -1,0 +1,46 @@
+uuid: 15b046e2-b550-4ad7-9390-09f30ac1a2a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.image.field_media_in_library
+    - field.field.media.image.image
+    - image.style.thumbnail
+    - media.type.image
+  module:
+    - field_layout
+    - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.image.media_library
+targetEntityType: media
+bundle: image
+mode: media_library
+content:
+  image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_in_library: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.default.yml
@@ -43,15 +43,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.media_browser.yml
@@ -36,15 +36,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.instagram.media_library.yml
@@ -1,0 +1,38 @@
+uuid: bcbf304d-4a10-4c73-b52a-df9311d3f314
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.instagram.embed_code
+    - field.field.media.instagram.field_media_in_library
+    - media.type.instagram
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.instagram.media_library
+targetEntityType: media
+bundle: instagram
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  embed_code: true
+  field_media_in_library: true
+  langcode: true
+  path: true
+  preview: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.default.yml
@@ -43,15 +43,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.media_browser.yml
@@ -36,15 +36,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.tweet.media_library.yml
@@ -1,0 +1,38 @@
+uuid: b1466868-0675-4b31-b50d-38af45371890
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.tweet.embed_code
+    - field.field.media.tweet.field_media_in_library
+    - media.type.tweet
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.tweet.media_library
+targetEntityType: media
+bundle: tweet
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  embed_code: true
+  field_media_in_library: true
+  langcode: true
+  path: true
+  preview: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.default.yml
@@ -42,15 +42,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.media_browser.yml
@@ -36,15 +36,6 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
-  moderation_state:
-    weight: 101
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   name:
     type: string_textfield
     weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -1,0 +1,38 @@
+uuid: 7bc0b2f1-dc30-4871-9873-e02d9640c703
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.video.field_media_in_library
+    - field.field.media.video.field_media_video_embed_field
+    - media.type.video
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.video.media_library
+targetEntityType: media
+bundle: video
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_in_library: true
+  field_media_video_embed_field: true
+  langcode: true
+  path: true
+  preview: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - field.field.media.video_file.field_media_video_file
     - media.type.video_file
   module:
-    - content_moderation
     - field_layout
     - file
     - layout_discovery
@@ -41,12 +40,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.media_browser.yml
@@ -8,7 +8,6 @@ dependencies:
     - field.field.media.video_file.field_media_video_file
     - media.type.video_file
   module:
-    - content_moderation
     - field_layout
     - file
     - layout_discovery
@@ -42,12 +41,6 @@ content:
     region: content
     settings:
       include_locked: true
-    third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
     third_party_settings: {  }
   name:
     type: string_textfield

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.media.video_file.media_library.yml
@@ -1,0 +1,37 @@
+uuid: ec1fdfff-bb30-424a-8600-379b4aa1d3e3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.video_file.field_media_in_library
+    - field.field.media.video_file.field_media_video_file
+    - media.type.video_file
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: media.video_file.media_library
+targetEntityType: media
+bundle: video_file
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_in_library: true
+  field_media_video_file: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.article.default.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.article.field_topics
     - image.style.thumbnail
     - node.type.article
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.assembly_page.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.assembly_page.field_tax_region
     - field.field.node.assembly_page.field_tax_stage
     - node.type.assembly_page
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.author.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.author.field_twitter
     - field.field.node.author.field_youtube
     - node.type.author
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
@@ -43,8 +43,6 @@ dependencies:
     - node.type.books
   module:
     - compose
-    - content_moderation
-    - entity_browser
     - field_group
     - field_layout
     - image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -31,7 +31,6 @@ dependencies:
     - node.type.cheat_sheet
   module:
     - compose
-    - content_moderation
     - entity_browser
     - field_group
     - field_layout

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.coding_resource.default.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.coding_resource.field_technologies
     - field.field.node.coding_resource.field_version
     - node.type.coding_resource
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.connectors.default.yml
@@ -28,6 +28,7 @@ dependencies:
     - field.field.node.connectors.field_tax_region
     - field.field.node.connectors.field_tax_stage
     - node.type.connectors
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.events.default.yml
@@ -36,6 +36,7 @@ dependencies:
     - field.field.node.events.field_topics
     - image.style.thumbnail
     - node.type.events
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_course.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_course.default.yml
@@ -9,8 +9,11 @@ dependencies:
     - field.field.node.katacoda_course.field_katacoda_course_url_slug
     - field.field.node.katacoda_course.field_katacoda_hero_more_link
     - node.type.katacoda_course
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
+    - field_layout
+    - layout_discovery
     - path
     - publication_date
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_individual_lesson.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_individual_lesson.default.yml
@@ -9,8 +9,11 @@ dependencies:
     - field.field.node.katacoda_individual_lesson.field_katacoda_scenario_time
     - field.field.node.katacoda_individual_lesson.field_katacoda_skill_level
     - node.type.katacoda_individual_lesson
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
+    - field_layout
+    - layout_discovery
     - path
     - publication_date
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.landing_page_single_offer.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.landing_page_single_offer.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.landing_page_single_offer.field_tax_region
     - field.field.node.landing_page_single_offer.field_tax_stage
     - node.type.landing_page_single_offer
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.learning_path.default.yml
@@ -29,6 +29,7 @@ dependencies:
     - field.field.node.learning_path.field_topics
     - field.field.node.learning_path.field_value_proposition
     - node.type.learning_path
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.body
     - field.field.node.page.field_meta_tags
     - node.type.page
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
     - field_layout

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.product.default.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.product.field_use_new_product_page
     - image.style.thumbnail
     - node.type.product
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_card.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_card.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.promotion_card.field_container_tags
     - field.field.node.promotion_card.field_containers_short_summary
     - node.type.promotion_card
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
     - field_layout

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.promotion_page.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.promotion_page.field_promotion_page_left_image
     - image.style.thumbnail
     - node.type.promotion_page
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
     - entity_browser

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_certification_exam.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.rh_certification_exam.field_tax_stage
     - field.field.node.rh_certification_exam.field_topics
     - node.type.rh_certification_exam
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rh_training_class.default.yml
@@ -24,10 +24,10 @@ dependencies:
     - field.field.node.rh_training_class.field_topics
     - image.style.thumbnail
     - node.type.rh_training_class
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation
-    - entity_browser
     - field_group
     - field_layout
     - image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_microsite.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_microsite.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.rhd_microsite.body
     - node.type.rhd_microsite
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
     - field_layout

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_solution_overview.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.rhd_solution_overview.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.rhd_solution_overview.field_solution_name
     - field.field.node.rhd_solution_overview.field_solution_tag_line
     - node.type.rhd_solution_overview
+    - workflows.workflow.00c7e3ae
   module:
     - content_moderation
     - field_layout

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.sub_product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.sub_product.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.sub_product.field_cta
     - field.field.node.sub_product.field_logo
     - node.type.sub_product
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.topic_page.field_tax_stage
     - image.style.thumbnail
     - node.type.topic_page
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.upstream_projects.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.upstream_projects.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.upstream_projects.field_link_to_repo
     - field.field.node.upstream_projects.field_logo
     - node.type.upstream_projects
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.video_resource.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - field.field.node.video_resource.field_video_transcript
     - field.field.node.video_resource.field_views
     - node.type.video_resource
+    - workflows.workflow.00c7e3ae
   module:
     - compose
     - content_moderation

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.buzz.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.buzz.default.yml
@@ -55,15 +55,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.community.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.community.default.yml
@@ -54,15 +54,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.connectors.default.yml
@@ -55,15 +55,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.docs_and_apis.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.docs_and_apis.default.yml
@@ -64,15 +64,6 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.document_details.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.document_details.default.yml
@@ -44,15 +44,6 @@ content:
     third_party_settings: {  }
     type: options_buttons
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.download.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.download.default.yml
@@ -91,15 +91,6 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  moderation_state:
-    weight: 8
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.get_started.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.get_started.default.yml
@@ -68,15 +68,6 @@ content:
       form_display_mode: default
     third_party_settings: {  }
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.getting_started_section.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.getting_started_section.default.yml
@@ -46,15 +46,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_support_progress: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.getting_started_tab_section.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.getting_started_tab_section.default.yml
@@ -50,15 +50,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.help.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.help.default.yml
@@ -54,15 +54,6 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.learn.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.learn.default.yml
@@ -46,15 +46,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.main_content.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.main_content.default.yml
@@ -43,15 +43,6 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 7
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   status: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.overview.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.overview.default.yml
@@ -86,15 +86,6 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 7
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.paragraph_with_image.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.paragraph_with_image.default.yml
@@ -55,15 +55,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_paragraph_image_image: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.resources.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.resources.default.yml
@@ -46,15 +46,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.updates.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.paragraph.updates.default.yml
@@ -46,15 +46,6 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 6
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   field_overview_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.taxonomy_term.topics.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.taxonomy_term.topics.field_alt_landing
     - taxonomy.vocabulary.topics
   module:
+    - field_layout
+    - layout_discovery
     - link
     - path
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.assembly.featured_articles.field_title
   module:
     - fences
+    - field_layout
+    - layout_discovery
 third_party_settings:
   field_layout:
     id: layout_disabled

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.card.yml
@@ -35,9 +35,9 @@ dependencies:
     - field.field.node.article.field_topics
     - node.type.article
   module:
-    - compose
     - fences
     - field_layout
+    - layout_discovery
     - metatag
     - options
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.rss.yml
@@ -35,8 +35,8 @@ dependencies:
     - field.field.node.article.field_topics
     - node.type.article
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.short_teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.short_teaser.yml
@@ -35,9 +35,9 @@ dependencies:
     - field.field.node.article.field_topics
     - node.type.article
   module:
-    - compose
     - fences
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -36,10 +36,10 @@ dependencies:
     - image.style.large
     - node.type.article
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.article.tile.yml
@@ -36,10 +36,10 @@ dependencies:
     - image.style.large
     - node.type.article
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.default.yml
@@ -19,9 +19,9 @@ dependencies:
     - field.field.node.assembly_page.field_tax_stage
     - node.type.assembly_page
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.assembly_page.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.assembly_page.field_hide_title
     - field.field.node.assembly_page.field_meta_tags
     - field.field.node.assembly_page.field_sections
     - field.field.node.assembly_page.field_share_image
@@ -19,9 +20,9 @@ dependencies:
     - field.field.node.assembly_page.field_tax_stage
     - node.type.assembly_page
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.card.yml
@@ -24,10 +24,10 @@ dependencies:
     - field.field.node.author.field_youtube
     - node.type.author
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.default.yml
@@ -23,10 +23,10 @@ dependencies:
     - field.field.node.author.field_youtube
     - node.type.author
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.short_teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.short_teaser.yml
@@ -25,10 +25,10 @@ dependencies:
     - image.style.square_small
     - node.type.author
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.teaser.yml
@@ -25,10 +25,10 @@ dependencies:
     - image.style.large
     - node.type.author
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.author.tile.yml
@@ -25,10 +25,10 @@ dependencies:
     - image.style.square_small
     - node.type.author
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.card.yml
@@ -43,10 +43,10 @@ dependencies:
     - image.style.large
     - node.type.books
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
@@ -41,9 +41,9 @@ dependencies:
     - field.field.node.books.field_web_reader_url
     - node.type.books
   module:
-    - compose
     - field_layout
     - interval
+    - layout_discovery
     - link
     - metatag
     - options

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.teaser.yml
@@ -43,10 +43,10 @@ dependencies:
     - image.style.medium
     - node.type.books
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.tile.yml
@@ -43,10 +43,10 @@ dependencies:
     - image.style.large
     - node.type.books
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.card.yml
@@ -31,10 +31,10 @@ dependencies:
     - image.style.large
     - node.type.cheat_sheet
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.default.yml
@@ -29,9 +29,9 @@ dependencies:
     - field.field.node.cheat_sheet.field_topics
     - node.type.cheat_sheet
   module:
-    - compose
     - field_layout
     - interval
+    - layout_discovery
     - link
     - metatag
     - options

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.cheat_sheet.teaser.yml
@@ -31,10 +31,10 @@ dependencies:
     - image.style.medium
     - node.type.cheat_sheet
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.card.yml
@@ -27,8 +27,8 @@ dependencies:
     - field.field.node.coding_resource.field_version
     - node.type.coding_resource
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.coding_resource.default.yml
@@ -26,8 +26,8 @@ dependencies:
     - field.field.node.coding_resource.field_version
     - node.type.coding_resource
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.connectors.default.yml
@@ -28,8 +28,8 @@ dependencies:
     - field.field.node.connectors.field_tax_stage
     - node.type.connectors
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.teaser.yml
@@ -36,11 +36,11 @@ dependencies:
     - field.field.node.events.field_topics
     - node.type.events
   module:
-    - compose
     - datetime
     - fences
     - field_layout
     - image
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.events.tile.yml
@@ -37,10 +37,10 @@ dependencies:
     - image.style.crop_thumbnail
     - node.type.events
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_course.teaser.yml
@@ -5,8 +5,14 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.katacoda_course.body
+    - field.field.node.katacoda_course.field_katacoda_course_audience
+    - field.field.node.katacoda_course.field_katacoda_course_lessons
+    - field.field.node.katacoda_course.field_katacoda_course_url_slug
+    - field.field.node.katacoda_course.field_katacoda_hero_more_link
     - node.type.katacoda_course
   module:
+    - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.teaser.yml
@@ -5,8 +5,14 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.katacoda_individual_lesson.body
+    - field.field.node.katacoda_individual_lesson.field_katacoda_embed_id
+    - field.field.node.katacoda_individual_lesson.field_katacoda_scenario_author
+    - field.field.node.katacoda_individual_lesson.field_katacoda_scenario_time
+    - field.field.node.katacoda_individual_lesson.field_katacoda_skill_level
     - node.type.katacoda_individual_lesson
   module:
+    - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.landing_page_single_offer.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.landing_page_single_offer.default.yml
@@ -20,9 +20,9 @@ dependencies:
     - field.field.node.landing_page_single_offer.field_tax_stage
     - node.type.landing_page_single_offer
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.card.yml
@@ -31,8 +31,8 @@ dependencies:
     - field.field.node.learning_path.field_value_proposition
     - node.type.learning_path
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.default.yml
@@ -30,9 +30,9 @@ dependencies:
     - field.field.node.learning_path.field_value_proposition
     - node.type.learning_path
   module:
-    - compose
     - field_layout
     - interval
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.learning_path.teaser.yml
@@ -31,9 +31,9 @@ dependencies:
     - field.field.node.learning_path.field_value_proposition
     - node.type.learning_path
   module:
-    - compose
     - fences
     - field_layout
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.page.default.yml
@@ -7,8 +7,8 @@ dependencies:
     - field.field.node.page.field_meta_tags
     - node.type.page
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - metatag
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -8,8 +8,8 @@ dependencies:
     - field.field.node.page.field_meta_tags
     - node.type.page
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.default.yml
@@ -34,9 +34,9 @@ dependencies:
     - field.field.node.product.field_use_new_product_page
     - node.type.product
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - link
     - metatag
     - options

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.featured_tile.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.featured_tile.yml
@@ -36,10 +36,10 @@ dependencies:
     - image.style.large
     - node.type.product
   module:
-    - compose
     - fences
     - field_layout
     - image
+    - layout_discovery
     - link
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.new_product_page.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.new_product_page.yml
@@ -35,9 +35,9 @@ dependencies:
     - field.field.node.product.field_use_new_product_page
     - node.type.product
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - metatag
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.product_download_page.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.product_download_page.yml
@@ -35,9 +35,9 @@ dependencies:
     - field.field.node.product.field_use_new_product_page
     - node.type.product
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - metatag
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.product_getting_started_page.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.product_getting_started_page.yml
@@ -35,9 +35,9 @@ dependencies:
     - field.field.node.product.field_use_new_product_page
     - node.type.product
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - metatag
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.default.yml
@@ -8,8 +8,8 @@ dependencies:
     - field.field.node.promotion_card.field_containers_short_summary
     - node.type.promotion_card
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_card.teaser.yml
@@ -9,8 +9,8 @@ dependencies:
     - field.field.node.promotion_card.field_containers_short_summary
     - node.type.promotion_card
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.promotion_page.default.yml
@@ -11,9 +11,9 @@ dependencies:
     - field.field.node.promotion_page.field_promotion_page_left_image
     - node.type.promotion_page
   module:
-    - compose
     - field_layout
     - image
+    - layout_discovery
     - link
     - text
     - user

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.default.yml
@@ -23,10 +23,10 @@ dependencies:
     - field.field.node.rh_certification_exam.field_topics
     - node.type.rh_certification_exam
   module:
-    - compose
     - field_layout
     - image
     - interval
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_certification_exam.teaser.yml
@@ -24,8 +24,8 @@ dependencies:
     - field.field.node.rh_certification_exam.field_topics
     - node.type.rh_certification_exam
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.default.yml
@@ -24,10 +24,10 @@ dependencies:
     - field.field.node.rh_training_class.field_topics
     - node.type.rh_training_class
   module:
-    - compose
     - field_layout
     - image
     - interval
+    - layout_discovery
     - link
     - options
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rh_training_class.teaser.yml
@@ -25,8 +25,8 @@ dependencies:
     - field.field.node.rh_training_class.field_topics
     - node.type.rh_training_class
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_microsite.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_microsite.default.yml
@@ -6,8 +6,8 @@ dependencies:
     - field.field.node.rhd_microsite.body
     - node.type.rhd_microsite
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_solution_overview.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_solution_overview.default.yml
@@ -8,8 +8,8 @@ dependencies:
     - field.field.node.rhd_solution_overview.field_solution_tag_line
     - node.type.rhd_solution_overview
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_solution_overview.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.rhd_solution_overview.teaser.yml
@@ -9,8 +9,8 @@ dependencies:
     - field.field.node.rhd_solution_overview.field_solution_tag_line
     - node.type.rhd_solution_overview
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.sub_product.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.sub_product.default.yml
@@ -7,9 +7,9 @@ dependencies:
     - field.field.node.sub_product.field_logo
     - node.type.sub_product
   module:
-    - compose
     - fences
     - field_layout
+    - layout_discovery
     - link
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.sub_product.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.sub_product.teaser.yml
@@ -8,8 +8,8 @@ dependencies:
     - field.field.node.sub_product.field_logo
     - node.type.sub_product
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic.default.yml
@@ -19,8 +19,8 @@ dependencies:
     - field.field.node.topic.field_topic_sub_title
     - node.type.topic
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - link
     - metatag
     - text

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic.teaser.yml
@@ -20,8 +20,8 @@ dependencies:
     - field.field.node.topic.field_topic_sub_title
     - node.type.topic
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
@@ -19,9 +19,9 @@ dependencies:
     - field.field.node.topic_page.field_tax_stage
     - node.type.topic_page
   module:
-    - compose
     - entity_reference_revisions
     - field_layout
+    - layout_discovery
     - text
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.teaser.yml
@@ -20,8 +20,8 @@ dependencies:
     - field.field.node.topic_page.field_tax_stage
     - node.type.topic_page
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.upstream_projects.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.upstream_projects.default.yml
@@ -8,9 +8,9 @@ dependencies:
     - field.field.node.upstream_projects.field_logo
     - node.type.upstream_projects
   module:
-    - compose
     - fences
     - field_layout
+    - layout_discovery
     - link
     - user
 third_party_settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.upstream_projects.teaser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.upstream_projects.teaser.yml
@@ -9,8 +9,8 @@ dependencies:
     - field.field.node.upstream_projects.field_logo
     - node.type.upstream_projects
   module:
-    - compose
     - field_layout
+    - layout_discovery
     - user
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.taxonomy_term.topics.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.taxonomy_term.topics.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.field.taxonomy_term.topics.field_alt_landing
     - taxonomy.vocabulary.topics
   module:
+    - field_layout
+    - layout_discovery
     - link
 third_party_settings:
   field_layout:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.user.user.compact.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.user.user.compact.yml
@@ -1,0 +1,50 @@
+uuid: 3cec1a08-1996-4983-bb04-63cfcf3222b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.compact
+    - field.field.user.user.field_long_bio
+    - field.field.user.user.field_short_bio
+    - field.field.user.user.field_user_photo
+    - field.field.user.user.field_user_title
+    - field.field.user.user.user_picture
+    - image.style.thumbnail
+  module:
+    - field_layout
+    - image
+    - layout_discovery
+    - user
+third_party_settings:
+  field_layout:
+    id: layout_disabled
+    settings: {  }
+id: user.user.compact
+targetEntityType: user
+bundle: user
+mode: compact
+content:
+  name:
+    type: string
+    weight: 1
+    region: content
+    settings:
+      link_to_entity: true
+    third_party_settings: {  }
+    label: hidden
+  user_picture:
+    type: image
+    weight: 0
+    region: content
+    settings:
+      image_style: thumbnail
+      image_link: content
+    third_party_settings: {  }
+    label: hidden
+hidden:
+  field_long_bio: true
+  field_short_bio: true
+  field_user_photo: true
+  field_user_title: true
+  langcode: true
+  member_for: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/embed.button.media_browser.yml
@@ -6,7 +6,7 @@ dependencies:
     - media.type.image
     - media.type.video
   content:
-    - 'file:file:2df741a0-59cd-4177-9166-257a8d964232'
+    - 'file:file:33cf61af-ffc3-4394-a8d1-a5de5f3240fd'
   module:
     - entity_embed
     - image
@@ -17,6 +17,7 @@ label: 'Media browser'
 id: media_browser
 type_id: entity
 type_settings:
+  entity_browser: ckeditor_media_browser
   entity_type: media
   bundles:
     - image
@@ -25,7 +26,6 @@ type_settings:
     - 'view_mode:media.embedded'
     - 'view_mode:media.thumbnail'
     - media_image
-  entity_browser: media_browser
   entity_browser_settings:
     display_review: false
 icon_uuid: 33cf61af-ffc3-4394-a8d1-a5de5f3240fd

--- a/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.ckeditor_media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.ckeditor_media_browser.yml
@@ -1,0 +1,54 @@
+uuid: 51946c61-b8e4-4b83-bb6a-baeab6d30501
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.media
+  module:
+    - lightning_media
+    - views
+_core:
+  default_config_hash: D9N3yb_9pTuhS5RYJ2c7eFzHgtexTWA07Ij5oCyshpQ
+name: ckeditor_media_browser
+label: 'Media browser (CKEditor)'
+display: iframe
+display_configuration:
+  width: 100%
+  height: '640'
+  link_text: 'Select entities'
+  auto_open: true
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: tabs
+widget_selector_configuration: {  }
+widgets:
+  134808d9-d854-4a0b-8699-d5eba006b8b7:
+    settings:
+      view: media
+      view_display: entity_browser_1
+      submit_text: Place
+      auto_select: false
+    uuid: 134808d9-d854-4a0b-8699-d5eba006b8b7
+    weight: -10
+    label: Library
+    id: view
+  8b142f33-59d1-47b1-9e3a-4ae85d8376fa:
+    settings:
+      submit_text: Place
+      target_bundles: {  }
+      form_mode: media_browser
+    uuid: 8b142f33-59d1-47b1-9e3a-4ae85d8376fa
+    weight: -8
+    label: 'Create embed'
+    id: embed_code
+  044d2af7-314b-4830-8b6d-64896bbb861e:
+    settings:
+      submit_text: Place
+      target_bundles: {  }
+      form_mode: media_browser
+      return_file: false
+      upload_validators: {  }
+    uuid: 044d2af7-314b-4830-8b6d-64896bbb861e
+    weight: -9
+    label: Upload
+    id: file_upload

--- a/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.media_browser.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/entity_browser.browser.media_browser.yml
@@ -11,12 +11,12 @@ _core:
   default_config_hash: D9N3yb_9pTuhS5RYJ2c7eFzHgtexTWA07Ij5oCyshpQ
 name: media_browser
 label: 'Media browser'
-display: iframe
+display: modal
 display_configuration:
-  width: 100%
-  height: '640'
-  link_text: 'Select entities'
-  auto_open: true
+  width: ''
+  height: ''
+  link_text: 'Add media'
+  auto_open: false
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.user.user.user_picture.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.user.user.user_picture.yml
@@ -1,0 +1,38 @@
+uuid: ba91fa39-0452-405a-8967-840b19fcc824
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.user_picture
+  module:
+    - image
+    - user
+id: user.user.user_picture
+field_name: user_picture
+entity_type: user
+bundle: user
+label: Picture
+description: 'Your virtual face or picture.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  file_directory: 'pictures/[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  alt_field: false
+  title_field: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  alt_field_required: false
+  title_field_required: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.user.user_picture.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.storage.user.user_picture.yml
@@ -1,0 +1,32 @@
+uuid: b96cc5c8-7cc5-4c32-91c8-9d9840ac9b43
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - user
+id: user.user_picture
+field_name: user_picture
+entity_type: user
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false
+custom_storage: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/image.style.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/image.style.media_library.yml
@@ -1,0 +1,15 @@
+uuid: 5d573efd-3339-458e-954f-9ae92c906418
+langcode: en
+status: true
+dependencies: {  }
+name: media_library
+label: 'Media Library (220x220)'
+effects:
+  0634e4fc-9fea-47b1-a27b-04b0404708dc:
+    uuid: 0634e4fc-9fea-47b1-a27b-04b0404708dc
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/lightning_core.versions.yml
@@ -60,8 +60,8 @@ jsonapi: 0.0.0
 layout_discovery: 0.0.0
 layoutmanager: 0.0.0
 lightning_contact_form: 0.0.0
-lightning_core: 0.0.0
-lightning_media: 3.1.0
+lightning_core: 3.6.0
+lightning_media: 3.6.0
 lightning_media_bulk_upload: 0.0.0
 lightning_media_document: 0.0.0
 lightning_media_image: 0.0.0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/media.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/media.settings.yml
@@ -1,3 +1,4 @@
 icon_base_uri: 'public://media-icons/generic'
 _core:
   default_config_hash: f_ouXNygByhTko09cj2hDG_CeERO4jKCV8zrIvORnd0
+standalone_url: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.audience_segment.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.audience_segment.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Audience/Segment
 vid: audience_segment
 description: ''
-hierarchy: 1
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.bonus_content_types.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.bonus_content_types.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Bonus content types'
 vid: bonus_content_types
 description: 'A list of bonus content types used for bonus content assembly list'
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.business_unit.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.business_unit.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Business Unit (BU)'
 vid: business_unit
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.campaign.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.campaign.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Campaign
 vid: campaign
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.katacoda_course_audience.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.katacoda_course_audience.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Katacoda Course Audience'
 vid: katacoda_course_audience
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.lifecycle.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.lifecycle.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Lifecycle
 vid: lifecycle
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Product
 vid: product
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product_categories.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product_categories.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Product Groups'
 vid: product_categories
 description: 'Use categories to group products into a controlled structure. Used on the all products landing page. '
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product_line.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.product_line.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Product Line (Portfolio)'
 vid: product_line
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.project.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.project.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Project
 vid: project
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.promotion.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.promotion.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Promotion
 vid: promotion
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.region.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.region.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Region
 vid: region
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.releases.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.releases.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Releases
 vid: releases
 description: 'Releases of Products, Sub-Products and Upstream Projects. Features can be grouped by release.'
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.stage.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.stage.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Stage
 vid: stage
 description: ''
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.tags.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.tags.yml
@@ -7,5 +7,4 @@ _core:
 name: Tags
 vid: tags
 description: 'Use tags to group articles on similar topics into categories.'
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.topics.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/taxonomy.vocabulary.topics.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Topics
 vid: topics
 description: 'Use topics to group content into a controlled category structure.'
-hierarchy: 0
 weight: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.media_manager.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.media_manager.yml
@@ -14,6 +14,7 @@ label: 'Media Manager'
 weight: -8
 is_admin: null
 permissions:
+  - 'access ckeditor_media_browser entity browser pages'
   - 'access contextual links'
   - 'access image_browser entity browser pages'
   - 'access media overview'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.media_library.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.media_library.yml
@@ -4,10 +4,12 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.media_library
+    - image.style.media_library
   enforced:
     module:
       - media_library
   module:
+    - image
     - media
     - media_library
     - user
@@ -75,7 +77,7 @@ display:
         type: default
         options:
           grouping: {  }
-          row_class: 'media-library-item js-media-library-item js-click-to-select'
+          row_class: 'media-library-item media-library-item--grid js-media-library-item js-click-to-select'
           default_row_class: true
       row:
         type: fields
@@ -394,25 +396,33 @@ display:
       tags:
         - 'config:core.entity_view_display.media.audio_file.default'
         - 'config:core.entity_view_display.media.audio_file.embedded'
+        - 'config:core.entity_view_display.media.audio_file.media_library'
         - 'config:core.entity_view_display.media.audio_file.thumbnail'
         - 'config:core.entity_view_display.media.document.default'
         - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.instagram.default'
         - 'config:core.entity_view_display.media.instagram.embedded'
+        - 'config:core.entity_view_display.media.instagram.media_library'
         - 'config:core.entity_view_display.media.instagram.thumbnail'
         - 'config:core.entity_view_display.media.tweet.default'
         - 'config:core.entity_view_display.media.tweet.embedded'
+        - 'config:core.entity_view_display.media.tweet.media_library'
         - 'config:core.entity_view_display.media.tweet.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.media_library'
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video_file.default'
         - 'config:core.entity_view_display.media.video_file.embedded'
+        - 'config:core.entity_view_display.media.video_file.media_library'
         - 'config:core.entity_view_display.media.video_file.thumbnail'
   page:
     display_plugin: page
@@ -442,25 +452,33 @@ display:
       tags:
         - 'config:core.entity_view_display.media.audio_file.default'
         - 'config:core.entity_view_display.media.audio_file.embedded'
+        - 'config:core.entity_view_display.media.audio_file.media_library'
         - 'config:core.entity_view_display.media.audio_file.thumbnail'
         - 'config:core.entity_view_display.media.document.default'
         - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.instagram.default'
         - 'config:core.entity_view_display.media.instagram.embedded'
+        - 'config:core.entity_view_display.media.instagram.media_library'
         - 'config:core.entity_view_display.media.instagram.thumbnail'
         - 'config:core.entity_view_display.media.tweet.default'
         - 'config:core.entity_view_display.media.tweet.embedded'
+        - 'config:core.entity_view_display.media.tweet.media_library'
         - 'config:core.entity_view_display.media.tweet.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.media_library'
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video_file.default'
         - 'config:core.entity_view_display.media.video_file.embedded'
+        - 'config:core.entity_view_display.media.video_file.media_library'
         - 'config:core.entity_view_display.media.video_file.thumbnail'
   widget:
     display_plugin: page
@@ -575,11 +593,159 @@ display:
       defaults:
         fields: false
         access: false
+        filters: false
+        filter_groups: false
+        arguments: false
+        css_class: false
+        header: false
       display_description: ''
       access:
         type: perm
         options:
           perm: 'view media'
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
+      css_class: 'media-library-view js-media-library-view media-library-view--widget'
+      header:
+        display_link_grid:
+          id: display_link_grid
+          table: views
+          field: display_link
+          display_id: widget
+          label: Grid
+          plugin_id: display_link
+          empty: true
+        display_link_table:
+          id: display_link_table
+          table: views
+          field: display_link
+          display_id: widget_table
+          label: Table
+          plugin_id: display_link
+          empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -591,23 +757,275 @@ display:
       tags:
         - 'config:core.entity_view_display.media.audio_file.default'
         - 'config:core.entity_view_display.media.audio_file.embedded'
+        - 'config:core.entity_view_display.media.audio_file.media_library'
         - 'config:core.entity_view_display.media.audio_file.thumbnail'
         - 'config:core.entity_view_display.media.document.default'
         - 'config:core.entity_view_display.media.document.embedded'
+        - 'config:core.entity_view_display.media.document.media_library'
         - 'config:core.entity_view_display.media.document.thumbnail'
         - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
         - 'config:core.entity_view_display.media.image.default'
         - 'config:core.entity_view_display.media.image.embedded'
+        - 'config:core.entity_view_display.media.image.media_library'
         - 'config:core.entity_view_display.media.image.thumbnail'
         - 'config:core.entity_view_display.media.instagram.default'
         - 'config:core.entity_view_display.media.instagram.embedded'
+        - 'config:core.entity_view_display.media.instagram.media_library'
         - 'config:core.entity_view_display.media.instagram.thumbnail'
         - 'config:core.entity_view_display.media.tweet.default'
         - 'config:core.entity_view_display.media.tweet.embedded'
+        - 'config:core.entity_view_display.media.tweet.media_library'
         - 'config:core.entity_view_display.media.tweet.thumbnail'
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.embedded'
+        - 'config:core.entity_view_display.media.video.media_library'
         - 'config:core.entity_view_display.media.video.thumbnail'
         - 'config:core.entity_view_display.media.video_file.default'
         - 'config:core.entity_view_display.media.video_file.embedded'
+        - 'config:core.entity_view_display.media.video_file.media_library'
         - 'config:core.entity_view_display.media.video_file.thumbnail'
+  widget_table:
+    display_plugin: page
+    id: widget_table
+    display_title: 'Widget (table)'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      path: admin/content/media-widget-table
+      css_class: 'media-library-view js-media-library-view media-library-view--widget'
+      defaults:
+        css_class: false
+        style: false
+        row: false
+        fields: false
+        access: false
+        filters: false
+        filter_groups: false
+        arguments: false
+        header: false
+      style:
+        type: table
+        options:
+          row_class: 'media-library-item media-library-item--table js-media-library-item js-click-to-select'
+          default_row_class: true
+      row:
+        type: fields
+      fields:
+        media_library_select_form:
+          id: media_library_select_form
+          label: ''
+          table: media
+          field: media_library_select_form
+          relationship: none
+          entity_type: media
+          plugin_id: media_library_select_form
+          element_wrapper_class: js-click-to-select-checkbox
+          element_class: ''
+        thumbnail__target_id:
+          id: thumbnail__target_id
+          label: Thumbnail
+          table: media_field_data
+          field: thumbnail__target_id
+          relationship: none
+          type: image
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
+          settings:
+            image_style: media_library
+            image_link: ''
+        name:
+          id: name
+          label: Name
+          table: media_field_data
+          field: name
+          relationship: none
+          type: string
+          entity_type: media
+          entity_field: name
+          plugin_id: field
+          settings:
+            link_to_entity: false
+        uid:
+          id: uid
+          label: Author
+          table: media_field_revision
+          field: uid
+          relationship: none
+          type: entity_reference_label
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
+          settings:
+            link: true
+        changed:
+          id: changed
+          label: Updated
+          table: media_field_data
+          field: changed
+          relationship: none
+          type: timestamp
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+      access:
+        type: perm
+        options:
+          perm: 'view media'
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: media
+          entity_field: name
+          plugin_id: string
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      arguments:
+        bundle:
+          id: bundle
+          table: media_field_data
+          field: bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
+      header:
+        display_link_grid:
+          id: display_link_grid
+          table: views
+          field: display_link
+          display_id: widget
+          label: Grid
+          plugin_id: display_link
+          empty: true
+        display_link_table:
+          id: display_link_table
+          table: views
+          field: display_link
+          display_id: widget_table
+          label: Table
+          plugin_id: display_link
+          empty: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - user.permissions
+      tags: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/workflows.workflow.00c7e3ae.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/workflows.workflow.00c7e3ae.yml
@@ -137,3 +137,4 @@ type_settings:
       - topic
       - topic_page
       - video_resource
+  default_moderation_state: draft

--- a/_docker/drupal/managed-platform/ansible/bootstrap-drupal.yml
+++ b/_docker/drupal/managed-platform/ansible/bootstrap-drupal.yml
@@ -25,7 +25,7 @@
         msg: "{{ (drush_rc.changed) | ternary(drush_rc.stderr_lines, drush_rc.stdout_lines) }}"
 
     - name: Run Drupal Module Database Updates
-      shell: 'drush -y --entity-updates updb && drush cr && touch {{ work_dir }}/drupal.updb.do.not.delete'
+      shell: 'drush -y updb && drush cr && touch {{ work_dir }}/drupal.updb.do.not.delete'
       register: entity_updates
       args:
         chdir: '/var/www/drupal/web'

--- a/_docker/tests/drupal/drupal_install_checker_test.rb
+++ b/_docker/tests/drupal/drupal_install_checker_test.rb
@@ -87,7 +87,7 @@ class DrupalInstallCheckerTest < Minitest::Test
 
 
     @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(--root=/var/www/drupal/web cr)]
-    @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(-y --root=/var/www/drupal/web --entity-updates updb)]
+    @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(-y --root=/var/www/drupal/web updb)]
     @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(--root=/var/www/drupal/web cr)]
     @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(--root=/var/www/drupal/web update:lightning --no-interaction)]
     @process_exec.expect :exec!, true, ['/var/www/drupal/vendor/bin/drush', %w(--root=/var/www/drupal/web cr)]


### PR DESCRIPTION
This implements the Drupal core update from 8.6.15 to 8.7.1, which
includes a necessary Lighting update to 3.3.1. After making these
updates with a `composer update drupal/core acquia/lightning
--with-dependencies`, I rebuilt the cache and then ran `drush updb`,
then I rebuilt the cache and ran `drush update:lightning`. Lastly, I
rebuilt the cache, verified the site was loading and that there weren't
errors in the logs, and after verifying that, I exported config.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5840

### Verification Process

* Visit: /admin/reports/status and verify we are on Drupal core version 8.7.1
* The site passes with all green tests
* The site functions exactly as it currently does but on the new Drupal core version


### Drupal 8.7.0 Release Notes

https://www.drupal.org/project/drupal/releases/8.7.0

The Drupal 8.7.1 release notes are mostly uninteresting and really only include the fix for SA-CORE-2019-007: https://www.drupal.org/SA-CORE-2019-007