### PR TITLE
[#3249] Reinstated the mobile search tests

### DIFF
--- a/_tests/e2e/tests/config/wdio.conf.base.js
+++ b/_tests/e2e/tests/config/wdio.conf.base.js
@@ -58,7 +58,6 @@ exports.config = {
         global.should = chai.should();
         global.tags = tags;
         global.downloadDir = path.resolve('tmp_downloads');
-        global.mobileSuite = testProfile === 'mobile'
     },
 
     afterTest: function(test) {

--- a/_tests/e2e/tests/specs/export/rhd-search.spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-search.spec.js
@@ -12,12 +12,6 @@ describe('Search Page', function() {
     // eslint-disable-next-line no-invalid-this
     this.retries(2);
 
-    before(function() {
-        if(global.mobileSuite === true) {
-            this.skip();
-        }
-    });
-
     it('should allow users to search for content via site-nav search field', () => {
         Home.open('/');
         NavigationBar.searchFor('hello world');


### PR DESCRIPTION
Follows up on #3265 . I believe that was the cause of the mobile search tests being broken.

### Verification Process

* Build should go green.


Closes #3249 