### PR TITLE
[SURGE-3203] Add templates Product download and getting started

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--product-download-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--product-download-page.html.twig
@@ -1,0 +1,18 @@
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+{{ attach_library('classy/node') }}
+<article{{ attributes.addClass(classes) }}>
+
+  <div{{ content_attributes.addClass('node__content') }}>
+    {{ content }}
+  </div>
+
+</article>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--product-getting-started-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--product--product-getting-started-page.html.twig
@@ -1,0 +1,18 @@
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+{{ attach_library('classy/node') }}
+<article{{ attributes.addClass(classes) }}>
+
+  <div{{ content_attributes.addClass('node__content') }}>
+    {{ content }}
+  </div>
+
+</article>


### PR DESCRIPTION
This adds Twig templates for the Product /download and /getting-started
subpages. This includes the changes required to remove the page title,
as we do not want that in our assembly-based content strategy.

### JIRA Issue Link

#3203 

### Verification Process

Go here: https://localhost/products/codeready-workspaces/download 
and here: https://localhost/products/codeready-workspaces/getting-started

You should **not** see a page title at the top of the page