### PR TITLE
[SURGE-3133] Katacoda All Courses View

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/views.view.katacoda_all_courses.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/views.view.katacoda_all_courses.yml
@@ -69,7 +69,16 @@ display:
             previous: ‹‹
             next: ››
       style:
-        type: default
+        type: grid
+        options:
+          uses_fields: false
+          columns: 1000
+          automatic_width: false
+          alignment: horizontal
+          col_class_default: false
+          col_class_custom: ''
+          row_class_default: false
+          row_class_custom: ''
       row:
         type: 'entity:node'
         options:
@@ -282,7 +291,7 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
-      css_class: 'container katacoda-courses-container'
+      css_class: 'component katacoda-courses-container'
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Implements the katacoda all courses View as a Card Grid.

### JIRA Issue Link

Closes #3133 

### Verification Process

Go here: /courses/

You should see this:

**NOTE**: I've altered a class on the 'Training for Developers' Rich Text with Image assembly from assembly-dark to dark. This change is already implemented here, but has not been merged yet: https://github.com/redhat-developer/developers.redhat.com/pull/3148

<img width="1680" alt="Screen Shot 2019-10-07 at 7 08 58 PM" src="https://user-images.githubusercontent.com/7155034/66362106-4ebc9b80-e936-11e9-8e81-6b0a4f2a726a.png">
