### PR TITLE
[SURGE-3268] Redhat.com logo link in universal nav

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/menu/menu--universal-header.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/menu/menu--universal-header.html.twig
@@ -35,7 +35,7 @@
       <ul class="rhd-menu">
     {% endif %}
       <li class="pf-c-nav__item">
-        <a href="#" class="pf-c-nav__link">
+        <a href="https://www.redhat.com" class="pf-c-nav__link">
           <img class="pf-c-brand" alt="Red Hat Logo" src="{{ theme_path }}/images/branding/RHLogo_white.svg">
         </a>
       </li>


### PR DESCRIPTION
This links the logo in the universal nav to https://www.redhat.com

### JIRA Issue Link

#3268 

### Verification Process

Go here: /home

When you click on the logo in the universal nav, it should direct you to https://www.redhat.com