### PR TITLE
[MWES-2920] Run pull request builds on Managed Platform

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+@Library('RedHatDevelopersPipelineUtils')
+import com.redhat.developer.pr.*
+import com.redhat.developer.mp.*
+
+properties([
+        [$class: 'ParametersDefinitionProperty', parameterDefinitions:
+                [
+                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The id of the Pull Request that should be built.', name: 'PULL_REQUEST_ID'],
+                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The current ref that is being built.', name: 'PULL_REQUEST_REF'],
+                ]
+        ]
+])
+
+
+node('cic-rhd-01') {
+
+    timeout(10) {
+
+        stage("Sanity Check") {
+
+            if(!params.PULL_REQUEST_ID) {
+                error "Please provide a pull request id."
+            }
+
+            if(!params.PULL_REQUEST_REF) {
+                error "Please provide the ref of the pull request being built."
+            }
+        }
+
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'robpblake-github-token', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+
+            waitForMpBuildToStart(gitRepository: 'robpblake/developers.redhat.com', pullRequestRef: "${params.PULL_REQUEST_REF}", cause: "The CI Build is complete.", gitApiCredentials: "${env.PASSWORD}") {
+                echo "Waiting for build for pull request '${params.PULL_REQUEST_ID}' at ref '${params.PULL_REQUEST_REF}' to start..."
+            }
+        }
+
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,9 @@
+/*
+    This pipeline is used to send a webhook from the legacy RHD Jenkins instance to the "new" Jenkins instance running on Managed Platform.
+
+    This pipeline is not intended to be run directly, but instead called by our existing Jenkins Job and passed parameters from the GitHub Pull Request Builder
+    plugin, namely the ID of the pull request that is being built and the SHA of the tip of that branch.
+ */
 @Library('RedHatDevelopersPipelineUtils')
 import com.redhat.developer.pr.*
 import com.redhat.developer.mp.*
@@ -29,13 +35,21 @@ node('cic-rhd-01') {
 
         def cause = "${params.PULL_REQUEST_REF}-${env.BUILD_NUMBER}"
 
+        /*
+            Firstly trigger the job on jenkins.paas.redhat.com by sending a web-hook with the ID of the pull request that we're building and the cause
+            defined as the current HEAD reference of the PR branch and then the current build number
+         */
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'redhat-developer-automated', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
-            String jenkinsJob = "https://jenkins.paas.redhat.com/generic-webhook-trigger/invoke?token=rhdp-pr-build"
+            def jenkinsJob = "https://jenkins.paas.redhat.com/generic-webhook-trigger/invoke?token=rhdp-pr-build"
             scheduleMpBuild(pullRequestId: "${params.PULL_REQUEST_ID}", cause: cause, jenkinsJob: jenkinsJob, jenkinsUser: env.USERNAME, jenkinsPassword: env.PASSWORD)
         }
 
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'robpblake-github-token', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
-            waitForMpBuildToStart(gitRepository: 'robpblake/developers.redhat.com', pullRequestRef: "${params.PULL_REQUEST_REF}", cause: cause, gitApiCredentials: "${env.PASSWORD}")
+        /*
+            And then we wait for that build to appear to be running on jenkins.paas.redhat.com. In particular we're waiting to see the above cause appear on the list
+            of statuses for our pull request.
+         */
+        withCredentials([string(credentialsId: 'e4d8cc35-9cfd-4df5-a842-eed5f4b6faf0', variable: 'TOKEN')]) {
+            waitForMpBuildToStart(gitRepository: 'redhat-developer/developers.redhat.com', pullRequestRef: "${params.PULL_REQUEST_REF}", cause: cause, gitApiCredentials: TOKEN)
         }
     }
 }

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/phinx.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/phinx.yml.j2
@@ -1,0 +1,18 @@
+paths:
+    migrations: db-migrations
+
+environments:
+    default_migration_table: phinxlog
+    default_database: automated
+    automated:
+        adapter: mysql
+        host: {{ drupal_db_host }}
+        name: {{ deployment_dbs[0] }}
+        user: {{ drupal_db_user }}
+        pass: {{ drupal_db_password }}
+        port: 3306
+        charset: utf8
+        mysql_attr_ssl_ca: /etc/pki/ca-trust/source/anchors/RH-IT-pki-validation-chain.pem
+        mysql_attr_ssl_verify_server_cert: false
+
+version_order: creation

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/phinx.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/phinx.yml.j2
@@ -12,7 +12,5 @@ environments:
         pass: {{ drupal_db_password }}
         port: 3306
         charset: utf8
