### PR TITLE
[SURGE-3036] Rich text with image

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--content-with-image.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--content-with-image.html.twig
@@ -21,7 +21,7 @@
     </div>
     <div class="pf-l-grid__item pf-m-7-col-on-lg pf-m-12-col-on-sm">
       <div class="rich-text-content pf-c-content">
-        {% if content.field_title.value %}
+        {% if content.field_title is not empty %}
           <h2 class="pf-c-title pf-m-3xl">{{ content.field_title }}</h2>
         {% endif %}
         {% if content %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--content-with-image.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--content-with-image.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file assembly--content-with-image.html.twig
+ * Rich text with Image (content_with_image) assembly type
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_assembly()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set background_image = "background-image: url(" ~ background_image_url ~ ");" %}
+
+<div{{ attributes.addClass(['assembly', 'component', 'rich-text']).setAttribute('style', background_image) }}{{ audience_selection }}>
+  <div class="pf-l-grid pf-m-gutter pf-u-pt-lg pf-u-pb-lg">
+    <div class="pf-l-grid__item pf-m-5-col-on-lg pf-m-12-col-on-sm">
+      {{ content.field_image }}
+    </div>
+    <div class="pf-l-grid__item pf-m-7-col-on-lg pf-m-12-col-on-sm">
+      <div class="rich-text-content pf-c-content">
+        {% if content.field_title.value %}
+          <h2 class="pf-c-title pf-m-3xl">{{ content.field_title }}</h2>
+        {% endif %}
+        {% if content %}
+          {{- content|without('field_title', 'field_image') -}}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### JIRA Issue Link
* #3036 

### Verification Process

Go here: /openshift

You should see this:

TBD

Go here: https://developer-preview-3077.ext.us-west.dc.preprod.paas.redhat.com/topics/containers

You should see this:

TBD

*NOTE:* The link at the bottom of the content is displaying as a plain text link instead of a CTA button. This is an issue that will either have to be resolved in content (WYSIWYG) or via CSS overrides. Since I think that it will be incredibly challenging to replace every instance of a legacy class in WYSIWYG text, I have suggested CSS override(s) in this ticket: https://github.com/redhat-developer/rhd-frontend/issues/199 in the rhd-frontend repo.