### PR TITLE
[NO ISSUE] Move pf-c-content from body to layout container

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
@@ -30,7 +30,6 @@
     node_type ? 'page-node-type-' ~ node_type|clean_class,
     db_offline ? 'db-offline',
     current_path ? 'page' ~ current_path|clean_class,
-    'pf-c-content',
   ]
 %}
 <!DOCTYPE html>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/page.html.twig
@@ -46,7 +46,7 @@
  */
 #}
 {% set nav_type = is_front ? ' front-nav' : '' %}
-<div class="layout-container pf-c-content">
+<div class="layout-container">
 
   <header role="banner">
     <div class="rhd-masthead{{ nav_type }}">
@@ -66,7 +66,7 @@
   <div class="rhd-mobile-overlay"></div>
   <div class="rhd-search-toggle-overlay"></div>
 
-  <main role="main">
+  <main role="main pf-c-content">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
 
     <div class="layout-content">

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/page.html.twig
@@ -46,7 +46,7 @@
  */
 #}
 {% set nav_type = is_front ? ' front-nav' : '' %}
-<div class="layout-container">
+<div class="layout-container pf-c-content">
 
   <header role="banner">
     <div class="rhd-masthead{{ nav_type }}">


### PR DESCRIPTION
### JIRA Issue Link
* n/a

### Verification Process

- `pf-c-content` is on the `div.layout-container` element on every page in Drupal
- `pf-c-content` is no longer on the <body> element of any page