### PR TITLE
[NO ISSUE] Dynamic content feed visual style centered

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.dynamic_content_feed.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.dynamic_content_feed.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: dynamic_content_feed
 label: 'Dynamic Content'
 description: 'An assembly type that displays a list of content from Wordpress and Drupal.'
-visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\ndark|Dark|Dark background with white text\r\ncenter|Centered|Center the cards on the page\r\ngray|Gray Background|Light gray background"
+visual_styles: "no-padding-top|No padding top|Remove top padding from this assembly\r\nno-padding-bottom|No padding-bottom|Remove bottom padding from this assembly\r\ndark|Dark|Dark background with white text\r\ncentered|Centered|Center the cards on the page\r\ngray|Gray Background|Light gray background"
 new_revision: true


### PR DESCRIPTION
This updates a visual style class of the Dynamic Content Feed assembly
type from `center` to `centered` to match the styles in the FE repo. I
accidentally committed
https://github.com/redhat-developer/developers.redhat.com/pull/3142
with the `center` class, so this is simply a follow-up to that.

### JIRA Issue Link

Follow-up to #3142 

### Verification Process

The Dynamic Content Feed assembly type has a visual style with the `centered` CSS class name and not the `center` CSS class name.