### PR TITLE
[SURGE-3059] Add container to assembly, Code snippet, Image

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly.html.twig
@@ -15,6 +15,12 @@
  * @ingroup themeable
  */
 #}
-{% if code %}
-  <pre{{ attributes.addClass('pf-l-flex') }}{{ audience_selection }}><code{{ create_attribute({'class': [language]}) }}>{{ code }}</code></pre>
-{% endif %}
+{% set classes = [
+  'assembly',
+  'pf-l-flex'
+] %}
+<div{{ attributes.addClass(classes) }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>


### PR DESCRIPTION
This adds a container, pf-l-flex, class to a generic assembly.html.twig
and assembly--code-snippet.html.twig. The generic assembly.html.twig
covers assemblies that do not have a specific template, like the Image
assembly type.

### JIRA Issue Link

This will close #3059 

### Verification Process

/coderland/serverless/building-a-serverless-service/

Before, you would see this:

<img width="620" alt="Screen Shot 2019-10-08 at 8 05 33 AM" src="https://user-images.githubusercontent.com/7155034/66408252-75fd8200-e9a3-11e9-9002-e0edc407ca6b.png">


Now, you should see this:

<img width="741" alt="Screen Shot 2019-10-08 at 8 09 48 AM" src="https://user-images.githubusercontent.com/7155034/66408257-785fdc00-e9a3-11e9-936c-42d60ac821c1.png">

Notice that the assemblies are not respecting the same container width in the Before example, and they are now