### PR TITLE
[DO NOT MERGE][NO ISSUE] Standardize light, dark, centered and assembly-slim visual style class names

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.content_with_image.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.content_with_image.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: content_with_image
 label: 'Rich Text with Image'
 description: ''
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-dark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nassembly-image-left|Image on the left| Image on the left side of the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image\r\nassembly-space|Space|Add some breathing room before and after the assembly"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\ndark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nassembly-image-left|Image on the left| Image on the left side of the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image\r\nassembly-space|Space|Add some breathing room before and after the assembly"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.events_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.events_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: events_hero
 label: 'Events Hero'
 description: ''
-visual_styles: "events-hero--light|Light|Displays a light background image for the hero.\r\nno-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly"
+visual_styles: "light|Light|Displays a light background image for the hero.\r\nno-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: hero
 label: 'Image Hero'
 description: ''
-visual_styles: 'assembly-dark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.'
+visual_styles: 'dark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.'
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_download_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_download_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: product_download_hero
 label: 'Product Download Hero'
 description: ''
-visual_styles: "center|Center|Center content.\r\ndark|Dark|Displays a dark background image for the hero.\r\nimage-first|Image first|Display the image before the content.\r\nslim|Slim|Displays a vertically slimmer hero.\r\n\r\nproduct-hero--dark|Dark (deprecated)|Displays a dark background image for the hero.\r\nproduct-hero--dark-centered|Dark centered (deprecated)|Displays a dark background with centered content.\r\nproduct-hero--light|Light (deprecated)|Displays a light background image for the hero.\r\nproduct-hero--light-centered|Light centered (deprecated)|Displays a light background with centered content.\r\nproduct-hero--slim|Slim (deprecated)|Displays a vertically slimmer hero."
+visual_styles: "centered|Center|Center content.\r\ndark|Dark|Displays a dark background image for the hero.\r\nimage-first|Image first|Display the image before the content.\r\nassembly-slim|Slim|Displays a vertically slimmer hero."
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_try_it_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.product_try_it_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: product_try_it_hero
 label: 'Product Try-It Hero'
 description: ''
-visual_styles: "center|Center|Center content.\r\ndark|Dark|Displays a dark background image for the hero.\r\nimage-first|Image first|Display the image before the content.\r\nslim|Slim|Displays a vertically slimmer hero.\r\nproduct-hero--dark|Dark (deprecated)|Displays a dark background image for the hero.\r\nproduct-hero--dark-centered|Dark centered (deprecated)|Displays a dark background with centered content.\r\nproduct-hero--light|Light (deprecated)|Displays a light background image for the hero.\r\nproduct-hero--light-centered|Light centered (deprecated)|Displays a light background with centered content.\r\nproduct-hero--slim|Slim (deprecated)|Displays a vertically slimmer hero."
+visual_styles: "center|Center|Center content.\r\ndark|Dark|Displays a dark background image for the hero.\r\nimage-first|Image first|Display the image before the content.\r\nslim|Slim|Displays a vertically slimmer hero."
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: rich_text
 label: 'Rich Text'
 description: ''
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-slim|Slim|Remove top padding and omit default background image\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\ndark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nassembly-center|Centered|Center the title and content in this assembly\r\nassembly-space|Space|Add some breathing room before and after the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-slim|Slim|Remove top padding and omit default background image\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\ndark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\ncentered|Centered|Center the title and content in this assembly\r\nassembly-space|Space|Add some breathing room before and after the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: rich_text
 label: 'Rich Text'
 description: ''
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-slim|Slim|Remove top padding and omit default background image\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\nassembly-dark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nassembly-center|Centered|Center the title and content in this assembly\r\nassembly-space|Space|Add some breathing room before and after the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-slim|Slim|Remove top padding and omit default background image\r\nassembly-narrow|Narrow|Restrict the maximum width of the content\r\ndark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nassembly-center|Centered|Center the title and content in this assembly\r\nassembly-space|Space|Add some breathing room before and after the assembly\r\nassembly-bigger-image|Bigger image|Use a bigger image"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text_columns.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.rich_text_columns.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: rich_text_columns
 label: 'Rich Text Columns'
 description: ''
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\nassembly-dark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nthree-up|Three Across|Three columns\r\nassembly-bigger-image|Bigger image|Use a bigger image"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\ndark|Dark|Dark background with white type. You can use this if you provide a dark image background as well.\r\nthree-up|Three Across|Three columns\r\nassembly-bigger-image|Bigger image|Use a bigger image"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.sign_up_hero.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.sign_up_hero.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: sign_up_hero
 label: 'Sign-Up Hero'
 description: 'A hero with a title, description, and a CTA to take the user to register / sign in'
