### PR TITLE
[MWES-3390] Added recommended PHP configuration for filesystem operations

### DIFF
--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -2,8 +2,7 @@ FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.0
 USER root
 ARG composer_profile="production"
 CMD ["/var/www/drupal/run-httpd.sh"]
-EXPOSE 8080
-EXPOSE 8443
+EXPOSE 8080 8443
 WORKDIR /var/www/drupal
 RUN gem install asciidoctor -v 1.5.8
 

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -3,12 +3,6 @@
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 
 /**
-    Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
-*/
-
-ini_set('memory_limit', '256M');
-
-/**
     Setup environment specific host and service configuration. This configuration used to live in rhd.settings.yml, but
     has now been moved into here directly to avoid having to parse YAML on a per-request basis. We still need to determine
     if all of this configuration is actually still needed.

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -3,12 +3,6 @@
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 
 /**
-    Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
-*/
-
-ini_set('memory_limit', '256M');
-
-/**
     Setup environment specific host and service configuration. This configuration used to live in rhd.settings.yml, but
     has now been moved into here directly to avoid having to parse YAML on a per-request basis. We still need to determine
     if all of this configuration is actually still needed.

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -3,12 +3,6 @@
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 
 /**
-    Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
-*/
-
-ini_set('memory_limit', '256M');
-
-/**
     Setup environment specific host and service configuration. This configuration used to live in rhd.settings.yml, but
     has now been moved into here directly to avoid having to parse YAML on a per-request basis. We still need to determine
     if all of this configuration is actually still needed.

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -3,12 +3,6 @@
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 
 /**
-    Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
-*/
-
-ini_set('memory_limit', '256M');
-
-/**
     Setup environment specific host and service configuration. This configuration used to live in rhd.settings.yml, but
     has now been moved into here directly to avoid having to parse YAML on a per-request basis. We still need to determine
     if all of this configuration is actually still needed.

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -3,12 +3,6 @@
 $settings['hash_salt'] = 'xuAWpK0fmrZ6UGofFcP3lBkcmdpdumWMLqvCbnYjFY85OgRXYvEKPItJDH66vs4UpeYORQXLHQ';
 
 /**
-    Increase default memory settings for Drupal to 256 meg. Taken from: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
-*/
-
-ini_set('memory_limit', '256M');
-
-/**
     Setup environment specific host and service configuration. This configuration used to live in rhd.settings.yml, but
     has now been moved into here directly to avoid having to parse YAML on a per-request basis. We still need to determine
     if all of this configuration is actually still needed.

--- a/_docker/drupal/managed-platform/etc/opt/rh/rh-php71/php.d/50-developer-drupal.ini
+++ b/_docker/drupal/managed-platform/etc/opt/rh/rh-php71/php.d/50-developer-drupal.ini
@@ -1,0 +1,14 @@
+;
+; The file contains PHP configuration for the Drupal deployment for developers.redhat.com.
+;
+
+;
+; Increase the default memory limit for Drupal: https://www.drupal.org/docs/7/managing-site-performance-and-scalability/changing-php-memory-limits
+;
+memory_limit = 256M
+
+;
+; Increase filesystem caching for rarely changing files: https://www.drupal.org/docs/7/managing-site-performance/tuning-phpini-for-drupal
+;
+realpath_cache_size = 256k
+realpath_cache_ttl = 300


### PR DESCRIPTION
This PR follows the advice at https://www.drupal.org/docs/7/managing-site-performance/tuning-phpini-for-drupal to apply recommended filesystem configuration for Drupal.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3390

### Verification Process

* The build should go green
* Visit `/admin/reports/status` and ensure that `PHP memory limit` is `256M`
* [Log in to the Drupal container](https://github.com/redhat-developer/developers.redhat.com/tree/master/previews) and ensure the following are true:
   * `drush php:eval "print_r(ini_get('memory_limit'));"` == `256M`
   * `drush php:eval "print_r(ini_get('realpath_cache_size'));"` == `256k`
   * `drush php:eval "print_r(ini_get('realpath_cache_ttl'));"` == `300`