### PR TITLE
[MWES-3412] Clean-up usage of http_proxy and https_proxy environment variables

### DIFF
--- a/_docker/drupal/Dockerfile
+++ b/_docker/drupal/Dockerfile
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.0
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.2
 MAINTAINER Jason Porter <jporter@redhat.com>
 
 ARG http_proxy
@@ -17,7 +17,7 @@ COPY drupal-filesystem/composer.json drupal-filesystem/composer.lock /var/www/dr
 COPY drupal-filesystem/patches /var/www/drupal/patches
 
 # Only install dev dependencies on dev environments
-RUN if [ "$composer_profile" = "development" ]; \ 
+RUN if [ "$composer_profile" = "development" ]; \
     then /usr/local/bin/composer install --no-interaction; \
     else /usr/local/bin/composer install --no-interaction --no-dev --optimize-autoloader; \
     fi

--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.1
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.2
 USER root
 ARG composer_profile="production"
 CMD ["/var/www/drupal/run-httpd.sh"]
@@ -25,7 +25,6 @@ COPY drupal-filesystem/web/modules/custom /var/www/drupal/web/modules/custom
 COPY drupal-filesystem/web/themes/custom /var/www/drupal/web/themes/custom
 
 # Build the theme
-ENV no_proxy="repository.engineering.redhat.com,$no_proxy"
 RUN cd /var/www/drupal/web/themes/custom/rhdp/rhd-frontend \
     && npm install \
     && npm run-script build \

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   update-composer:
-    image: images.paas.redhat.com/rhdp/developer-base:rhel-76.1
+    image: images.paas.redhat.com/rhdp/developer-base:rhel-76.2
     user: ${DUID}:0
     volumes:
       - ../drupal-filesystem/composer.json:/drupal/composer.json
@@ -10,8 +10,6 @@ services:
       - ../drupal-filesystem/scripts/ScriptHandler.php:/drupal/scripts/ScriptHandler.php
     command: ["/bin/bash"]
     environment:
-      - https_proxy
-      - http_proxy
       - COMPOSER_MEMORY_LIMIT=-1
     working_dir: /drupal
 
@@ -34,8 +32,6 @@ services:
     user: ${DUID}:0
     environment:
     - DEPLOYMENT_ID=1
-    - http_proxy
-    - https_proxy
     volumes:
     - ./env.yml:/credentials/ansible/env.yml
     - ./drupal-workspace:/drupal-workspace
@@ -50,8 +46,6 @@ services:
     user: ${DUID}:0
     environment:
     - DEPLOYMENT_ID=1
-    - https_proxy
-    - http_proxy
     volumes:
     - ./env.yml:/credentials/ansible/env.yml
     - ./edgerc:/credentials/akamai/edgerc
@@ -75,8 +69,6 @@ services:
       - "443:8443"
     environment:
       - DEPLOYMENT_ID=1
-      - https_proxy
-      - http_proxy
     volumes:
       - ./env.yml:/credentials/ansible/env.yml
       - ./edgerc:/credentials/akamai/edgerc

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -21,7 +21,7 @@ source "${DIR}"/local-config.sh
 # Login to required registries and pull required images
 docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
 docker pull docker-registry.engineering.redhat.com/developers/drupal-data:latest
-docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.1
+docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.2
 
 cd "${DIR}" && docker-compose down -v
 cd "${DIR}" && rm -rf $DIR/drupal-workspace


### PR DESCRIPTION
This updates the local development experience to remove the usage of `http_proxy` and `https_proxy` environment variables.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3412

### Verification Process

* Build should go green
* Log in to the container locally and ensure that `printenv` does not show the usage of `http_proxy` or `https_proxy`
* Log in to the PR Drupal container and ensure that `http_proxy` and `https_proxy` are correctly set to `http://proxy.util.phx2.redhat.com:8080`