### PR TITLE
[DEVELOPER-5878] update logic and fix issues with null

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/BlogPostsBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/BlogPostsBuild.php
@@ -23,9 +23,9 @@ class BlogPostsBuild extends AssemblyBuildBase implements AssemblyBuildInterface
 
     // get category logic
     if($entity->hasField('field_wordpress_category_logic')) {
-      $category_logic = $entity->get('field_wordpress_category_logic')->getValue() ? "and" : "or";
+      $category_logic = $entity->get('field_wordpress_category_logic')->getValue();
     } else {
-      $category_logic = "or";
+      $category_logic = NULL;
     }
 
     // grab category ids

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/DynamicContentFeedBuild.php
@@ -96,9 +96,9 @@ class DynamicContentFeedBuild extends AssemblyBuildBase implements AssemblyBuild
 
     // get category logic
     if($entity->hasField('field_wordpress_category_logic')) {
-      $category_logic = $entity->get('field_wordpress_category_logic')->getValue() ? "and" : "or";
+      $category_logic = $entity->get('field_wordpress_category_logic')->getValue();
     } else {
-      $category_logic = "or";
+      $category_logic = NULL;
     }
     
     // grab category ids

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -82,25 +82,35 @@ class WordpressApi implements RemoteContentApiInterface {
    */
   public function getContentByCategory($categories, $max_results, $select_logic) {
     $items = [];
-    $select_logic = $select_logic == "and" ? $select_logic : "or";
+
+    $select_logic_tmp = "or";
+
+    if($select_logic) {
+      $select_logic_tmp = $select_logic[0]['value'] == "1" ? "and" : "or";
+    }
 
     //$feed_url = $this->apiUrl . '/wp-json/wp/v2/posts';
     //$feed_url = 'http://localhost:8000/wp-json/wp/v2/posts';
     $feed_url = $this->apiUrl . '/wp-json/rhd-frontend-blog-theme/v1/posts-by-category';
 
     $query['per_page'] = $max_results;
-    $query['logic'] = $select_logic;
+    $query['logic'] = $select_logic_tmp;
 
-    if (!empty($categories)) {
-      $query['categories'] = $categories;
+    if($categories){
+      if (count($categories) > 0) {
+        $query['categories'] = implode(",", $categories);
+      }
     }
 
     try {
       // Retrieve the WP posts from the $feed_url and decode the JSON into a
       // $results array.
       $request = $this->client->request('GET', $feed_url, ['query' => $query]);
+
       $response = $request->getBody()->getContents();
+
       $results = json_decode($response);
+
 
       // Iterate of the WP results returned in $results, and get the
       // processed/formatted results from getContentComposite().


### PR DESCRIPTION
### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5878

### Verification Process
This is. fix for all dynamic list assembly requests returning the same content (broken filter).

check the homepage compared with live, the 'build here' and 'go anywhere' sections should have different content.

Also if you check /topics/kubernetes/ it should have different content in the 'Kubernetes development articles' to the 'go anywhere' panel on the homepage.

If you edit the /topics/kubernetes/ page and edit the dynamic list assembly on that page, checking the 'Wordpress category use 'and' logic' should change the content in the 'Kubernetes development articles' section then change it back and ensure the content changes back appropriately.

check the dynamic list assembly content varies as it should and the and/or logic works