-        mysql_attr_ssl_ca: /etc/pki/ca-trust/source/anchors/RH-IT-pki-validation-chain.pem
-        mysql_attr_ssl_verify_server_cert: false
 
 version_order: creation

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -1,0 +1,103 @@
+<?php
+use Symfony\Component\Yaml\Yaml;
+
+if (file_exists(__DIR__ . '/rhd.settings.yml')) {
+  $yml_settings = Yaml::parse(file_get_contents(__DIR__ . "/rhd.settings.yml"));
+  $config['redhat_developers'] = $yml_settings;
+}
+
+$settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
+
+$databases['default']['default'] = array (
+  'database' => '{{ deployment_dbs[0] }}',
+  'username' => '{{ drupal_db_user }}',
+  'password' => '{{ drupal_db_password }}',
+  'prefix' => 'lightning_',
+  'host' => '{{ drupal_db_host }}',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+  'pdo' => [
+    \PDO::MYSQL_ATTR_SSL_CA => '/etc/pki/ca-trust/source/anchors/RH-IT-pki-validation-chain.pem',
+    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false
+  ]
+);
+
+$config['automated_cron.settings']['interval'] = 0;
+/* Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits */
+ini_set('memory_limit', '256M');
+
+/* Relax Transaction Isolation to READ-COMMITTED: https://www.drupal.org/project/drupal/issues/2833539  */
+$databases['default']['default']['init_commands']['isolation'] = "SET SESSION tx_isolation='READ-COMMITTED'";
+$settings['trusted_host_patterns'] = [
+    '^{{ drupal_url }}',
+    '^{{ drupal_previous_url }}',
+    '^{{ drupal_next_url }}'
+];
+
+$config['simple_sitemap.settings']['base_url'] = "https://{{ drupal_url }}";
+
+#
+# Set the Akamai network that purge requests should go to
+#
+$config['akamai.settings']['domain']['production'] = false;
+$config['akamai.settings']['domain']['staging'] = true;
+
+// Get the specific config object, as an array, that we will use to set the
+// OpenID Config object.
+$content_editor_sso_config = $config["redhat_developers"]["keycloak"]["content_editor_sso"];
+
+// Ensure that all of the necessary SSO config is available.
+if ((isset($content_editor_sso_config["redirect_url"]) && !empty($content_editor_sso_config["redirect_url"]))
+    && (isset($content_editor_sso_config["client_id"]) && !empty($content_editor_sso_config["client_id"]))
+    && (isset($content_editor_sso_config["client_secret"]) && !empty($content_editor_sso_config["client_secret"]))
+    && (isset($content_editor_sso_config["keycloak_base"]) && !empty($content_editor_sso_config["keycloak_base"]))
+    && (isset($content_editor_sso_config["keycloak_realm"]) && !empty($content_editor_sso_config["keycloak_realm"]))
+    && (isset($content_editor_sso_config["authorization_endpoint_kc"]) && !empty($content_editor_sso_config["authorization_endpoint_kc"]))
+    && (isset($content_editor_sso_config["token_endpoint_kc"]) && !empty($content_editor_sso_config["token_endpoint_kc"]))
+    && (isset($content_editor_sso_config["userinfo_endpoint_kc"]) && !empty($content_editor_sso_config["userinfo_endpoint_kc"]))) {
+
+  // Set the OpenID config object using data from our redhat_developers config.
+  $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = $content_editor_sso_config["redirect_url"];
+  $config["openid_connect.settings.keycloak"]["settings"]["client_id"] = $content_editor_sso_config["client_id"];
+  $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = $content_editor_sso_config["client_secret"];
+  $config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = $content_editor_sso_config["keycloak_base"];
+  $config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = $content_editor_sso_config["keycloak_realm"];
+  $config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = $content_editor_sso_config["authorization_endpoint_kc"];
+  $config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = $content_editor_sso_config["token_endpoint_kc"];
+  $config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = $content_editor_sso_config["userinfo_endpoint_kc"];
+}
+else {
+  // The array keys of the SSO config variables.
+  $sso_array_keys = [
+    'redirect_url',
+    'client_id',
+    'client_secret',
+    'keycloak_base',
+    'keycloak_realm',
+    'authorization_endpoint_kc',
+    'token_endpoint_kc',
+    'userinfo_endpoint_kc'
+  ];
+  // Will hold a list of the SSO config variables keys had no value (or an empty value).
+  $unset_array_keys = [];
+
+  foreach ($sso_array_keys as $key) {
+    if (!isset($content_editor_sso_config[$key]) || empty($content_editor_sso_config[$key])) {
+      $unset_array_keys[] = $key;
+    }
+  }
+
+  // Log a notice that denotes any unset, but required, SSO config variable(s).
+  \Drupal::logger('rhd_build')->notice(
+    'Skipping SSO configuration as the following required variables are not set: @unset_variables.', [
+      '@unset_variables' => implode(', ', $unset_array_keys)
+    ]
+  );
+}
+
+# MWES-2462: Omit the vary: cookie HTTP header to better integrate with Akamai caching
+$settings['omit_vary_cookie'] = TRUE;
+
+# MWES-2910: Enable trailing_slash module in MP-based deployments
+$config['trailing_slash.settings']['enabled'] = TRUE;

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -16,11 +16,7 @@ $databases['default']['default'] = array (
   'host' => '{{ drupal_db_host }}',
   'port' => '3306',
   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-  'pdo' => [
-    \PDO::MYSQL_ATTR_SSL_CA => '/etc/pki/ca-trust/source/anchors/RH-IT-pki-validation-chain.pem',
-    \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false
-  ]
+  'driver' => 'mysql'
 );
 
 $config['automated_cron.settings']['interval'] = 0;

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
@@ -7,11 +7,11 @@ sentry_code: '{{ drupal_sentry_code }}'
 rhd_base_url: '{{ drupal_url }}'
 rhd_final_base_url: '{{ drupal_url }}'
 downloadManager:
