### PR TITLE
[MWES-2871] Make memcached default cache engine in all environments but prod and local dev.

### DIFF
--- a/_docker/drupal/dev/README.md
+++ b/_docker/drupal/dev/README.md
@@ -68,6 +68,16 @@ This will:
 
 Once the script has finished running, you can access Drupal at [https://localhost](https://localhost)
 
+#### Running Drupal with Memcached
+
+The local environment also has support for replacing Drupal's database cache with memcached. The database currently remains the default, but it is easy to replace this.
+
+Once you have Drupal running simply edit the `./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php` file and change
+the value of `$config['redhat_developers']['cache']['engine']` to `memcached`.
+
+Once you have done this, connect to the Drupal container using the `./run-drupal-connect.sh` script and execute `drush cr`. This will switch your environment to use
+Memcached for the cache. This change will last until you run `./run-drupal.sh` again.
+
 ### Exporting configuration from Drupal
 
 When you're ready to export changes from your running Drupal instance that you wish to submit in a pull request, simply

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -24,7 +24,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
-$config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['cache']['engine'] = 'memcached';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -24,7 +24,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
-$config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['cache']['engine'] = 'memcached';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -24,7 +24,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
-$config['redhat_developers']['cache']['engine'] = 'memcached';
+$config['redhat_developers']['cache']['engine'] = 'database';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -25,7 +25,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
-$config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['cache']['engine'] = 'memcached';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -25,7 +25,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
-$config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['cache']['engine'] = 'memcached';
 
 /**
     SSO Integration for Content Editor Authentication


### PR DESCRIPTION
This update makes memcached the default cache engine for all environments other than production and local dev to ensure it works as expected with our deployment workflow.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2871

### Verification Process

* Build should go green
* Visit `/admin/reports/memcache` and ensure that two memache instances are listed
