### PR TITLE
[SURGE-347] Node Reference Cards spacing

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--node-reference.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--node-reference.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file assembly.html.twig
+ * Default theme implementation to present Assembly data.
+ *
+ * This template is used when viewing Assembly pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_assembly()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass(classes) }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>


### PR DESCRIPTION
This resolves an issue where Node Reference cards, in static content
bands, had too much spacing between cards in the card grid.

### JIRA Issue Link

https://github.com/redhat-developer/rhd-frontend/issues/347

### Verification Process

Go here: https://localhost/topics/kubernetes/

You should see this:

<img width="1370" alt="Screen Shot 2019-10-16 at 1 02 50 PM" src="https://user-images.githubusercontent.com/7155034/66955273-de3d0b00-f016-11e9-864c-a8fdee6ad730.png">

and

<img width="500" alt="Screen Shot 2019-10-16 at 1 05 02 PM" src="https://user-images.githubusercontent.com/7155034/66955279-e09f6500-f016-11e9-81c1-7f18465c903c.png">


NOTE: I created a follow-up issue for that right margin on the cards on mobile here: https://github.com/redhat-developer/rhd-frontend/issues/384