### PR TITLE
[MWES-2989] Migrated base Docker images to images.paas.redhat.com

### DIFF
--- a/_docker/drupal/Dockerfile
+++ b/_docker/drupal/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.paas.redhat.com/rhdp/developer-base
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.0
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy

--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -1,4 +1,4 @@
-FROM registry.paas.redhat.com/rhdp/developer-base
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.0
 USER root
 ARG composer_profile="production"
 CMD ["/var/www/drupal/run-httpd.sh"]
@@ -42,8 +42,8 @@ COPY managed-platform/ /
 
 # Permissions here are required for us to run on Managed Platform
 RUN chown -R root:0 /opt/rh/httpd24/root/var/run/httpd \
-    && chmod -R 770 /opt/rh/httpd24/root/var/run/httpd
-RUN chgrp -R 0 /ansible \
+    && chmod -R 770 /opt/rh/httpd24/root/var/run/httpd \
+    && chgrp -R 0 /ansible \
     && chmod -R g=u /ansible
 
 USER 1001

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-testing-base
+FROM images.paas.redhat.com/rhdp/developer-testing-base:unit
 
 RUN mkdir /testing
 WORKDIR /testing
@@ -6,6 +6,3 @@ COPY . /testing
 
 RUN npm install \
     && chmod -R 777 /testing
-
-RUN gem install bundler:1.16.1 octokit:4.6.2 --no-rdoc --no-ri
-USER 1001

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/Dockerfile
@@ -6,3 +6,4 @@ COPY . /testing
 
 RUN npm install \
     && chmod -R 777 /testing
+USER 1001

--- a/_tests/e2e/tests/specs/support/pages/website/components/search/SearchFilter.js
+++ b/_tests/e2e/tests/specs/support/pages/website/components/search/SearchFilter.js
@@ -58,6 +58,11 @@ class SearchFilter extends Page {
         if (isMobile) {
             Driver.click(this.showBtn);
             Driver.awaitIsDisplayed(this.cover);
+            /*
+                Seems we need to wait for the menu to be fully displayed because we're at times getting partial menu displays in the test.
+                This solution is horrible. I've raised https://issues.jboss.org/browse/DEVELOPER-5896 for us to implement a better fix.
+             */
+            Driver.pause(3000)
             return true;
         }
         return false;


### PR DESCRIPTION
IT PaaS team are requesting that everyone build their images to images.paas.redhat.com so that registry.paas.redhat.com can be decommissioned. This is the first step for us getting our Drupal images into images.paas.redhat.com instead.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2989

### Verification Process

* The build should go green