### PR TITLE
[#3304] Remove multiple builds of rhd-frontend theme

### DIFF
--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -36,10 +36,7 @@ RUN cd /var/www/drupal/web/themes/custom/rhdp/rhd-frontend \
 ARG FONTAWESOME_LICENCE
 RUN cd /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend \
     && npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \
-    && npm config set "@fortawesome:registry" https://npm.fontawesome.com/ \
-    && npm config set "//npm.fontawesome.com/:_authToken" $FONTAWESOME_LICENCE \
     && npm install \
-    && npm run-script styles \
     && npm run-script build \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.min.css /var/www/drupal/web/themes/custom/rhdp2/css/ \
     && mv /var/www/drupal/web/themes/custom/rhdp2/rhd-frontend/dist/css-min/rhd.microsites.css /var/www/drupal/web/themes/custom/rhdp2/css/ \

--- a/_docker/drupal/dev/build-theme.sh
+++ b/_docker/drupal/dev/build-theme.sh
@@ -13,11 +13,7 @@ set +a
 
 cd "${FE_THEME_DIR}" \
 && npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \
-&& npm config set strict-ssl false \
-&& npm config set "@fortawesome:registry" https://npm.fontawesome.com/ \
-&& npm config set "//npm.fontawesome.com/:_authToken" $FONTAWESOME_LICENCE \
 && npm install \
-&& npm run-script styles \
 && npm run build \
 && cp dist/css-min/rhd.min.css "${DRUPAL_THEME_DIR}"/css/ \
 && cp dist/css-min/rhd.microsites.css "${DRUPAL_THEME_DIR}"/css/ \

--- a/_docker/drupal/dev/docker-compose.yml
+++ b/_docker/drupal/dev/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       context: ../
       dockerfile: Dockerfile.mp
       args:
-        - FONTAWESOME_LICENCE="${FONTAWESOME_LICENCE}"
         - composer_profile=development
     command: ["/bin/bash", "-c", "ansible-playbook /ansible/bootstrap-env.yml"]
     user: ${DUID}:0
@@ -46,7 +45,6 @@ services:
       context: ../
       dockerfile: Dockerfile.mp
       args:
-        - FONTAWESOME_LICENCE="${FONTAWESOME_LICENCE}"
         - composer_profile=development
     command: ["/bin/bash", "-c", "ansible-playbook /ansible/bootstrap-drupal.yml"]
     user: ${DUID}:0
@@ -69,7 +67,6 @@ services:
      context: ../
      dockerfile: Dockerfile.mp
      args:
-      - FONTAWESOME_LICENCE="${FONTAWESOME_LICENCE}"
       - composer_profile=development
     command: ["/bin/bash", "-c", "/var/www/drupal/run-httpd.sh"]
     user: ${DUID}:0


### PR DESCRIPTION
This commit does a couple of things.

Firstly it removes any reference to the fontawesome stuff from the Drupal build. We are now hosting those assets from a CDN.

Secondly it only calls `npm run-script build` to create the new rhd-frontend assets. We were previously calling `npm run-script styles` and then `npm run-script build`, however the build script additionally calls styles, so this was a duplication

### Verification Process

* The build should go green
* The site should look as expected
