### PR TITLE
add blured image for background on wordpress cards

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-tile.html.twig
@@ -2,8 +2,14 @@
 {% set tmpUrl = media.source_url %}
 {% if '.jpg' in tmpUrl or '.jpeg' in tmpUrl  or '.gif' in tmpUrl  or '.png' in tmpUrl %}
 {% set cacheImg = {'#theme':'imagecache_external', '#uri':tmpUrl, '#style_name':'static_item', '#alt':post.title.rendered|replace({'"':''}), } %}
+  <div class="rhd-c-card-blur-image">
+    {{ cacheImg }}
+  </div>
   {{ cacheImg }}
 {% else %}
+  <div class="rhd-c-card-blur-image">
+    <img src="{{ tmpUrl }}" alt="{{ post.title.rendered|replace({'"':''}) }}" />
+  </div>
   <img src="{{ tmpUrl }}" alt="{{ post.title.rendered|replace({'"':''}) }}" />
 {% endif %}
 {% endif %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_cards.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_cards.scss
@@ -81,6 +81,25 @@
     border-top: var(--rhd-theme--border-width-md) solid #ededed;
     margin: var(--pf-global--spacer--sm) 0; // 8px 0
   }
+  .rhd-c-card-blur-image {
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    right: 0;
+    img.image-style-static-item {
+      filter: blur(16px);
+      -webkit-filter: blur(16px);
+      max-height: 200px;
+      width: 100%;
+      object-fit: fill;
+    }
+  }
+  img.image-style-static-item {
+    position: relative;
+    max-height: 200px;
+    object-fit: contain;
+    width: 100%;
+  }
   .rhd-c-card__title + hr {
     margin-top: 0 !important; 
     margin-bottom: 0 !important; 


### PR DESCRIPTION
### JIRA Issue Link
Fixed #3282 

### Verification Process
on the homepage check on mobile and see that the images on the build here section ae centred with a blurred background image .

![Screenshot 2019-11-18 at 09 01 07](https://user-images.githubusercontent.com/900631/69038555-fae7ac80-09e1-11ea-831a-fe6157a36350.png)

