### PR TITLE
DEVELOPER-5885 - Updated Articles tile view

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.featured_articles.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.featured_articles.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: featured_articles
 label: 'Featured Articles'
 description: ''
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\nassembly-center|Centered|Center the title and content in this assembly\r\nfour-up|4-up|When displaying items in a row, show 4 instead of 3\r\nassembly-slim|Slim|Remove top padding and omit default background image"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\nfour-up|4-up|When displaying items in a row, show 4 instead of 3\r\nassembly-slim|Slim|Remove top padding and omit default background image"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_articles.default.yml
@@ -22,7 +22,7 @@ mode: default
 content:
   field_articles:
     weight: 1
-    label: visually_hidden
+    label: hidden
     settings:
       view_mode: card
       link: false

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_articles.scss
@@ -419,7 +419,7 @@
 #rhd-article .cards-wrapper {
   display: grid;
   grid-template-columns: repeat(3,1fr);
-  grid-gap: 4rem;
+  grid-gap: 3rem;
   margin-top: 2rem;
   
   @media screen and (max-width: 1240px){
@@ -435,6 +435,7 @@
     margin: 0;
     border-top: 1px solid $gray-2;
     font-size: 1rem;
+    height: 100%;
     p.article-card-type {
       font-size: 1rem;
     }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_articles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/assembly/_featured_articles.scss
@@ -2,6 +2,26 @@
 .related-articles {
   padding-bottom: 2rem;
   padding-top: 3rem;
+
+  .tiles {
+    display: flex;
+    flex-flow: wrap;
+    width: 100%;
+  }
+  .tiles > .field__item {
+    width: 100%;
+    @include tablet-landscape {
+      width: calc(100% / 2);
+    }
+    @include desktop-small {
+      width: calc(100% / 3);
+    }
+  }
+
+  .centered-tiles {
+    justify-content: center;
+  }
+
   h2 {
     text-align: center;
     margin-bottom: 50px;
@@ -12,16 +32,11 @@
     border-top: 6px solid $black;
     background-color: $white;
     padding: 30px;
-    min-height: 430px;
+    height: calc(100% - 40px);
     margin: 20px;
     @media screen and (max-width: 768px) {
       min-height: auto;
     }
-  }
-  &.assembly-center .centered-tiles {
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 
   .article-card-type {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/field--assembly--field-articles--featured-articles.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/field--assembly--field-articles--featured-articles.html.twig
@@ -51,10 +51,13 @@
     label_display == 'visually_hidden' ? 'visually-hidden',
   ]
 %}
+{%
+  set centered_tiles = (items|length < 3) ? 'centered-tiles' : ''
+%}
 
 {% if label_hidden %}
   {% if multiple %}
-    <div{{ attributes.addClass(classes, 'field__items') }}>
+    <div{{ attributes.addClass(centered_tiles, 'tiles field__items') }}>
       {% for item in items %}
         <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
       {% endfor %}
@@ -68,10 +71,10 @@
   <div{{ attributes.addClass(classes) }}>
     <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
     {% if multiple %}
-      <div class="field__items row centered-tiles ">
+      <div{{ attributes.addClass(centered_tiles, 'tiles field__items') }}>
     {% endif %}
     {% for item in items %}
-      <div{{ item.attributes.addClass('large-8 medium-12 small-24 columns end field__item') }}>{{ item.content }}</div>
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
     {% endfor %}
     {% if multiple %}
       </div>


### PR DESCRIPTION
## APPROVED BY UX

### JIRA Issue Link
https://issues.jboss.org/browse/DEVELOPER-5885

Updated Featured Articles assembly to use a Flexbox layout instead of the Zurb Foundation grid, and so that when there are only one or two articles, the tiles are centered instead of floating to the left.

### Verification Process
Featured Articles should be center aligned instad of left aligned on pages such as /products/codeready-workspaces/getting-started