-visual_styles: "product-signup-hero--dark|Dark|Displays a dark background image for the hero\r\nassembly-slim|Slim|Remove top padding and omit default background image"
+visual_styles: "dark|Dark|Displays a dark background image for the hero\r\nassembly-slim|Slim|Remove top padding and omit default background image"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
@@ -248,3 +248,5 @@ function node_product_route_validation(array &$form, FormStateInterface &$form_s
     }
   }
 }
+
+include_once 'rhd_assemblies.updates.inc';

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
@@ -5,6 +5,7 @@
  * Contains rhd_assemblies.module.
  */
 
+use Drupal\assembly\Entity\Assembly;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
@@ -1,0 +1,27 @@
+<?php
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Database;
+
+/**
+ * @file
+ * hook_update_N()s for assemblies or related functionality.
+ */
+
+/**
+ * Assemblies using the 'assembly-dark' visual style will change to 'dark'.
+ */
+function rhd_assemblies_update_8001() {
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'dark',])
+    ->condition('visual_styles_value', 'assembly-dark', '=')
+    ->execute();
+
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply');
+  }
+  else {
+    return t('rhd_assemblies_update_8001 was applied. Assemblies previously using the "assembly-dark" visual style now use "dark".');
+  }
+}

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
+use Drupal\assembly\Entity\Assembly;
 
 /**
  * @file
@@ -9,19 +10,112 @@ use Drupal\Core\Database\Database;
  */
 
 /**
- * Assemblies using the 'assembly-dark' visual style will change to 'dark'.
+ * Standardize light, dark and centered visual style class names.
+ *
+ * Visual styles with a light, dark or centered theme will use "light", "dark"
+ * and "centered"
  */
 function rhd_assemblies_update_8001() {
+  // Update assembly-dark visual styles to dark.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
-    ->fields(['visual_styles_value' => 'dark',])
+    ->fields(['visual_styles_value' => 'dark'])
     ->condition('visual_styles_value', 'assembly-dark', '=')
     ->execute();
-
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-dark" visual style to "dark".');
   }