-  baseUrl: 'https://developers.stage.redhat.com'
-  fileBaseUrl: '//developers.stage.redhat.com/download-manager/file/'
+  baseUrl: 'https://developers.redhat.com'
+  fileBaseUrl: '//developers.redhat.com/download-manager/file/'
 keycloak:
-  accountUrl: 'https://developers.stage.redhat.com/auth/realms/rhd/account/'
-  authUrl: 'https://developers.stage.redhat.com/auth/'
+  accountUrl: 'https://developers.redhat.com/auth/realms/rhd/account/'
+  authUrl: 'https://developers.redhat.com/auth/'
   content_editor_sso:
     redirect_url: 'https://{{ drupal_url }}/openid-connect/keycloak'
     client_id: {{ drupal_content_editor_sso_client_id }}
@@ -22,12 +22,12 @@ keycloak:
     token_endpoint_kc: 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token'
     userinfo_endpoint_kc: 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo'
 drupal:
-  host: https://developers.dev.redhat.com
+  host: '{{ drupal_url }}'
 searchisko:
   protocol: 'https'
-  host: dcp.stage.jboss.org
+  host: dcp.jboss.org
   port: "443"
-  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:443'
+  baseProtocolRelativeUrl: 'dcp.jboss.org:443'
 database:
   host: '{{ drupal_db_host }}'
   port: '3306'

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
@@ -25,9 +25,9 @@ drupal:
   host: '{{ drupal_url }}'
 searchisko:
   protocol: 'https'
