### PR TITLE
Uninitialized String Offset Product URL Alias

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
@@ -234,7 +234,7 @@ function node_product_route_validation(array &$form, FormStateInterface &$form_s
   if ($node_type !== 'product') {
     $url_alias = $form_state->getValue('path')[0]['alias'];
     // Remove preceding '/' character if one exists.
-    $url_alias =  ($url_alias[0] === '/') ? substr($url_alias, 1) : $url_alias;
+    $url_alias = (isset($url_alias[0]) && $url_alias[0] === '/') ? substr($url_alias, 1) : $url_alias;
     $url_alias_array = explode('/', $url_alias);
     $reserved_product_subpages = ['overview', 'download', 'getting-started', 'hello-world'];
 


### PR DESCRIPTION
Within a validation hook, used to validate that non-Product URL aliases
will not conflict with programmatically-generated Product URL paths, we
are not validating that a URL alias is set prior to accessing the value.
This commit validates that the URL alias is set prior to accessing the
value.

This will remove the following error from the Drupal logs: "Notice:
Uninitialized string offset: 0 in..."

### JIRA Issue Link
* n/a

### Verification Process

* Go to any non-Product Node edit form i.e. `node/209371/edit` pattern
* Save the node edit form without setting a URL Alias value
* You should _not_ see an error like "Notice:
Uninitialized string offset: 0 in..." in the Drupal logs