### PR TITLE
[No Issue] Support re-building rhd-frontend theme assets in local dev

### DIFF
--- a/_docker/drupal/.dockerignore
+++ b/_docker/drupal/.dockerignore
@@ -5,6 +5,7 @@ Gemfile
 Gemfile.lock
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/node_modules
 drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/docs
+drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/node_modules
 managed-platform/ansible/testing
 dev
 data-image

--- a/_docker/drupal/.gitignore
+++ b/_docker/drupal/.gitignore
@@ -23,3 +23,10 @@ dev/localhost-key.pem
 dev/drupal-workspace
 dev/edgerc
 dev/local-config.sh
+
+# Ignore locally generated rhd-frontend theme files
+drupal-filesystem/web/themes/custom/rhdp2/css/rhd.microsites.css
+drupal-filesystem/web/themes/custom/rhdp2/css/rhd.min.css
+drupal-filesystem/web/themes/custom/rhdp2/js/rhd.old.min.js
+drupal-filesystem/web/themes/custom/rhdp2/favicons
+

--- a/_docker/drupal/dev/README.md
+++ b/_docker/drupal/dev/README.md
@@ -98,6 +98,11 @@ the value of `$config['redhat_developers']['cache']['engine']` to `memcached`.
 Once you have done this, connect to the Drupal container using the `./run-drupal-connect.sh` script and execute `drush cr`. This will switch your environment to use
 Memcached for the cache. This change will last until you run `./run-drupal.sh` again.
 
+### Rebuilding Theme Assets
+
+To rebuild the theme assets from `rhd-frontend`, after you have run `run-drupal.sh`, simply run `build-theme.sh`. This will regenerate
+the theme assets from `rhd-frontend` to include your local changes.
+
 ### Exporting configuration from Drupal
 
 When you're ready to export changes from your running Drupal instance that you wish to submit in a pull request, simply

--- a/_docker/drupal/dev/build-theme.sh
+++ b/_docker/drupal/dev/build-theme.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+FE_THEME_DIR="${DIR}/../drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend"
+DRUPAL_THEME_DIR="${DIR}/../drupal-filesystem/web/themes/custom/rhdp2"
+
+mkdir -p "${DRUPAL_THEME_DIR}/css"
+mkdir -p "${DRUPAL_THEME_DIR}/js"
+
+set -a
+source "${DIR}"/local-config.sh
+set +a
+
+cd "${FE_THEME_DIR}" \
+&& npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \
+&& npm config set strict-ssl false \
+&& npm config set "@fortawesome:registry" https://npm.fontawesome.com/ \
+&& npm config set "//npm.fontawesome.com/:_authToken" $FONTAWESOME_LICENCE \
+&& npm install \
+&& npm run-script styles \
+&& npm run-script build \
+&& cp dist/css-min/rhd.min.css "${DRUPAL_THEME_DIR}"/css/ \
+&& cp dist/css-min/rhd.microsites.css "${DRUPAL_THEME_DIR}"/css/ \
+&& cp dist/js/@rhd/rhd.old.min.js "${DRUPAL_THEME_DIR}"/js/ \
+&& cp -r favicons "${DRUPAL_THEME_DIR}/"

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - ../drupal-filesystem/web/config/sync:/var/www/drupal/web/config/sync
       - ./drupal-workspace:/drupal-workspace
       - ../drupal-filesystem/web/modules/custom:/var/www/drupal/web/modules/custom
-      # - ../drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
+      - ../drupal-filesystem/web/themes/custom:/var/www/drupal/web/themes/custom
       - ./development.services.yml:/var/www/drupal/web/sites/development.services.yml
 
   memcached-0:


### PR DESCRIPTION
Adds a `build-theme.sh` to the local dev experience to support re-building `rhd-frontend` theme assets when changes are made locally.

### JIRA Issue Link
* N/A

### Verification Process

* Run `./run-drupal.sh`
* Run `./build-theme.sh` and see that the theme assets are in place
