### PR TITLE
[MWES-3564] Support for running e2e tests as a Jenkins pipeline.

### DIFF
--- a/_tests/e2e/Dockerfile.mp
+++ b/_tests/e2e/Dockerfile.mp
@@ -4,19 +4,20 @@
 FROM images.paas.redhat.com/rhdp/developer-testing-base:e2e
 MAINTAINER rblake@redhat.com
 USER root
-RUN groupadd -g 1000 e2e \
-    && useradd -g e2e -m -s /bin/bash -u 1000 e2e
+RUN useradd -g 0 -m -s /bin/bash -u 1000 e2e
 
 WORKDIR /home/e2e
 ENTRYPOINT ["/home/e2e/wait-for-selenium.sh"]
 
 COPY package.json package-lock.json wait-for-selenium.sh ./
-RUN chown -R e2e:e2e /home/e2e
+RUN chown -R e2e:root /home/e2e \
+    && chmod -R 770 /home/e2e
 
 USER e2e
 RUN npm config set "registry" https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/ \
     && npm config set strict-ssl=false \
-    && npm install
+    && npm install \
+    && chmod -R g+w /home/e2e/node_modules
 
 COPY tests tests
 

--- a/_tests/e2e/Jenkinsfile
+++ b/_tests/e2e/Jenkinsfile
@@ -1,0 +1,128 @@
+@Library('RedHatDevelopersPipelineUtils')
+import com.redhat.developer.pr.*
+
+properties ([
+        parameters([
+                string(name: 'PULL_REQUEST_ID', description: 'The id of the pull request to run the tests for.', defaultValue: ''),
+                string(name: 'PULL_REQUEST_SHA', description: 'The SHA of the commit that should be used to clone the pull request repository.', defaultValue: '')
+        ])
+])
+
+/*
+    Ensures that the workspace and any containers are properly cleaned up before we start and after we complete a test run.
+ */
+def clean() {
+    sh 'rm -rf tmp_downloads report'
+    sh 'docker-compose down -v --remove-orphans --rmi local'
+}
+
+/*
+    Some environment variables to support the tests.
+ */
+def testBaseDockerImage = 'images.paas.redhat.com/rhdp/developer-testing-base:e2e'
+def urlToTest = "https://developer-preview-${params.PULL_REQUEST_ID}.ext.us-west.dc.preprod.paas.redhat.com"
+def composeProjectName = "e2e${params.PULL_REQUEST_ID}"
+def testsFailed = false
+
+if(!params.PULL_REQUEST_ID) {
+    error "The PULL_REQUEST_ID parameter must be set."
+}
+
+if(!params.PULL_REQUEST_SHA) {
+    error "The SHA at which to run the tests must be set."
+}
+
+node('developer-docker') {
+
+    echo "Executing e2e tests for pull request '${params.PULL_REQUEST_ID}' using SHA '${params.PULL_REQUEST_SHA}'. The tests will execute against: '${urlToTest}'."
+
+    timeout(60) {
+
+        def pullRequest
+
+        withCredentials([usernamePassword(credentialsId: 'redhat-developer-ci-github-api-token', passwordVariable: 'GITHUB_API_TOKEN', usernameVariable: 'GITHUB_USERNAME')]) {
+            pullRequest = continuePullRequest(gitApiToken: "${GITHUB_API_TOKEN}", gitRepository: 'https://github.com/redhat-developer/developers.redhat.com', pullRequestId: params.PULL_REQUEST_ID)
+
+            if(pullRequest.branchSha != params.PULL_REQUEST_SHA) {
+                error "The tip of the branch for pull request '${params.PULL_REQUEST_ID}' is now at SHA '${pullRequest.branchSha}', but you are requesting to use SHA '${params.PULL_REQUEST_SHA}'. You're out of date!"
+            }
+        }
+
+        stage('Checkout SCM') {
+            checkout scm
+        }
+
+        dir('_tests/e2e') {
+
+            def uid = sh (
+                    script: 'id -u',
+                    returnStdout: true
+            ).trim()
+
+            def testEnv = [
+                    "COMPOSE_PROJECT_NAME=${composeProjectName}",
+                    "DUID=${uid}",
+                    "RHD_BASE_URL=${urlToTest}"
+            ]
+
+            withEnv(testEnv) {
+
+                try {
+                    stage('Build Docker Images') {
+                        clean()
+                        sh 'mkdir tmp_downloads report && chmod -R 777 tmp_downloads'
+                        sh "docker pull ${testBaseDockerImage}"
+                        sh 'docker-compose build'
+                        sh 'docker-compose up -d chrome'
+                    }
+
+                    def credentials = [
+                            usernamePassword(credentialsId: 'e2e-website-user-credentials', passwordVariable: 'RHD_KEYCLOAK_ADMIN_PASSWORD', usernameVariable: 'RHD_KEYCLOAK_ADMIN_USERNAME'),
+                            usernamePassword(credentialsId: 'e2e-drupal-user-credentials', passwordVariable: 'RHD_DRUPAL_ADMIN_PASSWORD', usernameVariable: 'RHD_DRUPAL_ADMIN_USERNAME')
+                    ]
+
+                    withCredentials(credentials) {
+
+                        def testToStatusMapping = [
+                                desktop: "js-e2e-tests",
+                                mobile: "js-mobile-e2e-tests",
+                                drupal: "js-drupal-e2e-tests"
+                        ]
+
+                        testToStatusMapping.each({ test, status ->
+
+                            def prStatus = pullRequest.statuses[status]
+
+                            echo "Running '${test}' tests and reporting results to status '${status}'..."
+
+                            if(prStatus) {
+
+                                def targetUrl = "${env.BUILD_URL}/artifact/report/${test}-report/index.html"
+
+                                try {
+                                    forStatus(status: prStatus, failureUrl: targetUrl, successUrl: targetUrl) {
+                                        sh "docker-compose run --rm ${test}"
+                                    }
+                                } catch(e) {
+                                    echo "Execution of tests '${test}' failed: ${e}"
+                                    testsFailed = true
+                                }
+                            } else {
+                                echo "Cannot locate required status check '${status}' on pull request '${params.PULL_REQUEST_ID}' at SHA '${params.PULL_REQUEST_SHA}'. Failing tests."
+                                testsFailed = true
+                            }
+                        })
+                    }
+
+                } finally {
+                    archiveArtifacts artifacts: 'report/**', fingerprint: false, allowEmptyArchive: true
+                    clean()
+
+                    if(testsFailed) {
+                        currentBuild.result = "FAILURE"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/_tests/e2e/docker-compose.yml
+++ b/_tests/e2e/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '2'
 services:
-  e2e_drupal:
+  drupal:
     build:
       context: .
       dockerfile: Dockerfile.mp
     command: 'npm run e2e:ci-drupal -- --base-url=$${RHD_BASE_URL}'
+    user: "${DUID}:0"
     environment:
       - RHD_BASE_URL
       - RHD_DRUPAL_ADMIN_USERNAME
@@ -14,16 +15,16 @@ services:
       - GRID_HOST=chrome
       - GRID_PORT=4444
     volumes:
-      - ./tmp_downloads:/home/e2e/tmp_downloads
       - ./report:/home/e2e/report
     depends_on:
       - chrome
 
-  e2e_desktop:
+  desktop:
     build:
       context: .
       dockerfile: Dockerfile.mp
     command: 'npm run e2e:ci-desktop -- --base-url=$${RHD_BASE_URL}'
+    user: "${DUID}:0"
     environment:
       - RHD_BASE_URL
       - RHD_DRUPAL_ADMIN_USERNAME
@@ -38,11 +39,12 @@ services:
     depends_on:
       - chrome
 
-  e2e_mobile:
+  mobile:
     build:
       context: .
       dockerfile: Dockerfile.mp
     command: 'npm run e2e:ci-mobile -- --base-url=$${RHD_BASE_URL}'
+    user: "${DUID}:0"
     environment:
       - RHD_BASE_URL
       - RHD_DRUPAL_ADMIN_USERNAME
@@ -58,7 +60,7 @@ services:
       - chrome
 
   chrome:
-    image: selenium/standalone-chrome:3.141.0-actinium
+    image: selenium/standalone-chrome:3.141.59-xenon
     volumes:
       - /dev/shm:/dev/shm
       - ./tmp_downloads:/home/e2e/tmp_downloads

--- a/_tests/e2e/tests/specs/support/utils/Utils.js
+++ b/_tests/e2e/tests/specs/support/utils/Utils.js
@@ -20,6 +20,8 @@ class Utils {
             logoutLink = `https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
         } else {
             logoutLink = `https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
+            let migratedLogoutLink = `https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
+            Driver.visit(migratedLogoutLink);
         }
 
         return Driver.visit(logoutLink);


### PR DESCRIPTION
By migrating to a Jenkins pipeline we can remove our dependency on Ruby in the d.r.c project which will help us further clean-up the repo. Additionally it helps us to make our Jenkins setup
much easier to recover and is captured as part of our migration to a PSI Jenkins instance

This PR merely installs the supporting infrastructure to make this change. It does not change the way in which the tests are currently executed and as such this build should go green with no further changes.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3564

### Verification Process

* The build should go green
