### PR TITLE
Fix broken comment script

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_disqus/js/disqusFetch.js
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_disqus/js/disqusFetch.js
@@ -76,7 +76,7 @@
         };
 
         var recentCommentsFail = function(response) {
-          if (comments === false) {
+          if (typeof(comments) === 'undefined' || comments === false) {
             $(instance.element).html('Oops! We were unable to retrieve comments at this time.');
           }
         }


### PR DESCRIPTION
### Sentry Issue Link
* https://sentry.io/share/issue/01661b0203b94e90a51aac4d81262f18/

This is an error from Sentry that has been a huge contributor to errors in the system. The original logic was not working in cases where the variable was undefined, which caused an error to be thrown.