### PR TITLE
[DEVELOPER-3385] All Content Types use Moderation State Widget

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.books.default.yml
@@ -41,8 +41,10 @@ dependencies:
     - field.field.node.books.field_web_reader_url
     - image.style.thumbnail
     - node.type.books
+    - workflows.workflow.00c7e3ae
   module:
     - compose
+    - content_moderation
     - field_group
     - field_layout
     - image
@@ -327,11 +329,9 @@ content:
     third_party_settings: {  }
   moderation_state:
     weight: 23
-    settings:
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: string_textfield
+    type: moderation_state_default
     region: settings
   path:
     type: path

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.cheat_sheet.default.yml
@@ -30,8 +30,10 @@ dependencies:
     - field.field.node.cheat_sheet.field_tax_stage
     - field.field.node.cheat_sheet.field_topics
     - node.type.cheat_sheet
+    - workflows.workflow.00c7e3ae
   module:
     - compose
+    - content_moderation
     - entity_browser
     - field_group
     - field_layout
@@ -280,11 +282,9 @@ content:
     third_party_settings: {  }
   moderation_state:
     weight: 21
-    settings:
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: string_textfield
+    type: moderation_state_default
     region: settings
   path:
     type: path

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_course.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_course.default.yml
@@ -21,8 +21,10 @@ dependencies:
     - field.field.node.katacoda_course.field_tax_stage
     - field.field.node.katacoda_course.field_topics
     - node.type.katacoda_course
+    - workflows.workflow.00c7e3ae
   module:
     - compose
+    - content_moderation
     - field_group
     - field_layout
     - path
@@ -194,11 +196,9 @@ content:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
-    type: string_textfield
+    type: moderation_state_default
     weight: 23
-    settings:
-      size: 60
-      placeholder: ''
+    settings: {  }
     region: settings
     third_party_settings: {  }
   path:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_individual_lesson.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.katacoda_individual_lesson.default.yml
@@ -21,8 +21,10 @@ dependencies:
     - field.field.node.katacoda_individual_lesson.field_tax_stage
     - field.field.node.katacoda_individual_lesson.field_topics
     - node.type.katacoda_individual_lesson
+    - workflows.workflow.00c7e3ae
   module:
     - compose
+    - content_moderation
     - field_group
     - field_layout
     - path
@@ -189,11 +191,9 @@ content:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
-    type: string_textfield
+    type: moderation_state_default
     weight: 9
-    settings:
-      size: 60
-      placeholder: ''
+    settings: {  }
     region: settings
     third_party_settings: {  }
   path:


### PR DESCRIPTION
This changes the moderation state field widget to Moderation State for
the following 4 node types: Books, Cheat Sheets, Katacoda Course and
Katacoda Individual Lesson.

### Github Issue Link
#3385 

### Verification Process

#### Books

Go here: https://developer-preview-3384.ext.us-west.dc.preprod.paas.redhat.com/books/adventures-aboard-kluster-kruise-ship/old/edit

#### Cheat Sheet

Go here: https://developer-preview-3384.ext.us-west.dc.preprod.paas.redhat.com/cheat-sheets/advanced-linux-commands/old/edit

#### Katacoda Individual Lesson

Go here: https://developer-preview-3384.ext.us-west.dc.preprod.paas.redhat.com/courses/openshift/playground-openshift311/edit

#### Katacoda Course

Go here: https://developer-preview-3384.ext.us-west.dc.preprod.paas.redhat.com/courses/modern-app-dev/edit

#### In all 4 of those instances/node edit forms, you should see this

<img width="774" alt="Screen Shot 2019-11-18 at 11 00 28 AM" src="https://user-images.githubusercontent.com/7155034/69081398-be707c80-09f2-11ea-901c-75864ef823f1.png">
