### PR TITLE
[MWES-3085] Ensured that unit tests run on blessed Docker Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,5 @@ _docker/drupal/drupal-filesystem/web/.ht.router.php
 _docker/drupal/drupal-filesystem/web/sites/example.settings.local.php
 _docker/drupal/drupal-filesystem/web/sites/example.sites.php
 _docker/drupal/drupal-filesystem/web/rhdp-apps
-_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/report/unit-test-report.html
+_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/report
 _docker/drupal/drupal-filesystem/web/themes/contrib

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/.dockerignore
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/.dockerignore
@@ -1,0 +1,12 @@
+favicons
+images
+node_modules
+src/docs
+styles
+rhd.js
+rhd.css
+.dockerignore
+.eslintrc.yml
+.eslintignore
+.gitignore
+.travis.yml

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/.dockerignore
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/.dockerignore
@@ -2,6 +2,7 @@ favicons
 images
 node_modules
 src/docs
+src/tests/unit/report
 styles
 rhd.js
 rhd.css

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
@@ -8,5 +8,4 @@ RUN npm install \
     && chmod -R 777 /testing
 
 RUN gem install bundler:1.16.1 octokit:4.6.2 --no-rdoc --no-ri
-ENV PATH /testing/node_modules/.bin:$PATH
 USER 1001

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
@@ -1,17 +1,12 @@
-FROM test-base:2.3.0
+FROM images.paas.redhat.com/rhdp/developer-testing-base
 
-RUN curl -O -L https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
-    && yum -y install google-chrome-stable_current_x86_64.rpm \
-       liberation-mono-fonts \
-       liberation-narrow-fonts \
-       liberation-sans-fonts \
-       liberation-serif-fonts
+RUN mkdir /testing
+WORKDIR /testing
+COPY . /testing
 
-RUN groupadd -g 1000 unit \
-    && useradd -g unit -m -s /bin/bash -u 1000 unit
-WORKDIR /home/unit
-COPY package.json ./
-COPY package-lock.json ./
-RUN npm install
-USER unit
-ENV PATH /home/unit/node_modules/.bin:$PATH
+RUN npm install \
+    && chmod -R 777 /testing
+
+RUN gem install bundler:1.16.1 octokit:4.6.2 --no-rdoc --no-ri
+ENV PATH /testing/node_modules/.bin:$PATH
+USER 1001

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/config/karma.conf.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/config/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function (config) {
         frameworks: ['jasmine-ajax', 'jasmine'],
         reporters: ['progress', 'html'],
         htmlReporter: {
-            outputFile: '../report/unit-test-report.html',
+            outputFile: '../report/index.html',
             pageTitle: 'RHD frontend unit-test results'
         },
         failOnEmptyTestSuite: false,

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/config/karma.conf.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/config/karma.conf.js
@@ -2,7 +2,7 @@
 // Karma configuration for running unit-tests in Docker
 module.exports = function (config) {
     config.set({
-        browsers: ['ChromeHeadless'],
+        browsers: ['ChromeNoSandbox'],
         plugins: [
             'karma-chrome-launcher',
             'karma-jasmine',
@@ -31,6 +31,15 @@ module.exports = function (config) {
             '../../../../rhd.min.js',
             '../../../../init.js',
             '../**/*_spec.js'
-      ]
+      ],
+      customLaunchers: {
+          ChromeNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: [
+              '--no-sandbox',
+              '--user-data-dir=/tmp'
+            ]
+          }
+      }
     })
 };

--- a/_docker/tests/test-runner/test_run_tests.rb
+++ b/_docker/tests/test-runner/test_run_tests.rb
@@ -24,13 +24,11 @@ class TestRunTests < MiniTest::Test
     test_configuration = {}
     test_configuration[:docker] = true
     test_configuration[:run_tests_command] = 'npm run test:docker'
+    test_configuration[:unit] = true
 
     @run_tests_options.expects(:parse_command_line).with(%w(--use-docker)).returns(test_configuration)
 
-    @process_runner.expects(:execute!).with('cd /tmp/_tests && docker build -t test-base:2.3.0 .')
-
-    @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p rhd_unit_testing build')
-
+    @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p rhd_unit_testing build --pull')
     @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p rhd_unit_testing run --rm --no-deps rhd_unit_testing npm run test:docker')
 
     @run_tests.execute_tests(%w(--use-docker))
@@ -43,13 +41,11 @@ class TestRunTests < MiniTest::Test
     test_configuration = {}
     test_configuration[:docker] = true
     test_configuration[:run_tests_command] = 'npm run test:docker'
+    test_configuration[:unit] = true
 
     @run_tests_options.expects(:parse_command_line).with(%w(--use-docker)).returns(test_configuration)
 
