### PR TITLE
[DEVELOPER-5907] Reduce calls to WordPress API to improve content editor experience

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -33,7 +33,7 @@ class WordpressApi implements RemoteContentApiInterface {
     // Used for local testing
     //$this->apiUrl = 'http://localhost:8000';
     //$this->apiUrl = 'https://developers.redhat.com/blog';
-    $this->apiUrl = 'https://developers.redhat.com/blog';
+    $this->apiUrl = 'https://origin-developers.redhat.com/blog';
     $this->client = $client;
   }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -243,7 +243,7 @@ class WordpressApi implements RemoteContentApiInterface {
     $item->date = date('F j, Y', strtotime($content->date));
 
     if (isset($content->featured_media) && $content->featured_media) {
-      $item->media = $this->getContentMedia([$content->featured_media]);
+      $item->media = reset($this->getContentMedia([$content->featured_media]));
       $aspect_ratio = $item->media->media_details->height / $item->media->media_details->width;
       $item->media->scale_orientation = ($aspect_ratio > .58) ? 'vertical' : 'horizontal';
     }

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/WordpressApi.php
@@ -243,7 +243,8 @@ class WordpressApi implements RemoteContentApiInterface {
     $item->date = date('F j, Y', strtotime($content->date));
 
     if (isset($content->featured_media) && $content->featured_media) {
-      $item->media = reset($this->getContentMedia([$content->featured_media]));
+      $content_media = $this->getContentMedia([$content->featured_media]);
+      $item->media = reset($content_media);
       $aspect_ratio = $item->media->media_details->height / $item->media->media_details->width;
       $item->media->scale_orientation = ($aspect_ratio > .58) ? 'vertical' : 'horizontal';
     }


### PR DESCRIPTION
This PR dramatically reduces the number of calls that are made to Wordpress to fetch content. It builds upon the work done by @jordanpagewhite in #2986 (this PR only adds PHP fixes for errors that were apparent in the Drupal logs).

We are looking to reduce the number of calls to Wordpress to an absolute minimum as they are very slow and produce a bad experience for content editors when they are accessing the site.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5907

### Verification Process

* The build should go green
* All Wordpress related functionality should be working as expected