-  else {
-    return t('rhd_assemblies_update_8001 was applied. Assemblies previously using the "assembly-dark" visual style now use "dark".');
+
+  // Update product-hero--dark visual styles to dark.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'dark'])
+    ->condition('visual_styles_value', 'product-hero--dark', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--dark" visual style to "dark".');
   }
+
+  // Update product-hero--light visual styles to light.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'light'])
+    ->condition('visual_styles_value', 'product-hero--light', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--light" visual style to "light".');
+  }
+
+  // Update product-hero--slim visual styles to slim.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'assembly-slim'])
+    ->condition('visual_styles_value', 'product-hero--slim', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--slim" visual style to "assembly-slim".');
+  }
+
+  // Update center visual styles to centered.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'centered'])
+    ->condition('visual_styles_value', 'center', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "center" visual style to "centered".');
+  }
+
+  // Update assembly-center visual styles to centered.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'centered'])
+    ->condition('visual_styles_value', 'assembly-center', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-center" visual style to "centered".');
+  }
+
+  // Update product-signup-hero--dark visual styles to dark.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'dark'])
+    ->condition('visual_styles_value', 'product-signup-hero--dark', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-signup-hero--dark" visual style to "dark".');
+  }
+
+  // Update events-hero--light visual styles to light.
+  $query = \Drupal::database()
+    ->update('assembly__visual_styles')
+    ->fields(['visual_styles_value' => 'light'])
+    ->condition('visual_styles_value', 'events-hero--light', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "events-hero--light" visual style to "light".');
+  }
+
+  // Update product-hero--dark-centered visual styles to dark and centered.
+  $assembly_ids = \Drupal::entityQuery('assembly')
+    ->condition('visual_styles', 'product-hero--dark-centered')
+    ->execute();
+  $assemblies = Assembly::loadMultiple($assembly_ids);
+  foreach ($assemblies as $assembly) {
+    $assembly->set('visual_styles', ['dark', 'centered']);
+    $assembly->save();
+  }
+
+  // Update product-hero--light-centered visual styles to light and centered.
+  $assembly_ids = \Drupal::entityQuery('assembly')
+    ->condition('visual_styles', 'product-hero--light-centered')
+    ->execute();
+  $assemblies = Assembly::loadMultiple($assembly_ids);
+  foreach ($assemblies as $assembly) {
+    $assembly->set('visual_styles', ['light', 'centered']);
+    $assembly->save();
+  }
+
+  //  If all updates were performed without exception, return a success message.
+  return t('rhd_assemblies_update_8001 was successfully applied. Assembly visual styles implementing a dark or centered theme will now use the classes "dark" and "centered".');
 }

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
@@ -97,22 +97,46 @@ function rhd_assemblies_update_8001() {
   }
 
   // Update product-hero--dark-centered visual styles to dark and centered.
+  $deprecated_class = 'product-hero--dark-centered';
   $assembly_ids = \Drupal::entityQuery('assembly')
-    ->condition('visual_styles', 'product-hero--dark-centered')
+    ->condition('visual_styles', $deprecated_class)
     ->execute();
   $assemblies = Assembly::loadMultiple($assembly_ids);
   foreach ($assemblies as $assembly) {
-    $assembly->set('visual_styles', ['dark', 'centered']);
+    $visual_styles = $assembly->get('visual_styles')->getValue();
+    // Remove the 'product-hero--dark-centered' visual style/class if it exists.
+    foreach ($visual_styles as $key => $visual_style) {
+      if ($deprecated_class === $visual_style['value']) {
+        unset($visual_styles[$key]);
+      }
+    }
+    // Add in the 'dark' and 'centered' visual styles/classes.
+    $visual_styles[] = ['value' => 'dark'];
+    $visual_styles[] = ['value' => 'centered'];
+    // Update the visual_styles field value.
+    $assembly->get('visual_styles')->setValue($visual_styles);
     $assembly->save();
   }
 
   // Update product-hero--light-centered visual styles to light and centered.
+  $deprecated_class = 'product-hero--light-centered';
   $assembly_ids = \Drupal::entityQuery('assembly')
-    ->condition('visual_styles', 'product-hero--light-centered')
+    ->condition('visual_styles', $deprecated_class)
     ->execute();
   $assemblies = Assembly::loadMultiple($assembly_ids);
   foreach ($assemblies as $assembly) {
-    $assembly->set('visual_styles', ['light', 'centered']);
+    $visual_styles = $assembly->get('visual_styles')->getValue();
+    // Remove the 'product-hero--dark-centered' visual style/class if it exists.
+    foreach ($visual_styles as $key => $visual_style) {
+      if ($deprecated_class === $visual_style['value']) {
+        unset($visual_styles[$key]);
+      }
+    }
+    // Add in the 'dark' and 'centered' visual styles/classes.
+    $visual_styles[] = ['value' => 'light'];
+    $visual_styles[] = ['value' => 'centered'];
+    // Update the visual_styles field value.
+    $assembly->get('visual_styles')->setValue($visual_styles);
     $assembly->save();
   }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.updates.inc