-    @process_runner.expects(:execute!).with('cd /tmp/_tests && docker build -t test-base:2.3.0 .')
-
-    @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p foo build')
-
+    @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p foo build --pull')
     @process_runner.expects(:execute!).with('cd /tmp/_tests/unit/environments && docker-compose -p foo run --rm --no-deps rhd_unit_testing npm run test:docker')
 
     @run_tests.execute_tests(%w(--use-docker))

--- a/_tests/run_tests.rb
+++ b/_tests/run_tests.rb
@@ -47,7 +47,7 @@ class RunTest
     compose_environment_directory = "#{@test_dir}/#{ENV['rhd_test']}/environments"
 
     @log.info("Launching #{ENV['rhd_test']} testing environment...")
-    @process_runner.execute!("cd #{compose_environment_directory} && docker-compose -p #{compose_project_name} build #{"--pull" if test_configuration[:unit]}")
+    @process_runner.execute!("cd #{compose_environment_directory} && docker-compose -p #{compose_project_name} build#{" --pull" if test_configuration[:unit]}")
 
     if test_configuration[:e2e]
       if test_configuration[:browserstack]

--- a/_tests/run_tests.rb
+++ b/_tests/run_tests.rb
@@ -47,7 +47,7 @@ class RunTest
     compose_environment_directory = "#{@test_dir}/#{ENV['rhd_test']}/environments"
 
     @log.info("Launching #{ENV['rhd_test']} testing environment...")
-    @process_runner.execute!("cd #{compose_environment_directory} && docker-compose -p #{compose_project_name} build")
+    @process_runner.execute!("cd #{compose_environment_directory} && docker-compose -p #{compose_project_name} build #{"--pull" if test_configuration[:unit]}")
 
     if test_configuration[:e2e]
       if test_configuration[:browserstack]

--- a/_tests/run_tests.rb
+++ b/_tests/run_tests.rb
@@ -41,7 +41,8 @@ class RunTest
   # a number of Docker commands in sequence.
   #
   def run_tests_in_docker(test_configuration)
-    build_base_docker_image(@test_dir)
+
+    build_base_docker_image(@test_dir) unless test_configuration[:unit]
     compose_project_name = docker_compose_project_name
     compose_environment_directory = "#{@test_dir}/#{ENV['rhd_test']}/environments"
 

--- a/_tests/unit/environments/docker-compose.yml
+++ b/_tests/unit/environments/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   rhd_unit_testing:
     build: ../../../_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend
+    user: '1000'
     volumes:
     - ../../../:/developers.redhat.com
     - ../../../_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/report:/testing/src/tests/unit/report

--- a/_tests/unit/environments/docker-compose.yml
+++ b/_tests/unit/environments/docker-compose.yml
@@ -4,10 +4,11 @@ services:
     build: ../../../_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend
     volumes:
     - ../../../:/developers.redhat.com
+    - ../../../_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/report:/testing/src/tests/unit/report
     entrypoint:
       - '/bin/bash'
       - '-c'
-      - 'source /etc/scl_enable && ruby /developers.redhat.com/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb npm test'
+      - 'source /etc/scl_enable && ruby /developers.redhat.com/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb npm test && cp src/tests/unit/report/index.html src/tests/unit/report/unit-test-report.html'
     working_dir: /testing
     environment:
     - github_status_enabled

--- a/_tests/unit/environments/docker-compose.yml
+++ b/_tests/unit/environments/docker-compose.yml
@@ -3,9 +3,12 @@ services:
   rhd_unit_testing:
     build: ../../../_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend
     volumes:
-    - ../../../:/home/unit/developers.redhat.com
-    entrypoint: ruby /home/unit/developers.redhat.com/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb
-    working_dir: /home/unit/developers.redhat.com/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend
+    - ../../../:/developers.redhat.com
+    entrypoint:
+      - '/bin/bash'
+      - '-c'
+      - 'source /etc/scl_enable && ruby /developers.redhat.com/_docker/lib/pull_request/exec_with_git_hub_status_wrapper.rb npm test'
+    working_dir: /testing
     environment:
     - github_status_enabled
     - github_status_api_token
@@ -13,5 +16,3 @@ services:
     - github_status_repo=redhat-developer/developers.redhat.com
     - github_status_target_url=${BUILD_URL}artifact/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/tests/unit/report/unit-test-report.html
     - github_status_sha1
-    cap_add:
-    - SYS_ADMIN


### PR DESCRIPTION
This PR updates the unit tests to run on Blessed Docker images ahead of our migration to Managed Platform for pull request builds.

In particular this PR:

- Ensures that unit tests run in a blessed container
- Ensures that the unit tests run as a non-root user (using root user is not supported on Managed Platform)
- Ensures that the unit tests container operates in non-priviledged mode (this is not supported on Managed Platform)

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3085

### Verification Process

- Unit tests should go green
- You can visit the test report successfully in Jenkins