### PR TITLE
[MWES-3422] Add static JSON from legacy Docroot

### DIFF
--- a/_docker/drupal/drupal-filesystem/static/cdn/devsuite/java-1.8.0-openjdk.windows.x86_64.version.json
+++ b/_docker/drupal/drupal-filesystem/static/cdn/devsuite/java-1.8.0-openjdk.windows.x86_64.version.json
@@ -1,0 +1,11 @@
+{
+  "package_name": "java-1.8.0-openjdk",
+  "package_description": "OpenJDK runtime",
+  "os_name": "Windows",
+  "os_arch": "x86_64",
+  "version_string": "1.8.0.111-3.b15",
+  "version_number": 10811103015,
+  "ui_balloon_text": "OpenJDK version 1.8.0.111-3.b15 is available for download",
+  "ui_update_header": "OpenJDK version 1.8.0.111-3.b15 is available for download",
+  "ui_update_text": "This version contains a number of fixes.\n\nTo proceed with download and installation please follow a link above, download page will be opened inside your web-browser.\n\nTo change a schedule of this notification please see 'RedHat_jdk_update_checker' and 'RedHat_jdk_update_notifier' tasks in 'Task Scheduler'.\n\nTo disable this notification permanently please select the installed application in 'Programs and Features' with a right-click, choose 'Change' and disable 'Update Notifier' installation feature."
+}


### PR DESCRIPTION
Adding this piece of JSON from the legacy docroot that we currently mount from the static web servers. No-one seems to know what it's for, but until we can track that down it will prevent us from decomissioning the legacy web servers. Instead we can simply host it as part of Drupal (for now) and that will allow us to decommission the old infrastructure.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3422

### Verification Process

* Build should go green
* Visit `/cdn/devsuite/java-1.8.0-openjdk.windows.x86_64.version.json` on the Drupal instance for this PR and ensure the contents of the file in this PR show.