@@ -16,84 +16,164 @@ use Drupal\assembly\Entity\Assembly;
  * and "centered"
  */
 function rhd_assemblies_update_8001() {
-  // Update assembly-dark visual styles to dark.
+  // Update assembly-dark visual styles to dark in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'dark'])
     ->condition('visual_styles_value', 'assembly-dark', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-dark" visual style to "dark".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-dark" visual style to "dark" in assembly__visual_styles.');
   }
 
-  // Update product-hero--dark visual styles to dark.
+  // Update assembly-dark visual styles to dark in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'dark'])
+    ->condition('visual_styles_value', 'assembly-dark', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-dark" visual style to "dark" in assembly_revision__visual_styles.');
+  }
+
+  // Update product-hero--dark visual styles to dark in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'dark'])
     ->condition('visual_styles_value', 'product-hero--dark', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--dark" visual style to "dark".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--dark" visual style to "dark" in assembly__visual_styles.');
   }
 
-  // Update product-hero--light visual styles to light.
+  // Update product-hero--dark visual styles to dark in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'dark'])
+    ->condition('visual_styles_value', 'product-hero--dark', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--dark" visual style to "dark" in assembly_revision__visual_styles.');
+  }
+
+  // Update product-hero--light visual styles to light in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'light'])
     ->condition('visual_styles_value', 'product-hero--light', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--light" visual style to "light".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--light" visual style to "light" in assembly__visual_styles.');
   }
 
-  // Update product-hero--slim visual styles to slim.
+  // Update product-hero--light visual styles to light in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'light'])
+    ->condition('visual_styles_value', 'product-hero--light', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--light" visual style to "light" in assembly_revision__visual_styles.');
+  }
+
+  // Update product-hero--slim visual styles to slim in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'assembly-slim'])
     ->condition('visual_styles_value', 'product-hero--slim', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--slim" visual style to "assembly-slim".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--slim" visual style to "assembly-slim" in assembly__visual_styles.');
   }
 
-  // Update center visual styles to centered.
+  // Update product-hero--slim visual styles to slim in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'assembly-slim'])
+    ->condition('visual_styles_value', 'product-hero--slim', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-hero--slim" visual style to "assembly-slim" in assembly_revision__visual_styles.');
+  }
+
+  // Update center visual styles to centered in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'centered'])
     ->condition('visual_styles_value', 'center', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "center" visual style to "centered".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "center" visual style to "centered" in assembly__visual_styles.');
   }
 
-  // Update assembly-center visual styles to centered.
+  // Update center visual styles to centered in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'centered'])
+    ->condition('visual_styles_value', 'center', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "center" visual style to "centered" in assembly_revision__visual_styles.');
+  }
+
+  // Update assembly-center visual styles to centered in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'centered'])
     ->condition('visual_styles_value', 'assembly-center', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-center" visual style to "centered".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-center" visual style to "centered" in assembly__visual_styles.');
   }
 
-  // Update product-signup-hero--dark visual styles to dark.
+  // Update assembly-center visual styles to centered in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'centered'])
+    ->condition('visual_styles_value', 'assembly-center', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "assembly-center" visual style to "centered" in assembly_revision__visual_styles.');
+  }
+
+  // Update product-signup-hero--dark visual styles to dark in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'dark'])
     ->condition('visual_styles_value', 'product-signup-hero--dark', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-signup-hero--dark" visual style to "dark".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-signup-hero--dark" visual style to "dark" in assembly__visual_styles.');
   }
 
-  // Update events-hero--light visual styles to light.
+  // Update product-signup-hero--dark visual styles to dark in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'dark'])
+    ->condition('visual_styles_value', 'product-signup-hero--dark', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "product-signup-hero--dark" visual style to "dark" in assembly_revision__visual_styles.');
+  }
+
+  // Update events-hero--light visual styles to light in assembly__visual_style.
   $query = \Drupal::database()
     ->update('assembly__visual_styles')
     ->fields(['visual_styles_value' => 'light'])
     ->condition('visual_styles_value', 'events-hero--light', '=')
     ->execute();
   if ($query === NULL) {
-    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "events-hero--light" visual style to "light".');
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "events-hero--light" visual style to "light" in assembly__visual_styles.');
+  }
+
+  // Update events-hero--light visual styles to light in assembly_revision__visual_style.
+  $query = \Drupal::database()
+    ->update('assembly_revision__visual_styles')
+    ->fields(['visual_styles_value' => 'light'])
+    ->condition('visual_styles_value', 'events-hero--light', '=')
+    ->execute();
+  if ($query === NULL) {
+    throw new DrupalUpdateException('rhd_assemblies_update_8001 failed to apply. Could not update "events-hero--light" visual style to "light" in assembly_revision__visual_styles.');
   }
 
   // Update product-hero--dark-centered visual styles to dark and centered.


### PR DESCRIPTION
### JIRA Issue Link
*  n/a

### Verification Process

| Old class       | New class         | New class (if applicable)  |
| ------------- |-------------| ------------|
| assembly-dark     | dark |  |
| product-hero--dark     | dark |  |
| product-hero--light    | light |  |
| product-hero--slim     | assembly-slim |  |
| center | centered |  |
| assembly-center | centered |  |
| product-signup-hero--dark | dark |  |
| events-hero--light | light |  |
| product-hero--dark-centered | dark | centered |
| product-hero--light-centered | light | centered |

### Rich Text

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/20025/edit

You should see this:

- The Dark visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/products/eap2/overview

- The Rich Text assembly about halfway down the page should have the `dark` class applied to the `div.assembly-center.assembly.assembly-type-rich_text` element

### Rich Text with Image

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/21315/edit

You should see this:

- The Dark visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/topics/event-driven/

You should see this:

- The 3rd assembly on the page should be a Rich Text with Image with the `dark` class applied to this element `div.assembly.assembly-type-content_with_image`

### Rich Text Columns

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/19315/edit

You should see this:

- The Dark visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/products/fuse2/overview

You should see this:

- About halfway down the page there is a (very incomplete) Rich Text Columns assembly that starts with the following text "Fuse is enterprise-ready." On this assembly, you should be able to inspect element and find the `dark` class on the element `div.assembly.assembly-type-rich_text_columns`

### Image Hero

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/17065/edit

You should see this:

- The Dark visual style should be applied

I could not find any example of an Image Hero with the Dark visual style actually being referenced anywhere in the database, so we can not verify that the class would be present using an existing piece of content.

However, you can just create any node or edit an existing one and add this 17065 Image Hero "Image Hero - Download AMQ Streams" and verify that the `dark` class exists.

### Events Hero

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/23605/edit

You should see this:

- The Light visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/node/212665

You should see this:

- The Events Hero assembly should have a `light` class on the `div.assembly.assembly-type-events_hero` element

### Product Download Hero

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/19735/edit

You should see this:

- The Dark visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/node/210785

You should see this:

- The Product Download Hero assembly should have a `dark` class on the `div.assembly.assembly-type-product_download_hero` element

### Product Try-It Hero

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/19495/edit

You should see this:

- The Dark visual style should be applied

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/node/210785

You should see this:

- The Product Download Hero assembly should have a `dark` class on the `div.assembly.assembly-type-product_download_hero` element

### Sign Up Hero

Go here: https://developer-preview-3148.ext.us-west.dc.preprod.paas.redhat.com/assembly/15065/edit

You should see this:

- The Dark visual style should be applied

I could not find any instance of this assembly type being actually referenced by a page/node on the site, so you will have to manually add this to some page to verify that the `dark` class is output.