### PR TITLE
Don't render grid item without image

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--product-download-hero.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--product-download-hero.html.twig
@@ -7,8 +7,8 @@
 ] %}
 
 <div {{ attributes.addClass(classes).setAttribute('style', background_image) }}{{ audience_selection }}>
+  {% if image_uri %}
   <div class="pf-l-grid__item rhd-c-product-download-hero-aside">
-    {% if image_uri %}
     <div class="pf-l-grid__item pf-m-4-col-on-lg pf-m-5-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
       <picture class="product-download-hero-aside">
         <source media="(min-width: 480px)" srcset="{{ image_uri }}">
@@ -17,8 +17,8 @@
         <img src="{{ image_uri }}" alt="{{ image_alt }}" />
       </picture>
     </div>
-    {% endif %}
   </div>
+  {% endif %}
   <div class="pf-l-grid__item rhd-c-product-download-hero-content">
     {% if content.field_title|render %}
     {{ content.field_title }}


### PR DESCRIPTION
We don't want to render the div/CSS Grid item at all if there is no
content because it will squish the display on mobile.

n/a

I meant to push this up before merging this PR https://github.com/redhat-developer/developers.redhat.com/pull/3228 . It was a part of what I just demo'd in the Google Hangouts chat, so it is already approved.
