### PR TITLE
option to skip docker login and fix comment list

### DIFF
--- a/_docker/drupal/dev/README.md
+++ b/_docker/drupal/dev/README.md
@@ -18,8 +18,7 @@ user account details for this registry.
 
 To do that, firstly visit registry.redhat.io and ensure that you can log in (you should be able to log in with your Red Hat Developer account)
 
-Next copy `local-config.sh.example` to `local-config.sh` and provide the values for your username and password. `local-config.sh` should not be committed
-to Git and is already set to be ignored.
+Next copy `local-config.sh.example` to `local-config.sh` and provide the values for your username and password, of you have a no exipre login cert you can change REGISTRY_REDHAT_IO_SKIP_LOGIN to true then the script will not attempt to login first. `local-config.sh` should not be committed to Git and is already set to be ignored.
 
 
 #### Install mkcert

--- a/_docker/drupal/dev/local-config.sh.example
+++ b/_docker/drupal/dev/local-config.sh.example
@@ -1,6 +1,7 @@
 #
 # Copy this example configuration file to local-config.sh and fill in the missing values
 #
+REGISTRY_REDHAT_IO_SKIP_LOGIN=false
 REGISTRY_REDHAT_IO_USERNAME=<TBD>
 REGISTRY_REDHAT_IO_PASSWORD=<TBD>
 FONTAWESOME_LICENCE=<TBD>

--- a/_docker/drupal/dev/run-drupal.sh
+++ b/_docker/drupal/dev/run-drupal.sh
@@ -21,7 +21,9 @@ source "${DIR}"/local-config.sh
 set +a
 
 # Login to required registries and pull required images
-docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
+if [[ $REGISTRY_REDHAT_IO_SKIP_LOGIN != true ]]; then
+  docker login registry.redhat.io -u "${REGISTRY_REDHAT_IO_USERNAME}" -p "${REGISTRY_REDHAT_IO_PASSWORD}"
+fi
 docker pull docker-registry.upshift.redhat.com/developers/drupal-data:latest
 docker pull images.paas.redhat.com/rhdp/developer-base:rhel-76.3
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_comment-list-card.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_comment-list-card.scss
@@ -1,4 +1,6 @@
 .rhd-c-card.comment-list {
+  height: auto;
+  padding-bottom: var(--pf-global--spacer--md);
   .rhd-c-card__title {
     font-size: var(--pf-global--FontSize--xl) !important;
     margin-bottom: var(--pf-global--spacer--md);
@@ -18,6 +20,11 @@
 
   &-content {
     margin-bottom: var(--pf-global--spacer--sm) !important;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
   }
 
   &-date {


### PR DESCRIPTION
### JIRA Issue Link
https://github.com/redhat-developer/developers.redhat.com/issues/3298

Fixes #3298 

### Verification Process
Go to any page with disqus comments and check no text is overlapping the comment box.

On a local dev environment, there is now an option to prevent the startup script from tying to login to get the docker container if you have a no expire key. Instructions added to the readme
