### PR TITLE
[DO NOT MERGE][GH-3007] Replace rhd_guzzle_throttle with Drupal caching

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.extension.yml
@@ -125,7 +125,6 @@ module:
   rhd_custom_meta: 0
   rhd_disqus: 0
   rhd_eloqua_embed: 0
-  rhd_guzzle_throttle: 0
   rhd_katacoda: 0
   rhd_microsite: 0
   rhd_solution_overview: 0

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.module
@@ -194,3 +194,4 @@ include_once 'rhd_common.form_validations.inc';
 include_once 'rhd_common.sitemap.inc';
 include_once 'rhd_common.tokens.inc';
 include_once 'rhd_common.video.inc';
+include_once 'rhd_common.updates.inc';

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.updates.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_common/rhd_common.updates.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Database updates.
+ */
+
+use Drupal\Core\Database;
+
+/**
+ * Drops the laravel_cache table.
+ *
+ * This will be committed alongside a config change to uninstall the
+ * rhd_guzzle_throttle custom module and replace the caching functionality of
+ * that module with Drupal caching.
+ */
+function rhd_common_update_8001() {
+  $schema = Database::getConnection()->schema();
+  $table_name = 'laravel_cache';
+  // TRUE if transaction was successful or FALSE if the table doesn't exist.
+  $isSuccess = $schema->dropTable($table_name);
+
+  if ($isSuccess) {
+    return t('Successfully dropped laravel_cache table.');
+  }
+  else {
+    throw new DrupalUpdateException('Failed to drop laravel_cache table.');
+  }
+}

--- a/_docker/drupal/managed-platform/var/www/drupal/drush/drush.yml
+++ b/_docker/drupal/managed-platform/var/www/drupal/drush/drush.yml
@@ -15,7 +15,6 @@ sql:
   structure-tables:
     structure-only:
       - 'lightning_watchdog'
-      - 'laravel_cache'
       - 'lightning_cache_bootstrap'
       - 'lightning_cache_config'
       - 'lightning_cache_container'


### PR DESCRIPTION
This uninstalls the custom rhd_guzzle_throttle module and replaces the
caching that module provided, for external calls to our Wordpress API
and Download Manager, with a standard Drupal Cache API implementation.
This also includes a database update in rhd_common.update.inc to drop
the laravel_cache table as we no longer will use that and do not
otherwise need it.

### Github Issue Link

* https://github.com/redhat-developer/developers.redhat.com/issues/3007

### Verification Process

* Build is green
* Database update hook, `rhd_common_update_8001()`, executes successfully and `laravel_cache` table is dropped

Upon visiting a freshly built environment, Drupal will make whatever Wordpress API and/or Download Manager call(s) are required to load a given page, and then it will cache the responses using the Drupal Cache API and in the `lightning_cache_default` table. You will notice entries like (cid values):

* download_manager_api:product:openjdk
* wordpress_api:by_category:per_page_3-logic_or-categories_4587
* wordpress_api:categories
* wordpress_api:content_media:574937
* wordpress_api:post:520407

These represent the different types of calls we make to Download Manager and the Wordpress API