### PR TITLE
DEVELOPER-5740 - Adjustments to global headers

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.full_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.full_html.yml
@@ -43,16 +43,31 @@ settings:
           name: 'Block Formatting'
           items:
             - Format
+            - Styles
         -
           name: Tools
           items:
             - ShowBlocks
             - Source
   plugins:
+    stylescombo:
+      styles: "a.button|Button\r\ncode.code-style|Code Style\r\na.caret-right|Link with right caret\r\ndiv.box.callout|Callout Box\r\nspan.h1|Header 1 Style\r\nspan.h2|Header 2 Style\r\nspan.h3|Header 3 Style\r\nspan.h4|Header 4 Style\r\nspan.h5|Header 5 Style\r\nspan.h6|Header 6 Style"
+    drupallink:
+      linkit_enabled: false
+      linkit_profile: ''
     language:
       language_list: un
-    stylescombo:
-      styles: ''
+    indentblock:
+      enable: 0
+    tokenbrowser:
+      token_types: {  }
+    video_embed:
+      defaults:
+        children:
+          autoplay: true
+          responsive: true
+          width: '854'
+          height: '480'
 image_upload:
   status: true
   scheme: public

--- a/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rhd_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rhd_html.yml
@@ -60,7 +60,7 @@ settings:
             - Indent
   plugins:
     stylescombo:
-      styles: "a.button|Button\r\ncode.code-style|Code Style\r\na.caret-right|Link with right caret\r\ndiv.box.callout|Callout Box"
+      styles: "a.button|Button\r\ncode.code-style|Code Style\r\na.caret-right|Link with right caret\r\ndiv.box.callout|Callout Box\r\nspan.h1|Header 1 Style\r\nspan.h2|Header 2 Style\r\nspan.h3|Header 3 Style\r\nspan.h4|Header 4 Style\r\nspan.h5|Header 5 Style\r\nspan.h6|Header 6 Style"
     drupallink:
       linkit_enabled: true
       linkit_profile: default

--- a/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rich_text.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/editor.editor.rich_text.yml
@@ -45,16 +45,31 @@ settings:
           name: 'Block Formatting'
           items:
             - Format
+            - Styles
         -
           name: Tools
           items:
             - ShowBlocks
             - Source
   plugins:
+    stylescombo:
+      styles: "a.button|Button\r\ncode.code-style|Code Style\r\na.caret-right|Link with right caret\r\ndiv.box.callout|Callout Box\r\nspan.h1|Header 1 Style\r\nspan.h2|Header 2 Style\r\nspan.h3|Header 3 Style\r\nspan.h4|Header 4 Style\r\nspan.h5|Header 5 Style\r\nspan.h6|Header 6 Style"
+    drupallink:
+      linkit_enabled: false
+      linkit_profile: ''
     language:
       language_list: un
-    stylescombo:
-      styles: ''
+    indentblock:
+      enable: 0
+    tokenbrowser:
+      token_types: {  }
+    video_embed:
+      defaults:
+        children:
+          autoplay: true
+          responsive: true
+          width: '854'
+          height: '480'
 image_upload:
   status: true
   scheme: public

--- a/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.full_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.full_html.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - asciidoc
     - editor
     - token_filter
 name: 'Full HTML'
@@ -38,4 +39,21 @@ filters:
     provider: token_filter
     status: true
     weight: 0
-    settings: {  }
+    settings:
+      replace_empty: '0'
+  asccidoc_simple:
+    id: asccidoc_simple
+    provider: asciidoc
+    status: false
+    weight: 0
+    settings:
+      command: asciidoctor
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <a href hreflang class="button caret-right"> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre> <code class="code-style"> <div class="box callout"> <span class="h1 h2 h3 h4 h5 h6">'
+      filter_html_help: true
+      filter_html_nofollow: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rhd_html.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - asciidoc
     - editor
     - entity_embed
     - linkit
@@ -98,3 +99,10 @@ filters:
     status: true
     weight: 0
     settings: {  }
+  asccidoc_simple:
+    id: asccidoc_simple
+    provider: asciidoc
+    status: false
+    weight: 0
+    settings:
+      command: asciidoctor

--- a/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rich_text.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/filter.format.rich_text.yml
@@ -3,8 +3,10 @@ langcode: en
 status: true
 dependencies:
   module:
+    - asciidoc
     - editor
     - entity_embed
+    - token_filter
 _core:
   default_config_hash: Mc8Hl-Ya14lrbMXaUx7Ybmv-18vtqE4lw2DpgNHPj-s
 name: 'Rich Text'
@@ -75,3 +77,17 @@ filters:
     weight: -42
     settings:
       filter_url_length: 72
+  asccidoc_simple:
+    id: asccidoc_simple
+    provider: asciidoc
+    status: false
+    weight: 0
+    settings:
+      command: asciidoctor
+  token_filter:
+    id: token_filter
+    provider: token_filter
+    status: false
+    weight: 0
+    settings:
+      replace_empty: '0'

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/typography/_heading.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/typography/_heading.scss
@@ -14,7 +14,9 @@ h1,h2,h3,h4,h5,h6 {
   }
 
   }
-h1 {
+
+/* Span classes are used by the 'Styles' dropdown options (Drupal CKEDITOR) */
+h1, span.h1 {
   font-size: 50px;
   line-height: 1.3;
   font-weight: 400;
@@ -23,7 +25,7 @@ h1 {
   }
 }
 
-h2 {
+h2, span.h2 {
   font-size: 36px;
   line-height: 1.3;
   font-weight: 600;
@@ -32,7 +34,7 @@ h2 {
   }
 }
 
-h3 {
+h3, span.h3 {
   font-size: 26px;
   font-weight: 700;
   line-height: 1.3;
@@ -41,7 +43,7 @@ h3 {
   }
 }
 
-h4 {
+h4, span.h4 {
   font-size: 22px;
   font-weight: 700;
   line-height: 1.5;
@@ -50,7 +52,7 @@ h4 {
   }
 }
 
-h5 {
+h5, span.h5 {
   font-size: 20px;
   font-weight: 700;
   line-height: 1.5;
@@ -64,7 +66,7 @@ h5 {
   }
 }
 
-h6 {
+h6, span.h6 {
   font-size: 16px;
   font-weight: 700;
   line-height: 1.5;


### PR DESCRIPTION
### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5740

Added the ability for the content creator to style headers with other header styles ( for example, to have an H2 that looks like an H1).

I spent a long time trying to get Alloy's plugin for this to work, but it was possible to get it to work with our RHDP theme. I tried to figure out what was breaking the plugin with Matt, but I ended up coming up with a solution that adds a `<span>` tag with the desired class, inside the header tag. Adding the span tag does not affect SEO, as the `<span>` element has no semantic meaning.

### Verification Process

I created a dummy page where you can preview these styles. You can use the inspector to be sure things headers are being styled correctly. Test page: http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37965/testpage

To test these styles yourself:
1. Login to http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37965/user/login
2. Go to http://rhdp-jenkins-slave.lab4.eng.bos.redhat.com:37965/testpage/edit
3. edit the rich text assembly
4. In the CKEditor, add a heading of any size you chose, and select a heading style from the 'Styles' dropdown.
5. Save the changes and check that the new header you added work/look as expected