### PR TITLE
[NO ISSUE] Display Code Snippet Assemblies

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/css/rhdp2.css
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/css/rhdp2.css
@@ -638,5 +638,5 @@ a.pf-c-button:hover {
 
 /* Code Snippet */
 .assembly.assembly-type-code_snippet .hljs {
-  padding; 8px;
+  padding: 8px;
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/css/rhdp2.css
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/css/rhdp2.css
@@ -635,3 +635,8 @@ a.pf-c-button:hover {
 .assembly-type-events_hero.has-sidebar .sidebar .short-description {
   display: none;
 }
+
+/* Code Snippet */
+.assembly.assembly-type-code_snippet .hljs {
+  padding; 8px;
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -456,6 +456,14 @@ function rhdp2_preprocess_assembly(&$variables) {
 
   // Code Snippet assembly type.
   if ($type == 'code_snippet') {
+    // Code field.
+    if ($assembly->hasField('field_code')) {
+      // Verify that the field isset before retrieving the value.
+      if (isset($assembly->field_code)) {
+        $field_code = $assembly->get('field_code')->getValue()[0]['value'];
+        $variables['code'] = $field_code;
+      }
+    }
     // Programming Language field.
     if ($assembly->hasField('field_programming_language')) {
       // Verify that the field isset before retrieving the value.


### PR DESCRIPTION
A regression was accidentally introduced here:
https://github.com/redhat-developer/developers.redhat.com/commit/7749cc4011c411c5f31f2c46b55b4e5436101d53#diff-304ef1e9f8b0e28569a944480f0512da
that removed a necessary variable for rendering the code snippet
assembly. I have added back the preprocessing of that variable, while
still leaving out the attachment of the highlight-js library, as that is
included globally to accommodate all `<code><pre>` elements. I used UX's
Marvel design to determine the 8px of padding.

### JIRA Issue Link

n/a

### Verification Process

Go here: `/coderland/serverless/building-a-serverless-service/`

You should see this:

<img width="1313" alt="Screen Shot 2019-10-16 at 12 54 48 PM" src="https://user-images.githubusercontent.com/7155034/66953891-2ad31700-f014-11e9-9761-ec50874d1d26.png">

