### PR TITLE
[DEVELOPER-5941] [DEVELOPER-5942] Fix drush cex errors in local development environment

### DIFF
--- a/_docker/drupal/dev/README.md
+++ b/_docker/drupal/dev/README.md
@@ -48,18 +48,16 @@ Ideally when we're updating the dependencies for the project through `composer`,
 our production Drupal instance. This way we can ensure consistent versions of PHP, O/S and anything other dependencies that may
 impact the way in which `composer update` runs.
 
-The `run-composer-update.sh` script in this directory runs an instance of the production Drupal container to update the dependencies,
+The `run-composer-update.sh` script in this directory runs an instance of the production Drupal container to allow you to update the dependencies,
 helping to ensure that the configuration will work in our production environment.
 
 To update dependencies in `composer.json`:
 
-* Make your version updates and additions to `composer.json` in your IDE
 * Run `bash run-composer-update.sh`
-  * This will take a bit of time to complete
-* Once the process completes, a `git status` will show you that `composer.json` and `composer.lock` have changes to them and can be submitted as
-a pull request to the project
+* Execute your desired `composer` commands e.g. `composer require drupal/foo:1.2.3`
+* Once you're finished, simply exit the container
+* Commit your changes to Git and raise a pull request.
 
-It also has the benefit that your local filesystem is not cluttered with loads of dependencies by composer.
 
 ### Running Drupal
 
@@ -77,7 +75,7 @@ This will:
     * password: password
 * Generate a set of SSL certificates on for your local machine
 * Start Drupal on port `443` on your local machine
