### PR TITLE
[DEVELOPER-3336] Purpose Attributes on Katacoda Individual Courses

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.katacoda_individual_lesson.default.yml
@@ -22,7 +22,6 @@ dependencies:
     - field.field.node.katacoda_individual_lesson.field_topics
     - node.type.katacoda_individual_lesson
   module:
-    - fences
     - field_layout
     - layout_discovery
     - user
@@ -36,7 +35,7 @@ bundle: katacoda_individual_lesson
 mode: default
 content:
   field_katacoda_embed_id:
-    weight: 1
+    weight: 0
     label: hidden
     settings:
       link_to_entity: false
@@ -50,196 +49,24 @@ content:
         fences_label_classes: ''
     type: string
     region: content
-  field_tags:
-    weight: 3
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_audience_segment:
-    weight: 4
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_business_unit:
-    weight: 5
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_campaign:
-    weight: 6
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_lifecycle:
-    weight: 7
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_product:
-    weight: 8
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_product_line:
-    weight: 9
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_project:
-    weight: 10
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_promotion:
-    weight: 11
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_region:
-    weight: 12
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_tax_stage:
-    weight: 13
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  field_topics:
-    weight: 2
-    label: above
-    settings:
-      link: true
-    third_party_settings:
-      fences:
-        fences_field_tag: none
-        fences_field_classes: ''
-        fences_field_item_tag: none
-        fences_field_item_classes: ''
-        fences_label_tag: none
-        fences_label_classes: ''
-    type: entity_reference_label
-    region: content
-  links:
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   body: true
   content_moderation_control: true
   field_katacoda_scenario_author: true
   field_katacoda_scenario_time: true
   field_katacoda_skill_level: true
+  field_tags: true
+  field_tax_audience_segment: true
+  field_tax_business_unit: true
+  field_tax_campaign: true
+  field_tax_lifecycle: true
+  field_tax_product: true
+  field_tax_product_line: true
+  field_tax_project: true
+  field_tax_promotion: true
+  field_tax_region: true
+  field_tax_stage: true
+  field_topics: true
   langcode: true
+  links: true
   published_at: true


### PR DESCRIPTION
This commit updates the Default view mode of the Katacoda Individual
Course node type so that Purpose Attributes are no longer displayed.

### Github Issue Link
#3336 

### Verification Process

Do this: Log in to your Drupal account
Go here: /courses/openshift/playground-openshift311/edit
Do this: Add Purpose Attributes under the Fields tab and publish a revision to the node.

You should see this:

![localhost_courses_openshift_playground-openshift311_](https://user-images.githubusercontent.com/7155034/69080285-86683a00-09f0-11ea-972d-9d4027868ac2.png)

You should **not** see Purpose Attributes listed across the bottom of the Katacoda Individual Lesson as links, as you would currently on Prod.