### PR TITLE
[MWES-3382] Add Fusion API endpoints to Drupal configuration

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -199,6 +199,9 @@ function rhdp_js_settings_alter(array &$settings, AttachedAssetsInterface $asset
   $rhd_settings['swel'] = [];
   $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
 
+  $rhd_settings['fusion'] = [];
+  $rhd_settings['fusion']['url'] = $env_settings->get('fusion')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp');
 
   $rhd_settings['templates'] = [];

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -659,6 +659,9 @@ function rhdp2_js_settings_alter(array &$settings, AttachedAssetsInterface $asse
   $rhd_settings['swel'] = [];
   $rhd_settings['swel']['url'] = $env_settings->get('swel')['url'];
 
+  $rhd_settings['fusion'] = [];
+  $rhd_settings['fusion']['url'] = $env_settings->get('fusion')['url'];
+
   $theme_path = drupal_get_path('theme', 'rhdp2');
 
   $rhd_settings['templates'] = [];
@@ -882,7 +885,7 @@ function rhdp2_library_info_alter(array &$libraries, $extension) {
     $keycloak_url = $rhd_config->get('keycloak')['scriptUrl'];
 
     // Keycloak_url is only set on the Stage environment.
-    if ($extension == 'rhdp' && $keycloak_url !== NULL) {
+    if ($extension == 'rhdp2' && $keycloak_url !== NULL) {
       // Remove the Prod Keycloak script URL from our library.
       unset($libraries['base-theme']['js']['https://developers.redhat.com/auth/js/keycloak.js']);
       // Add the Stage Keycloak script URL to our library.

--- a/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/dev/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/local/drupal/rhd.settings.php.j2
@@ -28,6 +28,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'database';
 $config['redhat_developers']['swel']['url'] = 'https://mwes-swel-service-qa.ext.us-west.dc.preprod.paas.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/preview/drupal/rhd.settings.php.j2
@@ -29,6 +29,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -30,6 +30,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = '//dcp2.jboss.org';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication

--- a/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/stage/drupal/rhd.settings.php.j2
@@ -29,6 +29,7 @@ $config['redhat_developers']['searchisko']['port'] = '443';
 $config['redhat_developers']['searchisko']['baseProtocolRelativeUrl'] = 'dcp.stage.jboss.org:443';
 $config['redhat_developers']['cache']['engine'] = 'memcached';
 $config['redhat_developers']['swel']['url'] = 'https://api.developers.stage.redhat.com/swel';
+$config['redhat_developers']['fusion']['url'] = 'https://api.developers.stage.redhat.com/search';
 
 /**
     SSO Integration for Content Editor Authentication


### PR DESCRIPTION
This commit adds the endpoint for the Fusion API for the new search to the Drupal configuration and then exposes them for the frontend integration on the
drupalSettings Javascript object.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3382

### Verification Process

* The build should go green
* Please visit the site and ensure the following variable is available on the Javascript console:
   * `drupalSettings.rhd.fusion.url` with the value `https://api.developers.stage.redhat.com/search`
