### PR TITLE
[MWES-3382] Add Fusion Search API to Drupal Configuration

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -199,6 +199,9 @@ function rhdp_js_settings_alter(array &$settings, AttachedAssetsInterface $asset
   $rhd_settings['swel'] = [];
   $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
 
+  $rhd_settings['fusion'] = [];
+  $rhd_settings['fusion']['url'] = $env_settings->get('fusion')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp');
 
   $rhd_settings['templates'] = [];

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -659,6 +659,9 @@ function rhdp2_js_settings_alter(array &$settings, AttachedAssetsInterface $asse
   $rhd_settings['swel'] = [];
   $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
 
+  $rhd_settings['fusion'] = [];
+  $rhd_settings['fusion']['url'] = $env_settings->get('fusion')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp2');
 
   $rhd_settings['templates'] = [];

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -885,7 +885,7 @@ function rhdp2_library_info_alter(array &$libraries, $extension) {
     $keycloak_url = $rhd_config->get('keycloak')['scriptUrl'];
 
     // Keycloak_url is only set on the Stage environment.
-    if ($extension == 'rhdp' && $keycloak_url !== NULL) {
+    if ($extension == 'rhdp2' && $keycloak_url !== NULL) {
       // Remove the Prod Keycloak script URL from our library.
       unset($libraries['base-theme']['js']['https://developers.redhat.com/auth/js/keycloak.js']);
       // Add the Stage Keycloak script URL to our library.

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -21,6 +21,7 @@ $config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redh
 $config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
 $config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
 $config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
+$config['redhat_developers']['keycloak']['scriptUrl'] = 'https://sso.stage.redhat.com/auth/js/keycloak.js';
 $config['redhat_developers']['drupal']['host'] = 'https://developers.dev.redhat.com';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -34,7 +35,7 @@ $config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.re
     SSO Integration for Content Editor Authentication
 */
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://developers.dev.redhat.com/openid-connect/keycloak';
-$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
+$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = 'rhd-web-cms';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -21,6 +21,7 @@ $config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.qa.redhat.
 $config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.qa.redhat.com/auth/';
 $config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
 $config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
+$config['redhat_developers']['keycloak']['scriptUrl'] = 'https://sso.qa.redhat.com/auth/js/keycloak.js';
 $config['redhat_developers']['drupal']['host'] = 'https://localhost';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -34,7 +35,7 @@ $config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.re
     SSO Integration for Content Editor Authentication
 */
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://localhost/openid-connect/keycloak';
-$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
+$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = 'rhd-web-cms';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.qa.redhat.com/auth';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'database';
 $config['redhat_developers']['swel']['url'] = 'https://mwes-swel-service-qa.ext.us-west.dc.preprod.paas.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -18,10 +18,10 @@ $config['redhat_developers']['rhd_base_url'] = '{{ drupal_url }}';
 $config['redhat_developers']['rhd_final_base_url'] = '{{ drupal_url }}';
 $config['redhat_developers']['downloadManager']['baseUrl'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['downloadManager']['fileBaseUrl'] = '//developers.stage.redhat.com/download-manager/file/';
-$config['redhat_developers']['keycloak']['accountUrl'] = 'https://developers.stage.redhat.com/auth/realms/rhd/account/';
-$config['redhat_developers']['keycloak']['authUrl'] = 'https://developers.stage.redhat.com/auth/';
-$config['redhat_developers']['keycloak']['client_id'] = 'web';
-$config['redhat_developers']['keycloak']['realm'] = 'rhd';
+$config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/account/';
+$config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
+$config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
+$config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
 $config['redhat_developers']['drupal']['host'] = '{{ drupal_url }}';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -29,6 +29,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication
@@ -36,11 +37,11 @@ $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redh
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://{{ drupal_url }}/openid-connect/keycloak';
 $config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://developers.stage.redhat.com/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'rhd';
-$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/token';
-$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';
+$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/userinfo';
 
 
 /**

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -22,6 +22,7 @@ $config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redh
 $config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
 $config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
 $config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
+$config['redhat_developers']['keycloak']['scriptUrl'] = 'https://sso.stage.redhat.com/auth/js/keycloak.js';
 $config['redhat_developers']['drupal']['host'] = '{{ drupal_url }}';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -35,7 +36,7 @@ $config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.re
     SSO Integration for Content Editor Authentication
 */
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://{{ drupal_url }}/openid-connect/keycloak';
-$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
+$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = 'rhd-web-cms';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -30,6 +30,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = '//dcp2.jboss.org';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -22,6 +22,7 @@ $config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.stage.redh
 $config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.stage.redhat.com/auth/';
 $config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
 $config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
+$config['redhat_developers']['keycloak']['scriptUrl'] = 'https://sso.stage.redhat.com/auth/js/keycloak.js';
 $config['redhat_developers']['drupal']['host'] = 'https://developers.stage.redhat.com';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp.stage.jboss.org';
@@ -35,7 +36,7 @@ $config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.re
     SSO Integration for Content Editor Authentication
 */
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://developers.stage.redhat.com/openid-connect/keycloak';
-$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
+$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = 'rhd-web-cms';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.stage.redhat.com/auth';
 $config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -29,6 +29,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_tests/e2e/tests/specs/support/utils/Utils.js
+++ b/_tests/e2e/tests/specs/support/utils/Utils.js
@@ -19,9 +19,7 @@ class Utils {
         if(this.isProduction() === true) {
             logoutLink = `https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
         } else {
-            logoutLink = `https://developers.stage.redhat.com/auth/realms/rhd/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
-            let migratedLogoutLink = `https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
-            Driver.visit(migratedLogoutLink);
+            logoutLink = `https://sso.stage.redhat.com/auth/realms/redhat-external/protocol/openid-connect/logout?redirect_uri=${encodedURL}`;
         }
 
         return Driver.visit(logoutLink);


### PR DESCRIPTION
This commit makes two additions to the Drupal configuration:

It adds the Fusion Search API endpoint to all environments to support the new Fusion based search pages.

Secondly it updates the preview environments to use sso.stage.redhat.com after our discussions with IT around redirect handling in those environments

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3382

### Verification Process

* The build should go green
* Check that the following is set as a Javascript variable `drupalSettings.rhd.fusion` using developers tools console. It should have the value: `https://api.developers.stage.redhat.com/search`
* Please visit the site and ensure you can log in as a site visitor
* Please visit Drupal and ensure that you can log in as a content editor using the SSO login option.
