### PR TITLE
[3033] Fix permissions on /modules/contrib for local development

### DIFF
--- a/_docker/drupal/dev/run-drupal-connect.sh
+++ b/_docker/drupal/dev/run-drupal-connect.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -e
-docker exec -it dev_drupal_1 /bin/bash
+DUID="$(id -u)"; export DUID
+docker exec -u "$DUID" -it dev_drupal_1 /bin/bash

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -22,7 +22,6 @@ source "${DIR}"/local-config.sh
 docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
 docker pull docker-registry.engineering.redhat.com/developers/drupal-data:latest
 docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.1
-docker pull registry.redhat.io/rhel8/memcached
 
 cd "${DIR}" && docker-compose down -v
 cd "${DIR}" && rm -rf $DIR/drupal-workspace
@@ -35,4 +34,5 @@ cd "${DIR}" && docker-compose run --rm bootstrap_env
 cd "${DIR}" && docker-compose run --rm bootstrap_drupal
 cd "${DIR}" && chmod -R 777 ./drupal-workspace/drupal_1/drupal/sites/default/files && chown -R "${DUID}" "${DIR}"/drupal-workspace
 cd "${DIR}" && docker-compose up -d drupal
+cd "${DIR}" && docker-compose exec -u root drupal /bin/bash -c "chown -R ${DUID}:0 /var/www/drupal/web/modules/contrib"
 cd "${DIR}" && docker-compose logs -f drupal


### PR DESCRIPTION
This PR fixes the permissions in the local dev environment so that you can edit the contrib modules files.

Closes #3033 

### JIRA Issue Link
* #3033 

### Verification Process

* Ensure that in the local development environment, once Drupal has booted you can run `./run-drupal-connect.sh` and edit any of the files within the `/var/www/drupal/web/modules/contrib` directory.

