### PR TITLE
[SURGE-354] Fix product card cta links

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -347,6 +347,10 @@ function rhdp2_preprocess_node(&$variables) {
     }
   }
 
+  // Provide the url_product_name to the Twig template to build the path alias to the Download route.
+  if ($type === 'product' && $variables['view_mode'] === 'featured_tile') {
+    $variables['url_product_name'] = $node->get('field_url_product_name')->value;
+  }
 }
 
 /**

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--featured-tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--featured-tile.html.twig
@@ -5,7 +5,7 @@
   'hero_image': content.field_image,
   'body': content.field_short_description[0],
   'cta': {
-    'url': url ~ '/download/',
+    'url': '/products/' ~ url_product_name ~ '/download/',
     'text': 'Download'
   }
 } only %}


### PR DESCRIPTION
### JIRA Issue Link

https://github.com/redhat-developer/rhd-frontend/issues/354

### Verification Process

The CTA link in product cards (on for example: /products) direct to the Download page for the correct product.

Go here: https://developer-preview-3200.ext.us-west.dc.preprod.paas.redhat.com/products/

Click each of the Download CTA button in the Product cards at the top of the page.

You should be directed here:

https://developer-preview-3200.ext.us-west.dc.preprod.paas.redhat.com/products/rhel/download

https://developer-preview-3200.ext.us-west.dc.preprod.paas.redhat.com/products/openshift/download

https://developer-preview-3200.ext.us-west.dc.preprod.paas.redhat.com/products/eap/download
