### PR TITLE
[SURGE-3047] Wordpress Post Reference

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.module
@@ -75,6 +75,15 @@ function rhd_assemblies_theme($existing, $type, $theme, $path) {
     ],
   ];
 
+  // Registers a custom template and variables for Wordpress Post Tile.
+  $theme['wordpress_post_tile'] = [
+    'template' => 'wordpress-post-tile',
+    'variables' => [
+      'post' => NULL,
+      'media' => NULL,
+    ],
+  ];
+
   return $theme;
 }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
@@ -1,0 +1,12 @@
+{% if media and media.media_type == 'image' %}
+{% set tmpUrl = media.source_url %}
+{% if '.jpg' in tmpUrl or '.jpeg' in tmpUrl  or '.gif' in tmpUrl  or '.png' in tmpUrl %}
+{% set cacheImg = {'#theme':'imagecache_external', '#uri':tmpUrl, '#style_name':'static_item', '#alt':post.title.rendered|replace({'"':''}), } %}
+  {{ cacheImg }}
+{% else %}
+  <img src="{{ tmpUrl }}" alt="{{ post.title.rendered|replace({'"':''}) }}" />
+{% endif %}
+{% endif %}
+<div class="rhd-c-card-content">
+  <h3 class="rhd-c-card__title"><a href="{{ post.link }}" class="rhd-m-link">{{ post.title.rendered|raw }}</a></h3>
+</div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--wordpress-post-reference.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--wordpress-post-reference.html.twig
@@ -1,0 +1,9 @@
+{% set classes = [
+  'pf-c-card',
+  'rhd-c-card'
+] %}
+<div{{ attributes.addClass(classes) }}{{ audience_selection }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>


### PR DESCRIPTION
This adds the proper template suggestion(s) and templates to render the
Wordpress Post Reference assembly type as a Card. The actual wordpress
post will render as a Tile, which you will see configured and in the
Twig template name. I am doing this, instead of using the Card because
this implementation has to render the _content_ of the Card vs. the
entire Card, so the markup is actually different. The top-level
container element comes from assembly--wordpress-post-reference.

### JIRA Issue Link

Closes #3047 

### Verification Process

Go here: /openshift/

You should see this:

<img width="1193" alt="Screen Shot 2019-10-09 at 8 26 36 AM" src="https://user-images.githubusercontent.com/7155034/66496047-22f10100-ea6f-11e9-8a49-e42beafa28a1.png">
