### PR TITLE
[MWES-2920] Ensure that search tests explictly wait for the results to be shown

### DIFF
--- a/_tests/e2e/tests/specs/export/rhd-search.spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-search.spec.js
@@ -30,6 +30,7 @@ describe('Search Page', function() {
         NavigationBar.searchFor('cdk');
         SearchResults.await();
         SearchResultSort.select('Most Recent');
+        SearchResults.await();
         const sR = SearchResults.all();
         const firstResult = SearchResults.dateFor(1);
         for (let i = 1; i < sR.length; i++) {

--- a/_tests/e2e/tests/specs/export/rhd-search.spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-search.spec.js
@@ -15,6 +15,7 @@ describe('Search Page', function() {
     it('should allow users to search for content via site-nav search field', () => {
         Home.open('/');
         NavigationBar.searchFor('hello world');
+        SearchResults.await();
         expect(SearchResults.all().length).to.be.gt(0);
     });
 
@@ -27,6 +28,7 @@ describe('Search Page', function() {
     it("should sort results by 'Most Recent'", () => {
         Home.open('/');
         NavigationBar.searchFor('cdk');
+        SearchResults.await();
         SearchResultSort.select('Most Recent');
         const sR = SearchResults.all();
         const firstResult = SearchResults.dateFor(1);
@@ -41,6 +43,7 @@ describe('Search Page', function() {
     it('should filter results by Content Type', () => {
         Home.open('/');
         NavigationBar.searchFor('java');
+        SearchResults.await();
         SearchFilter.choose('Content Type', 'APIs and Docs');
         SearchResults.await();
         expect(SearchFilter.active().getText()).to.include('APIs and Docs');
@@ -49,6 +52,7 @@ describe('Search Page', function() {
     it('should filter results by Product', () => {
         Home.open('/');
         NavigationBar.searchFor('java');
+        SearchResults.await();
         SearchFilter.choose('Product', 'Red Hat Enterprise Linux');
         SearchResults.await();
         expect(SearchFilter.active().getText()).to.include('Red Hat Enterprise Linux');
@@ -57,6 +61,7 @@ describe('Search Page', function() {
     it('should filter results by Topic', () => {
         Home.open('/');
         NavigationBar.searchFor('java');
+        SearchResults.await();
         SearchFilter.choose('Topic', 'Containers');
         SearchResults.await();
         expect(SearchFilter.active().getText()).to.include('Containers');
@@ -65,6 +70,7 @@ describe('Search Page', function() {
     it('should clear search filters', () => {
         Home.open('/');
         NavigationBar.searchFor('java');
+        SearchResults.await();
         SearchFilter.choose('Topic', 'Containers');
         SearchResults.await();
         SearchFilter.clear();


### PR DESCRIPTION
We're seeing intermittent failures on the search tests. Running through the tests by hand everything seems to be fine. Looking over the tests there doesn't seem to be anything that explicitly waits for the results to be loaded before running assertions. In the new preview environments, pages will load noticeably quicker than before as we have gzip compression enabled. It could simply be that the improved performance here is showing up race conditions that we've always had but were simply hidden by the performance of the site

### JIRA Issue Link
* Link to the JIRA ticket(s) this pull request solves

### Verification Process
<!--
What process should a tester use to verify this pull request closes the JIRA ticket?

- Which page(s) should one visit?
- Which buttons to click?
- What is the expected outcome?
- etc.
-->
