### PR TITLE
[MWES-3311] Support only running tests on pull request builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ properties([
                 [
                         [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The id of the Pull Request that should be built.', name: 'PULL_REQUEST_ID'],
                         [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The current ref that is being built.', name: 'PULL_REQUEST_REF'],
-                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'rebuild this please', description: 'The current ref that is being built.', name: 'PULL_REQUEST_CONTEXT']
+                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'rebuild this please', description: 'A context to be sent to the CI pipeline.', name: 'PULL_REQUEST_CONTEXT']
                 ]
         ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ properties([
                 [
                         [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The id of the Pull Request that should be built.', name: 'PULL_REQUEST_ID'],
                         [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The current ref that is being built.', name: 'PULL_REQUEST_REF'],
+                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'rebuild this please', description: 'The current ref that is being built.', name: 'PULL_REQUEST_CONTEXT']
                 ]
         ]
 ])
@@ -41,7 +42,7 @@ node('cic-rhd-01') {
          */
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'redhat-developer-automated', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
             def jenkinsJob = "https://jenkins.paas.redhat.com/generic-webhook-trigger/invoke?token=rhdp-pr-build"
-            scheduleMpBuild(pullRequestId: "${params.PULL_REQUEST_ID}", cause: cause, jenkinsJob: jenkinsJob, jenkinsUser: env.USERNAME, jenkinsPassword: env.PASSWORD)
+            scheduleMpBuild(pullRequestId: "${params.PULL_REQUEST_ID}", cause: cause, jenkinsJob: jenkinsJob, jenkinsUser: env.USERNAME, jenkinsPassword: env.PASSWORD, context: "${params.PULL_REQUEST_CONTEXT}")
         }
 
         /*


### PR DESCRIPTION
This PR adds the ability to run _only_ the acceptance tests on a pull request build if you want too. This is particularly useful when a test is being flaky and you want to quickly retry it.

The PR introduces the following behaviour:

* Comment `rebuild this please` on your pull request to receive a full rebuild of  your preview environment and a re-run of the acceptance test suite
* Comment `retest this please` on your pull request to re-run _only_ the acceptance tests. You will obviously need to ensure that your environment is up and running.

I've just used the `retest this please` functionality to get the tests to pass on this PR as you can see from the comment history.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3311

### Verification Process

* Comment `rebuild this please` on the PR to see a complete environment rebuild
* One that is complete, comment `retest this please` on the PR to see only the tests run
