### PR TITLE
Add Authors to Ebook and Cheat Sheet Cards

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card.twig
@@ -18,6 +18,9 @@
  * - content_image: An image rendered within the content of the Card.
  * - comment_count: A string integer of the number of comments made on the
  *   content within the card.
+ * - cta:
+ *   - cta.text: The link text
+ *   - cta.url: The link href
  * - absolute_url: The absolute path to a piece of content
  *   @see rhd_disqus.module
  * - rhd_domain: Returns TRUE if this is a redhat.com domain

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--books--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--books--card.html.twig
@@ -10,6 +10,7 @@
   'title': {
     'text': node.label,
   },
+  'authors': node.field_author[0].value,
   'cta': {
     'text': 'Download',
     'url': url

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--cheat-sheet--card.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--cheat-sheet--card.html.twig
@@ -10,6 +10,7 @@
   'title': {
     'text': node.label,
   },
+  'authors': node.field_cheat_sheet_author[0].value,
   'cta': {
     'text': 'Download',
     'url': url


### PR DESCRIPTION
### JIRA Issue Link
* n/a

### Verification Process

- Go to the homepage
- Scroll down a bit to find Cheat Sheet and Ebook cards and verify that the ones with authors set actually display the authors

<img width="698" alt="Screen Shot 2019-09-30 at 2 27 11 PM" src="https://user-images.githubusercontent.com/7155034/65918403-6c19c480-e38e-11e9-916a-3a9b655c7098.png">

### Known issue(s)

There is an issue with Card spacing that will be resolved in this ticket in the rhd-frontend repo

https://github.com/redhat-developer/rhd-frontend/issues/229