### PR TITLE
[NO ISSUE] Topic Page node title and summary fit container

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/field/field--node--body--topic-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/field/field--node--body--topic-page.html.twig
@@ -1,5 +1,7 @@
-<div class="component topic-page__summary">
-  {% for item in items %}
-    {{ item.content }}
-  {% endfor %}
+<div class="topic-page__summary component">
+  <div class="pf-l-grid">
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  </div>
 </div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
@@ -10,10 +10,12 @@
 %}
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
-  <div class="component topic-page__title">
-    {{ title_prefix }}
-    <h1{{ title_attributes }}>{{ label }}</h1>
-    {{ title_suffix }}
+  <div class="topic-page__title component">
+    <div class="pf-l-grid">
+      {{ title_prefix }}
+      <h1{{ title_attributes }}>{{ label }}</h1>
+      {{ title_suffix }}
+    </div>
   </div>
 
   <div{{ content_attributes.addClass('node__content') }}>


### PR DESCRIPTION
This changes the markup of the node title and summary in the Topic
Page, default/full view mode, so that it now respects our container
width, .component .pf-l-grid, and matches other components on the page.

Before/current state:

<img width="877" alt="Screen Shot 2019-10-10 at 7 41 46 AM" src="https://user-images.githubusercontent.com/7155034/66579524-cf93b700-eb31-11e9-9f54-37b6e14c4abc.png">

### JIRA Issue Link

n/a

### Verification Process

Go here: https://developer-preview-3181.ext.us-west.dc.preprod.paas.redhat.com/topics/service-mesh/

You should see this:

<img width="798" alt="Screen Shot 2019-10-10 at 7 41 35 AM" src="https://user-images.githubusercontent.com/7155034/66579493-c4408b80-eb31-11e9-9296-ed69b4f9c66a.png">