### PR TITLE
[NO ISSUE] Build rhdp theme

### DIFF
--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -25,7 +25,14 @@ COPY drupal-filesystem/web/sites/default /var/www/drupal/web/sites/default
 COPY drupal-filesystem/web/modules/custom /var/www/drupal/web/modules/custom
 COPY drupal-filesystem/web/themes/custom /var/www/drupal/web/themes/custom
 
-# Build the theme
+# Build the rhdp theme
+# This theme is still required to render the old, paragraphs-based Product pages
+RUN cd /var/www/drupal/web/themes/custom/rhdp/rhd-frontend \
+    && npm install \
+    && npm run-script build \
+    && rm -rf /var/www/drupal/web/themes/custom/rhdp/rhd-frontend/node_modules
+
+# Build the rhdp2 theme
 ARG FONTAWESOME_LICENCE
 RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \
@@ -44,6 +51,7 @@ RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && rm -rf /var/www/drupal/web/themes/custom/rhdp2/js/rhd \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/js/@rhd /var/www/drupal/web/themes/custom/rhdp2/js/rhd \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/favicons /var/www/drupal/web/themes/custom/rhdp2/ \
+    && rm -rf /var/www/drupal/web/themes/custom/rhdp2/fonts \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/fonts /var/www/drupal/web/themes/custom/rhdp2/ \
     && rm -rf /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend
 


### PR DESCRIPTION
This adds back the rhdp theme builds steps. We have implemented a
ThemeNegotiator to load the rhdp theme for only the old,
paragraphs-based Product pages.

There was a regression accidentally introduced here: https://github.com/redhat-developer/developers.redhat.com/commit/bacf9259f6cc977fe157798f7e24e7cc591be988#diff-ed77739bf4e1242389299ce08b6729cdL29

### JIRA Issue Link

n/a

### Verification Process

These routes should load the `rhdp` theme:

https://localhost/products/rhel/
https://localhost/products/rhel/overview/
https://localhost/products/rhel/download/
https://localhost/products/rhel/hello-world/
https://localhost/products/rhel/docs-and-apis/
https://localhost/products/rhel/help/

These routes should load the `rhdp2` theme:

https://localhost/products/openjdk/
https://localhost/products/openjdk/overview/
https://localhost/products/openjdk/download/
https://localhost/products/openjdk/getting-started/

- All of the download e2e tests should pass.