### PR TITLE
[RHDFEED-816] update cdk download version 3.9.0-1

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
@@ -133,7 +133,7 @@ app.products = {
 };
 
 app.products.downloads = {
-    "cdk" : {"windowsUrl" : "/download-manager/file/cdk-3.8.0-2-minishift-windows-amd64.exe", "macUrl" : "/download-manager/file/cdk-3.8.0-2-minishift-darwin-amd64", "rhelUrl" : "/download-manager/file/cdk-3.8.0-2-minishift-linux-amd64"}
+    "cdk" : {"windowsUrl" : "/download-manager/file/cdk-3.9.0-1-minishift-windows-amd64.exe", "macUrl" : "/download-manager/file/cdk-3.9.0-1-minishift-darwin-amd64", "rhelUrl" : "/download-manager/file/cdk-3.9.0-1-minishift-linux-amd64"}
 };
 
 /*


### PR DESCRIPTION
### JIRA Issue Link
https://issues.jboss.org/browse/RHDFEED-816

### Verification Process

Unable to test this in PR since the download manager is showing 3.8 version for this environment.
 
go to /products/cdk/download and check the feature download has the 3.9 version and the link is correct.