### PR TITLE
[MWES-3660] Phase 2 of SSO migration

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
@@ -152,7 +152,7 @@ app.ssoConfig.auth_url = drupalSettings.rhd.keycloak.authUrl;
 app.ssoConfig.client_id = drupalSettings.rhd.keycloak.client_id;
 app.ssoConfig.realm = drupalSettings.rhd.keycloak.realm;
 
-var homeLink = 'https://' + drupalSettings.urls.final_base_url;
+var homeLink = 'https://' + drupalSettings.rhd.urls.final_base_url;
 app.ssoConfig.confirmation = homeLink + '/confirmation';
 app.ssoConfig.logout_url = homeLink;
 app.projects = {};

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-namespace.js
@@ -152,9 +152,9 @@ app.ssoConfig.auth_url = drupalSettings.rhd.keycloak.authUrl;
 app.ssoConfig.client_id = drupalSettings.rhd.keycloak.client_id;
 app.ssoConfig.realm = drupalSettings.rhd.keycloak.realm;
 
-var homeLink = document.getElementById('home-link') || { href: ''};
-app.ssoConfig.confirmation = homeLink.href + '/confirmation';
-app.ssoConfig.logout_url = homeLink.href;
+var homeLink = 'https://' + drupalSettings.urls.final_base_url;
+app.ssoConfig.confirmation = homeLink + '/confirmation';
+app.ssoConfig.logout_url = homeLink;
 app.projects = {};
 app.projects.defaultImage = "/images/design/projects/default_200x150.png";
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/sso.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/sso.js
@@ -158,8 +158,8 @@ app.sso = function () {
 
     var keycloak = Keycloak({
         url: app.ssoConfig.auth_url,
-        realm: 'rhd',
-        clientId: 'web'
+        realm: app.ssoConfig.realm,
+        clientId: app.ssoConfig.client_id
     });
     app.keycloak = keycloak;
 
@@ -178,7 +178,7 @@ app.sso = function () {
         checkIfProtectedPage();
 
         if(app.termsAndConditions) {
-            // app.termsAndConditions.isDownloadPage() test for tcDownloadURL is not empty, tcDownloadFileName is not empty and tcSourceLink (contains 'download-manager') 
+            // app.termsAndConditions.isDownloadPage() test for tcDownloadURL is not empty, tcDownloadFileName is not empty and tcSourceLink (contains 'download-manager')
             if(app.termsAndConditions.isDownloadPage()) {
                 app.termsAndConditions.download();
             }

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -17,10 +17,10 @@ $config['redhat_developers']['rhd_base_url'] = 'developers.dev.redhat.com';
 $config['redhat_developers']['rhd_final_base_url'] = 'developers.dev.redhat.com';
 $config['redhat_developers']['downloadManager']['baseUrl'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['downloadManager']['fileBaseUrl'] = '//developers.stage.redhat.com/download-manager/file/';
-$config['redhat_developers']['keycloak']['accountUrl'] = 'https://developers.stage.redhat.com/auth/realms/rhd/account/';
-$config['redhat_developers']['keycloak']['authUrl'] = 'https://developers.stage.redhat.com/auth/';
-$config['redhat_developers']['keycloak']['client_id'] = 'web';
-$config['redhat_developers']['keycloak']['realm'] = 'rhd';
+$config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/account/';
+$config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
+$config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
+$config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
 $config['redhat_developers']['drupal']['host'] = 'https://developers.dev.redhat.com';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -34,11 +34,11 @@ $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://developers.dev.redhat.com/openid-connect/keycloak';
 $config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://developers.stage.redhat.com/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'rhd';
-$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token';
-$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';
+$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/userinfo';
 
 
 /**

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -17,10 +17,10 @@ $config['redhat_developers']['rhd_base_url'] = 'localhost';
 $config['redhat_developers']['rhd_final_base_url'] = 'localhost';
 $config['redhat_developers']['downloadManager']['baseUrl'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['downloadManager']['fileBaseUrl'] = '//developers.stage.redhat.com/download-manager/file/';
-$config['redhat_developers']['keycloak']['accountUrl'] = 'https://developers.stage.redhat.com/auth/realms/rhd/account/';
-$config['redhat_developers']['keycloak']['authUrl'] = 'https://developers.stage.redhat.com/auth/';
-$config['redhat_developers']['keycloak']['client_id'] = 'web';
-$config['redhat_developers']['keycloak']['realm'] = 'rhd';
+$config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.qa.redhat.com/auth/realms/redhat-external/account/';
+$config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.qa.redhat.com/auth/';
+$config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
+$config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
 $config['redhat_developers']['drupal']['host'] = 'https://localhost';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -34,11 +34,11 @@ $config['redhat_developers']['cache']['engine'] = 'database';
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://localhost/openid-connect/keycloak';
 $config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://developers.stage.redhat.com/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'rhd';
-$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token';
-$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.qa.redhat.com/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';
+$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://sso.qa.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://sso.qa.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://sso.qa.redhat.com/auth/realms/redhat-external/protocol/openid-connect/userinfo';
 
 
 /**

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -18,10 +18,10 @@ $config['redhat_developers']['rhd_base_url'] = 'developers.stage.redhat.com';
 $config['redhat_developers']['rhd_final_base_url'] = 'developers.stage.redhat.com';
 $config['redhat_developers']['downloadManager']['baseUrl'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['downloadManager']['fileBaseUrl'] = '/developers.stage.redhat.com/download-manager/file/';
-$config['redhat_developers']['keycloak']['accountUrl'] = 'https://developers.stage.redhat.com/auth/realms/rhd/account/';
-$config['redhat_developers']['keycloak']['authUrl'] = 'https://developers.stage.redhat.com/auth/';
-$config['redhat_developers']['keycloak']['client_id'] = 'web';
-$config['redhat_developers']['keycloak']['realm'] = 'rhd';
+$config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/account/';
+$config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
+$config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
+$config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
 $config['redhat_developers']['drupal']['host'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -35,11 +35,11 @@ $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://developers.stage.redhat.com/openid-connect/keycloak';
 $config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://developers.stage.redhat.com/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'rhd';
-$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token';
-$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';
+$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/userinfo';
 
 
 /**


### PR DESCRIPTION
This commit updates dev, stage and local dev to use the new SSO servers. Additionally it updates the rhd-frontend reference to pull in changes made in that project to support the SSO migration. The changes are also replicated in the legacy rhd-frontend component in this repo.

### Verification Process

* The build should go green
* Visit Drupal and ensure you can login as a site visitor
* Visit Drupal and ensure you can login as a Drupal content editor
* Visit `/login` and ensure you correctly redirected to the homepage after completing the login process.