-  host: dcp.jboss.org
+  host: dcp.stage.jboss.org
   port: "443"
-  baseProtocolRelativeUrl: 'dcp.jboss.org:443'
+  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:443'
 database:
   host: '{{ drupal_db_host }}'
   port: '3306'

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
@@ -1,0 +1,36 @@
+environment: 'dev'
+broker: 'https://broker.staging.redhat.com/partner/drc/userMapping?redirect='
+dtm_code: 'https://www.redhat.com/dtm-staging.js'
+sentry_track: false
+sentry_script: 'https://cdn.ravenjs.com/3.23.1/raven.min.js'
+sentry_code: '{{ drupal_sentry_code }}'
+rhd_base_url: '{{ drupal_url }}'
+rhd_final_base_url: '{{ drupal_url }}'
+downloadManager:
+  baseUrl: 'https://developers.stage.redhat.com'
+  fileBaseUrl: '//developers.stage.redhat.com/download-manager/file/'
+keycloak:
+  accountUrl: 'https://developers.stage.redhat.com/auth/realms/rhd/account/'
+  authUrl: 'https://developers.stage.redhat.com/auth/'
+  content_editor_sso:
+    redirect_url: 'https://{{ drupal_url }}/openid-connect/keycloak'
+    client_id: {{ drupal_content_editor_sso_client_id }}
+    client_secret: {{ drupal_content_editor_sso_client_secret }}
+    keycloak_base: 'https://developers.stage.redhat.com/auth'
+    keycloak_realm: 'rhd'
+    authorization_endpoint_kc: 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/auth'
+    token_endpoint_kc: 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token'
+    userinfo_endpoint_kc: 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo'
+drupal:
+  host: https://developers.dev.redhat.com
+searchisko:
+  protocol: 'https'
+  host: dcp.stage.jboss.org
+  port: "443"
+  baseProtocolRelativeUrl: 'dcp.stage.jboss.org:443'
+database:
+  host: '{{ drupal_db_host }}'
+  port: '3306'
+  username: '{{ drupal_db_user }}'
+  password: '{{ drupal_db_password }}'
+  name: '{{ deployment_dbs[0] }}'

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
@@ -7,11 +7,11 @@ sentry_code: '{{ drupal_sentry_code }}'
 rhd_base_url: '{{ drupal_url }}'
 rhd_final_base_url: '{{ drupal_url }}'
 downloadManager:
-  baseUrl: 'https://developers.redhat.com'
-  fileBaseUrl: '//developers.redhat.com/download-manager/file/'
+  baseUrl: 'https://developers.stage.redhat.com'
+  fileBaseUrl: '//developers.stage.redhat.com/download-manager/file/'
 keycloak:
-  accountUrl: 'https://developers.redhat.com/auth/realms/rhd/account/'
-  authUrl: 'https://developers.redhat.com/auth/'
+  accountUrl: 'https://developers.stage.redhat.com/auth/realms/rhd/account/'
+  authUrl: 'https://developers.stage.redhat.com/auth/'
   content_editor_sso:
     redirect_url: 'https://{{ drupal_url }}/openid-connect/keycloak'
     client_id: {{ drupal_content_editor_sso_client_id }}

--- a/_tests/.dockerignore
+++ b/_tests/.dockerignore
@@ -1,0 +1,3 @@
+e2e/node_modules
+e2e/tmp_downloads
+e2e/reports

--- a/_tests/e2e/.dockerignore
+++ b/_tests/e2e/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+tmp_downloads
+report
+rules-of-thumb.png

--- a/_tests/e2e/tests/config/wdio.conf.base.js
+++ b/_tests/e2e/tests/config/wdio.conf.base.js
@@ -8,7 +8,7 @@ const testType = typeof commandlineArgs.testType === 'undefined' ? 'export' : co
 const exclude = testType === 'export' ? 'drupal' : 'export';
 
 let host;
