### PR TITLE
[#3249] Reinstate search tests for mobile

### DIFF
--- a/_tests/e2e/tests/config/wdio.conf.base.js
+++ b/_tests/e2e/tests/config/wdio.conf.base.js
@@ -58,7 +58,6 @@ exports.config = {
         global.should = chai.should();
         global.tags = tags;
         global.downloadDir = path.resolve('tmp_downloads');
-        global.mobileSuite = testProfile === 'mobile'
     },
 
     afterTest: function(test) {

--- a/_tests/e2e/tests/specs/export/rhd-search.spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-search.spec.js
@@ -12,12 +12,6 @@ describe('Search Page', function() {
     // eslint-disable-next-line no-invalid-this
     this.retries(2);
 
-    before(function() {
-        if(global.mobileSuite === true) {
-            this.skip();
-        }
-    });
-
     it('should allow users to search for content via site-nav search field', () => {
         Home.open('/');
         NavigationBar.searchFor('hello world');


### PR DESCRIPTION
This reinstates the mobile search tests that were disabled as part of the `surge` work. 

Closes #3249 

### Verification Process

* The build should go green