### PR TITLE
[NO ISSUE] Load PFElement in the head

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.info.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.info.yml
@@ -7,6 +7,7 @@ core: 8.x
 libraries:
   - rhdp2/web-components
   - rhdp2/base-theme
+  - rhdp2/rhdp-pfelement
   - rhdp2/rhdp-web-components
 stylesheets-remove:
   - core/assets/vendor/normalize-css/normalize.css

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -43,6 +43,15 @@ base-theme:
     - core/drupal
     - core/drupalSettings
 
+rhdp-pfelement:
+  header: true
+  js:
+    js/pfelement.umd.min.js: { minified: true, preprocess: false }
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
+
 rhdp-web-components:
   js:
     js/rhd/dp-alert.js: { minified: true, preprocess: false }
@@ -51,12 +60,10 @@ rhdp-web-components:
     js/rhd/rhdp-tryitnow.js: { minified: true, preprocess: false }
     js/rhd/dp-category-list/dp-category-list-wc.js: { minified: true, preprocess: false }
     js/rhd/dp-search/dp-search.js: { minified: true, preprocess: false }
-    js/rhd/dp-search/dp-search-onebox.js: { minified: true, preprocess: false }
     js/rhd/rhdp-downloads/rhdp-downloads.js: { minified: true, preprocess: false }
     js/rhd/rhdp-projects/rhdp-project-wc.js: { minified: true, preprocess: false }
     js/rhd/rhdp-search/rhdp-search.js: { minified: true, preprocess: false }
     js/pfe-datetime.umd.min.js: { minified: true, preprocess: false }
-    js/pfelement.umd.min.js: { minified: true, preprocess: false }
   dependencies:
     - core/jquery
     - core/drupal

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -47,10 +47,6 @@ rhdp-pfelement:
   header: true
   js:
     js/pfelement.umd.min.js: { minified: true, preprocess: false }
-  dependencies:
-    - core/jquery
-    - core/drupal
-    - core/drupalSettings
 
 rhdp-web-components:
   js:
@@ -64,10 +60,6 @@ rhdp-web-components:
     js/rhd/rhdp-projects/rhdp-project-wc.js: { minified: true, preprocess: false }
     js/rhd/rhdp-search/rhdp-search.js: { minified: true, preprocess: false }
     js/pfe-datetime.umd.min.js: { minified: true, preprocess: false }
-  dependencies:
-    - core/jquery
-    - core/drupal
-    - core/drupalSettings
 
 video_embed_field.responsive-video:
   css:


### PR DESCRIPTION
This loads the PFElement JS file in the head and no longer loads the
onebox JS file explicitly, as that is loaded via the Search JS file.

### JIRA Issue Link

n/a

### Verification Process

- `js/pfelement.umd.min.js` is loaded in the head.
- There are no JS errors in the console on the /search page, or at least none specifically related to our web component implementation.