-* Start two instances of [memcached](https://memcached.org) on your local machine and configure Drupal to use these
+* Start two instances of [memcached](https://memcached.org) on your local machine
 
 Once the script has finished running, you can access Drupal at [https://localhost](https://localhost)
 
@@ -100,11 +98,11 @@ run:
 bash run-config-export.sh
 ```
 
-This will connect to the Drupal Docker container and run `drush cex -y` to export the configuration from your running Drupal
-instance.
+This will run `drush cex -y` to export the configuration from your local Drupal instance. The above script performs a quick check
+to make sure Drupal is running as a way to verify that you've run `run-drupal.sh` before trying to perform a config export.
 
-The configuration is also immediately copied into the `_docker/drupal/drupal-filesystem/web/config/sync`, so it's just a case
-of verifying the changes and then committing and pushing your pull request.
+All configuration changes are immediately exported into `_docker/drupal/drupal-filesystem/web/config/sync`, so it's just a case
+of verifying the changes are what you expect and then committing and pushing your pull request.
 
 ### Working with Drupal
 
@@ -141,7 +139,7 @@ This will delete all resources running on your local machine.
 
 ### A typical work-flow:
 
-* Update `composer.json` and then run `bash run-composer-update.sh` to update dependencies for Drupal
+* Run `bash run-composer-update.sh` to update dependencies for Drupal
 * Start Drupal using `bash run-drupal.sh`
 * Access [https://localhost](https://localhost) and use the Drupal Admin interface to install a new module and configure it
 * Run `bash run-config-export.sh` to export your changes into your working tree, commit and raise a pull request with your changes

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -42,27 +42,6 @@ services:
     depends_on:
     - mysql
 
-  drush_cex:
-    build:
-      context: ../
-      dockerfile: Dockerfile.mp
-    command: ["/bin/bash", "-c", "drush cex -y"]
-    user: ${DUID}:0
-    environment:
-      - DEPLOYMENT_ID=1
-      - https_proxy
-      - http_proxy
-    volumes:
-      - ./env.yml:/credentials/ansible/env.yml
-      - ./edgerc:/credentials/akamai/edgerc
-      - ./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
-      - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
-      - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
-      - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
-    depends_on:
-      - mysql
-      - drupal
-
   bootstrap_drupal:
     build:
       context: ../
@@ -79,6 +58,7 @@ services:
     - ./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
     - ./drupal-workspace/drupal_1/drupal/credentials/phinx.yml:/var/www/drupal/phinx.yml
     - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
+    - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
     - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
     - ./drupal-workspace:/drupal-workspace
     depends_on:
@@ -106,6 +86,7 @@ services:
       - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
       - ./drupal-workspace/drupal_1/drupal/apache/drupal.conf:/opt/rh/httpd24/root/etc/httpd/conf.d/drupal.conf
       - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
+      - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
       - ./drupal-workspace:/drupal-workspace
       - ../drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
       - ./development.services.yml:/var/www/drupal/web/sites/development.services.yml

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -42,6 +42,27 @@ services:
     depends_on:
     - mysql
 
+  drush_cex:
+    build:
+      context: ../
+      dockerfile: Dockerfile.mp
+    command: ["/bin/bash", "-c", "drush cex -y"]
+    user: ${DUID}:0
+    environment:
+      - DEPLOYMENT_ID=1
+      - https_proxy
+      - http_proxy
+    volumes:
+      - ./env.yml:/credentials/ansible/env.yml
+      - ./edgerc:/credentials/akamai/edgerc
+      - ./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
+      - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
+      - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
+      - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
+    depends_on:
+      - mysql
+      - drupal
+
   bootstrap_drupal:
     build:
       context: ../
@@ -83,7 +104,6 @@ services:
       - ./localhost-key.pem:/ssl/tls.key
       - ./drupal-workspace/drupal_1/drupal/credentials/rhd.settings.php:/var/www/drupal/web/sites/default/rhd.settings.php
       - ./drupal-workspace/drupal_1/drupal/sites/default/files:/var/www/drupal/web/sites/default/files
-      - ./drupal-workspace/drupal_1/drupal/credentials/phinx.yml:/var/www/drupal/phinx.yml
       - ./drupal-workspace/drupal_1/drupal/apache/drupal.conf:/opt/rh/httpd24/root/etc/httpd/conf.d/drupal.conf
       - ./drupal-workspace/drupal_1/drupal/config/active:/var/www/drupal/web/config/active
       - ./drupal-workspace:/drupal-workspace

--- a/_docker/drupal/dev/run-config-export.sh
+++ b/_docker/drupal/dev/run-config-export.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-set -e
+RED='\033[0;31m'
+NC='\033[0m'
 echo "Exporting config from Drupal..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 DUID="$(id -u)"; export DUID
 
-cd "$DIR" && docker exec dev_drupal_1 /bin/bash -c "drush -y cex"
-cd "$DIR" && docker cp dev_drupal_1:/var/www/drupal/web/config/sync/. ../drupal-filesystem/web/config/sync
+# We need to ensure we've actually booted Drupal for this to be useful. Technically Drupal doesn't need to be running, but this
+# provides a reasonable sanity check for now
+$(curl -sfSk -m 5 https://localhost/user/login > /dev/null);
+if [ $? -ne 0 ]
+then
+  echo -e "${RED}ERROR: ${NC}It doesn't look like Drupal is running. Have you run run-drupal.sh?"
+  exit 1
+fi
+
+cd "$DIR" && docker-compose run --rm drush_cex

--- a/_docker/drupal/dev/run-config-export.sh
+++ b/_docker/drupal/dev/run-config-export.sh
@@ -14,4 +14,4 @@ then
   exit 1
 fi
 
-cd "$DIR" && docker-compose run --rm drush_cex
+docker exec dev_drupal_1 /bin/bash -c "drush cex -y"


### PR DESCRIPTION
This commit changes the way we run drush cex in the local development environment to ensure that deletion of configuration is properly captured and also to address an issue whereby Drupal could not write to the sync directory because it was owned by root.

The README.md is also updated to reflect the latest changes and the run-config-export.sh now performs a quick check to ensure we have properly bootstrapped the local Drupal instance before trying to export configuration

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5942
* https://issues.jboss.org/browse/DEVELOPER-5941

### Verification Process

* Build should go green
* Make changes to your local Drupal configuration (including uninstalling a module)
  * Run `run-config-export.sh` in the `_docker/drupal/dev` directory
  * Ensure that a `git status` shows what you would expect to see in terms of changes to the Drupal configuration