### PR TITLE
[MWES-3660] Expose SWEL API endpoint for user registration event integration

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -196,6 +196,9 @@ function rhdp_js_settings_alter(array &$settings, AttachedAssetsInterface $asset
   $rhd_settings['keycloak']['client_id'] = $env_settings->get('keycloak')['client_id'];
   $rhd_settings['keycloak']['realm'] = $env_settings->get('keycloak')['realm'];
 
+  $rhd_settings['swel'] = [];
+  $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp');
 
   $rhd_settings['templates'] = [];

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -656,6 +656,9 @@ function rhdp2_js_settings_alter(array &$settings, AttachedAssetsInterface $asse
   $rhd_settings['keycloak']['client_id'] = $env_settings->get('keycloak')['client_id'];
   $rhd_settings['keycloak']['realm'] = $env_settings->get('keycloak')['realm'];
 
+  $rhd_settings['swel'] = [];
+  $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp2');
 
   $rhd_settings['templates'] = [];

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -27,7 +27,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
-$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -27,6 +27,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -27,6 +27,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'database';
+$config['redhat_developers']['swel']['url'] = 'https://mwes-swel-service-qa.ext.us-west.dc.preprod.paas.redhat.com/swel'
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -27,7 +27,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'database';
-$config['redhat_developers']['swel']['url'] = 'https://mwes-swel-service-qa.ext.us-west.dc.preprod.paas.redhat.com/swel'
+$config['redhat_developers']['swel']['url'] = 'https://mwes-swel-service-qa.ext.us-west.dc.preprod.paas.redhat.com/swel';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -28,7 +28,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
-$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -29,6 +29,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp2.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = '//dcp2.jboss.org';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.redhat.com/swel'
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -29,7 +29,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp2.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = '//dcp2.jboss.org';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
-$config['redhat_developers']['swel']['url'] = 'https://api.developers.redhat.com/swel'
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.redhat.com/swel';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -28,7 +28,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
-$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
 $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
+$config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel'
 
 /**
     SSO Integration for Content Editor Authentication


### PR DESCRIPTION
Makes available the SWEL API endpoint for user registration event management post SSO merge.

This does not change any work-flow, merely makes available the configuration for future work.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3660

### Verification Process

* The build should go green
* Please ensure the following variable is available via the JS console: `drupalSettings.rhd.swel.url`. For the preview environment its value should be: `https://api.developers.stage.redhat.com/swel`
