### PR TITLE
Fixes broken favicon paths & updates rhd-frontend

### DIFF
--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -46,6 +46,7 @@ RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.min.css /var/www/drupal/web/themes/custom/rhdp2/css/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.microsites.css /var/www/drupal/web/themes/custom/rhdp2/css/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/js/@rhd/rhd.old.min.js /var/www/drupal/web/themes/custom/rhdp2/js/ \
+    && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/favicons /var/www/drupal/web/themes/custom/rhdp2/ \
     && rm -rf /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend
 
 # Copy in the Drupal configuration

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
@@ -235,14 +235,14 @@ window.NREUM||(NREUM={}),__nr_require=function(t,n,e){function r(e){if(!n[e]){va
 
     <head-placeholder token="{{ placeholder_token }}">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/{{ directory }}/rhd-frontend/favicons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/{{ directory }}/rhd-frontend/favicons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/{{ directory }}/rhd-frontend/favicons/favicon-16x16.png">
-    <link rel="manifest" href="/{{ directory }}/rhd-frontend/favicons/site.webmanifest">
-    <link rel="mask-icon" href="/{{ directory }}/rhd-frontend/favicons/safari-pinned-tab.svg" color="#da532c">
-    <link rel="shortcut icon" href="/{{ directory }}/rhd-frontend/favicons/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/{{ directory }}/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/{{ directory }}/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/{{ directory }}/favicons/favicon-16x16.png">
+    <link rel="manifest" href="/{{ directory }}/favicons/site.webmanifest">
+    <link rel="mask-icon" href="/{{ directory }}/favicons/safari-pinned-tab.svg" color="#da532c">
+    <link rel="shortcut icon" href="/{{ directory }}/favicons/favicon.ico">
     <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="msapplication-config" content="/{{ directory }}/rhd-frontend/favicons/browserconfig.xml">
+    <meta name="msapplication-config" content="/{{ directory }}/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
 
     <css-placeholder token="{{ placeholder_token }}">


### PR DESCRIPTION
### Github Issue Link
* none

### Verification Process

<img width="1680" alt="Screen Shot 2019-09-05 at 12 47 35 PM" src="https://user-images.githubusercontent.com/7155034/64375736-5efdf580-cfdb-11e9-9f5e-b8d6f8c202c3.png">

The following errors (in the screenshot above) should no longer exist:

- All of the font fetch errors starting at the second error in the list down to overpass-bold.ttf
- The errors for site.webmanifest and favicon.ico (second and third from the bottom)