### PR TITLE
[No Issue] Removed .gitmodules file from the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend"]
-	path = _docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend
-	url = https://github.com/redhat-developer/rhd-frontend.git


### PR DESCRIPTION
The `.gitmodules` file is no longer required since `rhd-frontend` was bought into this repo. This simply deletes the file.

### Verification Process

* Build should go green.