### PR TITLE
Assembly pagination is outside of content area #3374

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-base.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-base.scss
@@ -2,7 +2,8 @@
     .pf-l-grid,
     .pf-l-level,
     .pf-l-gallery,
-    .pf-l-flex {
+    .pf-l-flex,
+    .pager {
         max-width: map-get($rhd-breakpoints, xlarge);
         margin: 0 auto;
     }


### PR DESCRIPTION
### JIRA Issue Link
Fixes #3374 

### Verification Process
Go to /training/ the pagination should sit inline with the content at all screen sizes 
