### PR TITLE
DEVELOPER-5847: Twig Tweak Type Error

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/books/node--books--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/books/node--books--card.html.twig
@@ -11,6 +11,7 @@
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
   <a href="{{ url }}">
+    {% if content.field_cover_image.0 is not empty %}
     <div class="card-image">
       <div class="table">
         <div class="cell">
@@ -18,6 +19,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
     <div class="content-block">
       <div class="asset-type">{% if login_req %}<span class="login-required" title="Free for members"><span class="fas fa-users"></span></span>{% endif %}EBook</div>
       <h3 class="card-title">{{ label }}</h3>


### PR DESCRIPTION
I have added a validation check around our markup for the image in the
Books Card template. This resolves the issue that Gina was experiencing
with the Featured Resources assembly type.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5847

### Verification Process

* Create a Basic Page and add a Featured Resources assembly type
* Add Drools Developer’s Cookbook to the entity reference field (autocomplete) of that Featured Resources assembly
* Save the Basic Page and view it
* You should not receive any error, and you should be able to view the page
* It should look something like this

<img width="1345" alt="Screen Shot 2019-05-17 at 7 37 19 AM" src="https://user-images.githubusercontent.com/7155034/57935422-9ef76c00-7876-11e9-8584-15bb9e683d6f.png">
