### PR TITLE
[SURGE-3143] Update card grid cta markup

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card-grid.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card-grid.twig
@@ -12,10 +12,10 @@
     {{ content }}
   </div>
   {% if ctas is not empty %}
+    <div class="pf-l-flex rhd-c-card-grid__cta">
     {% for cta in ctas['#items'] %}
-      <div class="pf-l-flex rhd-c-card-grid__cta">
-        <a class="pf-c-button pf-m-secondary" href={{ cta.uri }}>{{ cta.title }}</a>
-      </div>
+      <a class="pf-c-button pf-m-secondary" href={{ cta.uri }}>{{ cta.title }}</a>
     {% endfor %}
+    </div>
   {% endif %}
 </div>


### PR DESCRIPTION
### JIRA Issue Link
* #3143 

### Verification Process

Go here: /harmonize/styleguide/

You should see this at the bottom of the page:

<img width="806" alt="Screen Shot 2019-09-27 at 9 24 26 AM" src="https://user-images.githubusercontent.com/7155034/65785174-a40fd600-e108-11e9-833d-72b23a61fdc0.png">

with a total of 32px of vertical space between the last row of cards and the CTAs

and 24px of horizontal space between each CTA in the row of CTAs