### PR TITLE
[SURGE-3056] Curated links

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -20,8 +20,8 @@ base-theme:
   js:
     # This handles JS for our navigation menu(s).
     js/menu.js: {}
-    # NOTE: I believe that all.min.js is just some FontAwesome assets.
-    # js/all.min.js: { minified: true }
+    # RHD FontAwesome Kit
+    https://kit.fontawesome.com/3f83b4c6d2.js: { type: external, minified: true }
     # NOTE: According to Luke, Angular is only used on the Help page(s). We will
     # supposedly be removing these page(s) and Angular soon.
     # https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.3/angular.min.js: { type: external, minified: true }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--curated-links.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--curated-links.html.twig
@@ -14,14 +14,25 @@
 #}
 {% set background_image = "background-image: url(" ~ background_image_url ~ ");" %}
 
-<div{{ attributes.addClass(['assembly', 'curated-links']).setAttribute('style', background_image) }}{{ audience_selection }}>
-  <div class="pf-l-grid pf-m-gutter pf-u-pt-lg pf-u-pb-lg">
-    <div class="pf-l-grid__item pf-m-8-col-on-lg pf-m-7-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column pf-u-pt-lg-on-sm pf-u-pb-lg-on-sm pf-u-pt-2xl-on-md pf-u-pb-2xl-on-md">
+{# @todo please remove this. #}
+<style type="text/css">
+.assembly-type-curated_links.component .component {
+  padding-left: 0;
+  padding-right: 0;
+  margin: 0;
+}
+</style>
+
+<div{{ attributes.addClass(['assembly', 'component']).setAttribute('style', background_image) }}{{ audience_selection }}>
+  <div class="pf-l-grid pf-m-gutter">
+    <div class="pf-l-grid__item pf-m-8-col-on-lg pf-m-7-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
       {{ content.field_additional_content }}
     </div>
     <div class="pf-l-grid__item pf-m-4-col-on-lg pf-m-5-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
-      <div class="pf-l-flex pf-m-column rhd-c-curated-links">
-        <h2 class="pf-c-title pf-m-2xl pf-u-pt-lg">{{ content.field_title }}</h2>
+      <div class="pf-l-flex pf-m-column rhd-c-curated-links component">
+        {% if content.field_title.value is not empty %}
+          <h2 class="pf-c-title pf-m-2xl pf-u-pt-lg">{{ content.field_title }}</h2>
+        {% endif %}
         <hr class="rhd-c-divider">
         {% if elements.links %}
           {% for link in elements.links %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--curated-links.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--curated-links.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file assembly--curated-links.html.twig
+ * Curated links assembly type
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_assembly()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set background_image = "background-image: url(" ~ background_image_url ~ ");" %}
+
+<div{{ attributes.addClass(['assembly', 'curated-links']).setAttribute('style', background_image) }}{{ audience_selection }}>
+  <div class="pf-l-grid pf-m-gutter pf-u-pt-lg pf-u-pb-lg">
+    <div class="pf-l-grid__item pf-m-8-col-on-lg pf-m-7-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column pf-u-pt-lg-on-sm pf-u-pb-lg-on-sm pf-u-pt-2xl-on-md pf-u-pb-2xl-on-md">
+      {{ content.field_additional_content }}
+    </div>
+    <div class="pf-l-grid__item pf-m-4-col-on-lg pf-m-5-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
+      <div class="pf-l-flex pf-m-column rhd-c-curated-links">
+        <h2 class="pf-c-title pf-m-2xl pf-u-pt-lg">{{ content.field_title }}</h2>
+        <hr class="rhd-c-divider">
+        {% if elements.links %}
+          {% for link in elements.links %}
+            <div class="pf-l-flex__item">
+              <i class="fal fa-arrow-circle-right"></i>
+              {{ link }}
+            </div>
+          {% endfor %}
+        {% endif %}
+        <hr class="rhd-c-divider">
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### JIRA Issue Link
* #3056 
* #3070 

### Verification Process

#### Curated Links assembly type

Go to: https://developer-preview-3081.ext.us-west.dc.preprod.paas.redhat.com/openshift

You should see this:

<img width="1328" alt="Screen Shot 2019-09-12 at 5 54 20 PM" src="https://user-images.githubusercontent.com/7155034/64830899-c7267b80-d587-11e9-9fa8-7feba5680bc1.png">

#### FontAwesome RHD Kit

Also, our new RHD FontAwesome kit should load https://kit.fontawesome.com/3f83b4c6d2.js , and our prior iteration of the FontAwesome script should not js/all.min.js

This addresses #3070 