### PR TITLE
[MWES-2871] Enable memcached for our production deployment of Drupal

### DIFF
--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -26,7 +26,7 @@ $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp2.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = '//dcp2.jboss.org';
-$config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['cache']['engine'] = 'memcached';
 
 /**
     SSO Integration for Content Editor Authentication


### PR DESCRIPTION
As a follow up to #3017 , this PR enables memcached as the cache engine of choice for Drupal in production.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2871

### Verification Process

* Build should go green.
