### PR TITLE
Remove DTM load from dev environments

### DIFF
--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.yml.j2
@@ -1,6 +1,5 @@
 environment: 'dev'
 broker: 'https://broker.staging.redhat.com/partner/drc/userMapping?redirect='
-dtm_code: 'https://www.redhat.com/dtm-staging.js'
 sentry_track: false
 sentry_script: 'https://cdn.ravenjs.com/3.23.1/raven.min.js'
 sentry_code: '{{ drupal_sentry_code }}'

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.yml.j2
@@ -1,6 +1,5 @@
 environment: 'dev'
 broker: 'https://broker.staging.redhat.com/partner/drc/userMapping?redirect='
-dtm_code: 'https://www.redhat.com/dtm-staging.js'
 sentry_track: false
 sentry_script: 'https://cdn.ravenjs.com/3.23.1/raven.min.js'
 sentry_code: '{{ drupal_sentry_code }}'

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.yml.j2
@@ -1,6 +1,5 @@
 environment: 'dev'
 broker: 'https://broker.staging.redhat.com/partner/drc/userMapping?redirect='
-dtm_code: 'https://www.redhat.com/dtm-staging.js'
 sentry_track: false
 sentry_script: 'https://cdn.ravenjs.com/3.23.1/raven.min.js'
 sentry_code: '{{ drupal_sentry_code }}'

--- a/_tests/e2e/tests/specs/support/pages/website/NavigationBar.section.js
+++ b/_tests/e2e/tests/specs/support/pages/website/NavigationBar.section.js
@@ -11,7 +11,7 @@ class NavigationBar extends Page {
     get searchBar() {return $$('.user-search');}
 
     toggle() {
-        const mobileNavToggle = Driver.isVisible(this.mobileNavToggle);
+        const mobileNavToggle = Driver.awaitIsDisplayed(this.mobileNavToggle);
         if (mobileNavToggle) {
             Driver.click(this.mobileNavToggle);
             // wait for modal to completely open


### PR DESCRIPTION
Update to remove the load of Adobe DTM scripts on environments lower than Staging. Marketing Ops only verifies changes on Staging and Prod, so there is no need to load DTM on anything but those.