### PR TITLE
[SURGE-3122] Load rhd.min.js in rhdp2 theme

### DIFF
--- a/_docker/drupal/.gitignore
+++ b/_docker/drupal/.gitignore
@@ -28,5 +28,6 @@ dev/local-config.sh
 drupal-filesystem/web/themes/custom/rhdp2/css/rhd.microsites.css
 drupal-filesystem/web/themes/custom/rhdp2/css/rhd.min.css
 drupal-filesystem/web/themes/custom/rhdp2/js/rhd.old.min.js
+drupal-filesystem/web/themes/custom/rhdp2/js/rhd.min.js
 drupal-filesystem/web/themes/custom/rhdp2/favicons
 

--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -34,9 +34,11 @@ RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && npm install \
     && npm run-script styles \
     && npm run-script build \
+    && npm run-script scripts:new \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.min.css /var/www/drupal/web/themes/custom/rhdp2/css/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.microsites.css /var/www/drupal/web/themes/custom/rhdp2/css/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/js/@rhd/rhd.old.min.js /var/www/drupal/web/themes/custom/rhdp2/js/ \
+    && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/js/@rhd/rhd.min.js /var/www/drupal/web/themes/custom/rhdp2/js/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/favicons /var/www/drupal/web/themes/custom/rhdp2/ \
     && rm -rf /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend
 

--- a/_docker/drupal/dev/build-theme.sh
+++ b/_docker/drupal/dev/build-theme.sh
@@ -19,9 +19,11 @@ cd "${FE_THEME_DIR}" \
 && npm install \
 && npm run-script styles \
 && npm run-script build \
+&& npm run-script scripts:new \
 && cp dist/css-min/rhd.min.css "${DRUPAL_THEME_DIR}"/css/ \
 && cp dist/css-min/rhd.microsites.css "${DRUPAL_THEME_DIR}"/css/ \
 && cp dist/js/@rhd/rhd.old.min.js "${DRUPAL_THEME_DIR}"/js/ \
+&& cp dist/js/@rhd/rhd.min.js "${DRUPAL_THEME_DIR}"/js/ \
 && cp -r favicons "${DRUPAL_THEME_DIR}/"
 
 cd "${DIR}" && docker-compose exec drupal /bin/bash -c "drush cr"

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -37,6 +37,7 @@ base-theme:
     # https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.21.4/system-production.js: { type: external, minified: true }
     https://developers.redhat.com/auth/js/keycloak.js: { type: external, minified: false  }
     js/rhd.old.min.js: { minified: true }
+    js/rhd.min.js: { minified: true }
   dependencies:
     - core/jquery
     - core/drupal


### PR DESCRIPTION
This adds the building of rhd.min.js file to the FE build process in
Dockerfile.mp and dev/build-theme.sh and the copying of the file into
the ./rhdp2/js directory. It also declares the file in the
rhdp2.libraries.yml file. Lastly, I've added rhd.min.js to .gitignore
since we do not want to track a file we are building.

### JIRA Issue Link

Closes #3122 

### Verification Process

- `./rhdp2/js/rhd.min.js` exists
- `./rhdp2/js/rhd.min.js` is loaded in the browser

The 'Report a website issue' footer button works and brings up a JIRA iframe like this:

<img width="1640" alt="Screen Shot 2019-10-07 at 1 51 53 PM" src="https://user-images.githubusercontent.com/7155034/66348007-641bd080-e90a-11e9-912c-3040cad491b0.png">
