### PR TITLE
[NO ISSUE] BUG: Dynamic content list closing div

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--dynamic-content-list.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--dynamic-content-list.html.twig
@@ -11,6 +11,7 @@
           <div class="rhd-c-card-content">
             <h3 class="rhd-c-card__title">Latest Comments</h3>
             {{ content.latest_comments }}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### JIRA Issue Link
* n/a

See: https://github.com/redhat-developer/developers.redhat.com/pull/3112/files#diff-13e27bc27aa0565c90e70152bfbd1a37R11

### Verification Process

- The dynamic content list component closes and the padding for the component doesn't  extend to all subsequent elements on the page. This can be verified on the homepage.