-if (commandlineArgs['base-url'].includes('developers-pr') && testType === 'drupal') {
+if (commandlineArgs['base-url'].includes('developers-pr.stage.redhat.com') && testType === 'drupal') {
     const parsedUrl = require('url').parse(commandlineArgs['base-url']);
     const prNumber = parseInt(parsedUrl.pathname.split('/')[2]);
     host = `http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:${(35000 + prNumber)}`;

--- a/_tests/e2e/tests/specs/export/rhd-downloads.spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-downloads.spec.js
@@ -24,15 +24,23 @@ tags('desktop').describe('Download Manager', function() {
             expect(downloadName.toString(), 'rhel download was not triggered').to.include('rhel');
         });
 
+    /*
+        Disabling this in managed paas environments until we can work out how to support downloads of content in lower environments
+     */
     it('should allow users to log-in and download advanced-linux-commands', function() {
-            CheatSheets
-                .open('advanced-linux-commands')
-                .loginToDownload();
-            Login.with(process.env.RHD_KEYCLOAK_ADMIN_USERNAME, process.env.RHD_KEYCLOAK_ADMIN_PASSWORD);
-            CheatSheets.awaitDownloadThankYou();
-            const downloadName = DownloadDir.get();
-            expect(downloadName.toString(), 'rhel advanced linux cheatsheet download was not triggered').to.include('rheladvancedlinux_cheat_sheet');
-        });
+
+        if(Utils.isManagedPaasEnvironment() === false) {
+
+                CheatSheets
+                    .open('advanced-linux-commands')
+                    .loginToDownload();
+                Login.with(process.env.RHD_KEYCLOAK_ADMIN_USERNAME, process.env.RHD_KEYCLOAK_ADMIN_PASSWORD);
+                CheatSheets.awaitDownloadThankYou();
+                const downloadName = DownloadDir.get();
+                expect(downloadName.toString(), 'rhel advanced linux cheatsheet download was not triggered').to.include('rheladvancedlinux_cheat_sheet');
+
+            }
+    });
 
     afterEach(function() {
         DownloadDir.clear(global.downloadDir);

--- a/_tests/e2e/tests/specs/support/utils/Utils.js
+++ b/_tests/e2e/tests/specs/support/utils/Utils.js
@@ -4,10 +4,15 @@ import Driver from '../utils/Driver.Extension';
 
 
 class Utils {
+
+    isManagedPaasEnvironment() {
+        return config.baseUrl.includes('.preprod.paas.redhat.com')
+    }
+
     cleanSession() {
         let logoutLink;
         const encodedURL = qs.escape(config.baseUrl);
-        if (config.baseUrl === 'https://developers.stage.redhat.com') {
+        if (config.baseUrl === 'https://developers.stage.redhat.com' || this.isManagedPaasEnvironment()) {
             logoutLink = `https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
         } else {
             logoutLink = `https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;

--- a/previews/README.md
+++ b/previews/README.md
@@ -1,0 +1,124 @@
+### Developer Preview Environments
+
+This directory contains a few utility scripts to help you connect to the preview environment associated with your pull
+request build.
+
+#### Getting started
+
+##### Install the Openshift CLI
+
+Before you can use these scripts you will need to install the Openshift Command Line tools (OC). The current version of 
+OC that is supported is 3.11.
+
+The OC binary can be downloaded from the following locations:
+
+* Mac Users: [https://mojo.redhat.com/thread/953528](https://mojo.redhat.com/thread/953528)
+* Unix Users: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+
+Download the binary and install it somewhere into your $PATH. Once installed you should be able to run:
+
+```bash
+which oc
+```
+
+The Managed Platform clusters enforce GSSAPI/Kerberos authentication on all environments, so once you have the binary installed
+ensure that `oc version` from the command line shows you something like this:
+
+```bash
+Robs-Mac-mini:previews Rob$ oc version
+oc v3.11.0+02103b0-103-dirty
+kubernetes v1.11.0+d4cacc0
+features: Basic-Auth GSSAPI Kerberos SPNEGO
+
+Server https://manage.us-west.dc.preprod.paas.redhat.com:443
+openshift v3.11.88
+kubernetes v1.11.0+d4cacc0
+```
+
+The bit you're looking for is `features: Basic-Auth GSSAPI Kerberos SPNEGO`. If that all looks good, you're set to continue.
+
+
+##### Configure Kerberos Authentication
+
+Next you need to follow ITs instructions on how to configure Kerberos authentication. The instructions are [here](https://mojo.redhat.com/docs/DOC-1153539#jive_content_id_Using_the_IPAREDHATCOM_Realm_without_joining_your_system_as_an_IdM_Client) and include
+details for Mac users.
+
+Once you've followed their instructions, you should be able to do the following:
+
+```bash
+kinit <username>@IPA.REDHAT.COM
+oc login manage.us-west.dc.preprod.paas.redhat.com -u <username>
+```
+
+##### Create local configuration
+
+Finally copy the [oc-config.sh.example](oc-config.sh.example) to `oc-config.sh`. This configures the helper scripts with details
+specific to your account. You should under no circumstances check this file into Git and it is configured already in the `.gitignore`
+of this directory.
+
+
+#### Connecting to Drupal in your preview environment
+
+You can connect to the Drupal container for your pull request by running the following:
+
+```bash
+./connect-to-drupal.sh <pull_request_id>
+```
+
+So for pull request 39, that would be:
+
+```bash
+./connect-to-drupal.sh 39
+```
+
+This will drop you into a `bash` shell on the Drupal container. Once there you should additionally run:
+
+```bash
+source /etc/scl_enable
+```
+
+You can now browse around the container as you see fit to investigate any issues with your preview environment.
+
+
+#### Connecting to the database in your preview environment
+
+To connect to the database in your preview environment use the following:
+
+```bash
+./connnect-to-db.sh <pull_request_id>
+```
+
+So for pull request 39 that would be:
+
+```bash
+./connect-to-db.sh 39
+```
+
+#### Viewing the boot logs for Drupal in your preview environment
+
+For whatever reason it may be that Drupal is not booting after your latest changes. You can view the Drupal boot sequence
+to diagnose any problems with the following:
+
+```bash
+./view-drupal-boot-logs.sh <pull_request_id>
+```
+
+So for pull request 39 that would be:
+
+```bash
+./view-drupal-boot-logs.sh 39
+```
+
+#### Watching the Drupal logs
+
+You can also watch requests as they come into Drupal to help diagnose any issues. Use the following for that:
+
+```bash
+./view-drupal-logs.sh <pull_request_id>
+```
+
+So for pull request 39 that would be:
+
+```bash
+./view-drupal-logs.sh 39
+```

--- a/previews/connect-to-db.sh
+++ b/previews/connect-to-db.sh
@@ -1,0 +1,27 @@
+#
+# Connects to the Drupal database in the preview environment for the given pull request
+#
+#!/usr/bin/env bash
+set -e
+
+OC=$(which oc)
+if [[ oc == '' ]]; then
+    echo "Please install the Openshift Command Line Client"
+    exit 1
+fi
+
+PULL_REQUEST_ID=$1
+
+if [[ $PULL_REQUEST_ID == '' ]]; then
+    echo "Please specific a pull request id"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+if [[ -f "$DIR/oc-config.sh" ]]; then
+    source "$DIR/oc-config.sh"
+fi
+
+${OC} login manage.us-west.dc.preprod.paas.redhat.com -u ${OC_USER}
+${OC} project rhdp--preview
+${OC} rsh --shell=/bin/bash "drupal-deployment-preview-$PULL_REQUEST_ID-0" /bin/bash -c "source /etc/scl_enable && eval \$(drush sql:connect)"

--- a/previews/connect-to-drupal.sh
+++ b/previews/connect-to-drupal.sh
@@ -1,0 +1,27 @@
+#
+# Connects to Drupal in the preview environment for the given pull request
+#
+#!/usr/bin/env bash
+set -e
+
+OC=$(which oc)
+if [[ oc == '' ]]; then
+    echo "Please install the Openshift Command Line Client"
+    exit 1
+fi
+
+PULL_REQUEST_ID=$1
+
+if [[ $PULL_REQUEST_ID == '' ]]; then
+    echo "Please specific a pull request id"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+if [[ -f "$DIR/oc-config.sh" ]]; then
+    source "$DIR/oc-config.sh"
+fi
+
+${OC} login manage.us-west.dc.preprod.paas.redhat.com -u ${OC_USER}
+${OC} project rhdp--preview
+${OC} rsh --shell=/bin/bash "drupal-deployment-preview-$PULL_REQUEST_ID-0"

--- a/previews/oc-config.sh.example
+++ b/previews/oc-config.sh.example
@@ -1,0 +1,4 @@
+#
+# Configuration file for accessing preview environments on Managed Platform.
+#
+OC_USER=<your_managed_platform_username>

--- a/previews/view-drupal-boot-logs.sh
+++ b/previews/view-drupal-boot-logs.sh
@@ -1,0 +1,32 @@
+#
+# Prints out the boot logs for Drupal in the preview environment
+#
+#!/usr/bin/env bash
+set -e
+
+OC=$(which oc)
+if [[ oc == '' ]]; then
+    echo "Please install the Openshift Command Line Client"
+    exit 1
+fi
+
+PULL_REQUEST_ID=$1
+
+if [[ $PULL_REQUEST_ID == '' ]]; then
+    echo "Please specific a pull request id"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+if [[ -f "$DIR/oc-config.sh" ]]; then
+    source "$DIR/oc-config.sh"
+fi
+
+${OC} login manage.us-west.dc.preprod.paas.redhat.com -u ${OC_USER}
+${OC} project rhdp--preview
+
+echo "[[ BOOTSTRAP ENV LOGS ]]"
+${OC} logs drupal-deployment-preview-$PULL_REQUEST_ID-0 -c developer-bootstrap-env
+
+echo "[[ BOOTSTRAP DRUPAL LOGS ]]"
+${OC} logs drupal-deployment-preview-$PULL_REQUEST_ID-0 -c developer-bootstrap-drupal

--- a/previews/view-drupal-logs.sh
+++ b/previews/view-drupal-logs.sh
@@ -1,0 +1,27 @@
+#
+# Connects to Drupal in the preview environment and tails the logs
+#
+#!/usr/bin/env bash
+set -e
+
+OC=$(which oc)
+if [[ oc == '' ]]; then
+    echo "Please install the Openshift Command Line Client"
+    exit 1
+fi
+
+PULL_REQUEST_ID=$1
+
+if [[ $PULL_REQUEST_ID == '' ]]; then
+    echo "Please specific a pull request id"
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+if [[ -f "$DIR/oc-config.sh" ]]; then
+    source "$DIR/oc-config.sh"
+fi
+
+${OC} login manage.us-west.dc.preprod.paas.redhat.com -u ${OC_USER}
+${OC} project rhdp--preview
+${OC} logs -f drupal-deployment-preview-$PULL_REQUEST_ID-0


### PR DESCRIPTION
This PR introduces supporting code for migrating the `d.r.c` pull request pipeline to run on Managed Platform. This PR _**does not**_ change the existing pipeline, so the build for this PR should complete as normal. Any failure on this build should be investigated.

Once on managed platform, PR builds will benefit from:

* No export
* Full HTTPS support 
* Downloads work in PR environments
* Keycloak logins work in PR environments
* Drupal runs on its own domain name at the root of the domain

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2920

### Verification Process

* The build should go green
