### PR TITLE
[DEVELOPER-5907] Reduce network calls to wordpress

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -33,7 +33,7 @@ class WordpressApi implements RemoteContentApiInterface {
     // Used for local testing
     //$this->apiUrl = 'http://localhost:8000';
     //$this->apiUrl = 'https://developers.redhat.com/blog';
-    $this->apiUrl = 'https://developers.redhat.com/blog';
+    $this->apiUrl = 'https://origin-developers.redhat.com/blog';
     $this->client = $client;
   }
 


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5907

### Verification Process

* 3 calls are made to the Wordpress REST API for the Dynamic Content List and the Dynamic Content assembly types regardless of how many posts are retrieved from the Wordpress REST API. Previously 2N+1 calls were performed when multiple posts were retrieved, where N is the number of WP posts.
* Verify hypothesis that hitting developers.redhat.com, as opposed to origin-developers.redhat.com, is actually faster
