### PR TITLE
DEVELOPER-5830 Fix multiple downloads on media pages

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/terms-and-conditions.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/terms-and-conditions.js
@@ -51,6 +51,10 @@ app.termsAndConditions = {
     var tmpTcWhenSigned = tcWhenSigned ? $.encoder.encodeForHTML(tcWhenSigned) : "";
     tcProduct = tcProduct.replace(/\+/g, ' ');
 
+    if ($('body.page-media-download-confirmation').length) {
+      return;
+    }
+
     if (tcEndsIn) {
       if (tcEndsIn == "1") {
         tmpTcEndsIn = "one day ";


### PR DESCRIPTION
### JIRA Issue Link
[DEVELOPER-5830 - Fix multiple downloads on media page](https://issues.jboss.org/browse/DEVELOPER-5830)

### Verification Process
The media download thank you page should only display one of the blue banners, and it should only download the file once.

To test this go to: /cheat-sheets/podman-basics/

**Note:** when testing this, you'll need to go back to the PR build after logging in, otherwise you'll be testing the staging media thank you page