### PR TITLE
[MWES-3558] Update local dev to pull data images from PSI Upshift registry

### DIFF
--- a/_docker/drupal/dev/README.md
+++ b/_docker/drupal/dev/README.md
@@ -29,6 +29,15 @@ SSL but not receiving any certificate warnings.
 
 Follow the instructions relevant to your operating environment.
 
+#### Authenticate with our Data Container Docker Registry
+
+To ensure the local development experience contains production-like data, we build and push data images after each successful deployment to production. These data images
+are stored in an internal Docker registry that requires authentication.
+
+Please speak to a member of the project team and ask them to add you to the list of approved users that can pull the data containers. Once done, please follow
+the instructions on [this](https://mojo.redhat.com/docs/DOC-1192810-developersredhatcom-giving-a-dev-team-member-access-to-data-images) page to authenticate your local development
+environment.
+
 #### Effective user of the containers
 
 The local development environment is designed to map your current user id into the containers to ensure that any files written by Drupal or created

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -20,7 +20,7 @@ source "${DIR}"/local-config.sh
 
 # Login to required registries and pull required images
 docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
-docker pull docker-registry.engineering.redhat.com/developers/drupal-data:latest
+docker pull docker-registry.upshift.redhat.com/developers/drupal-data:latest
 docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.2
 
 cd "${DIR}" && docker-compose down -v

--- a/_docker/drupal/managed-platform/ansible/testing/rhdp-data-seed/Dockerfile
+++ b/_docker/drupal/managed-platform/ansible/testing/rhdp-data-seed/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker-registry.engineering.redhat.com/developers/drupal-data:latest
+FROM docker-registry.upshift.redhat.com/developers/drupal-data:latest
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
The Docker registry on which we host data images for local development is being decommissioned and therefore we need to migrate to the PSI hosted registry.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2904

### Verification Process

* The build should go green