### PR TITLE
[DO NOT MERGE] [MWES-3661] Update prod to use new SSO servers

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.libraries.yml
@@ -20,7 +20,7 @@ base-theme:
     https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.3/angular.min.js: { type: external, minified: true }
     https://cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.3.3/angular-sanitize.min.js: { type: external, minified: true }
     https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.21.4/system-production.js: { type: external, minified: true }
-    https://developers.redhat.com/auth/js/keycloak.js: { type: external, minified: false  }
+    https://sso.redhat.com/auth/js/keycloak.js: { type: external, minified: false  }
     rhd-frontend/rhd.min.js: { minified: true }
     rhd-frontend/init.js: {}
   dependencies:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhdp.theme
@@ -1067,7 +1067,7 @@ function rhdp_library_info_alter(array &$libraries, $extension) {
     // Keycloak_url is only set on the Stage environment.
     if ($extension == 'rhdp' && $keycloak_url !== NULL) {
       // Remove the Prod Keycloak script URL from our library.
-      unset($libraries['base-theme']['js']['https://developers.redhat.com/auth/js/keycloak.js']);
+      unset($libraries['base-theme']['js']['https://sso.redhat.com/auth/js/keycloak.js']);
       // Add the Stage Keycloak script URL to our library.
       $libraries['base-theme']['js'][$keycloak_url] = [
         'type' => 'external',

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -37,7 +37,7 @@ base-theme:
     https://cdnjs.cloudflare.com/ajax/libs/angular-sanitize/1.3.3/angular-sanitize.min.js: { type: external, minified: true }
     # NOTE: SystemJS is a dynamic ES module loader.
     # https://cdnjs.cloudflare.com/ajax/libs/systemjs/0.21.4/system-production.js: { type: external, minified: true }
-    https://developers.redhat.com/auth/js/keycloak.js: { type: external, minified: false  }
+    https://sso.redhat.com/auth/js/keycloak.js: { type: external, minified: false  }
     js/rhd.old.min.js: { minified: true }
     js/rhd.min.js: { minified: true }
   dependencies:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -887,7 +887,7 @@ function rhdp2_library_info_alter(array &$libraries, $extension) {
     // Keycloak_url is only set on the Stage environment.
     if ($extension == 'rhdp2' && $keycloak_url !== NULL) {
       // Remove the Prod Keycloak script URL from our library.
-      unset($libraries['base-theme']['js']['https://developers.redhat.com/auth/js/keycloak.js']);
+      unset($libraries['base-theme']['js']['https://sso.redhat.com/auth/js/keycloak.js']);
       // Add the Stage Keycloak script URL to our library.
       $libraries['base-theme']['js'][$keycloak_url] = [
         'type' => 'external',

--- a/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/prod/drupal/rhd.settings.php.j2
@@ -19,10 +19,10 @@ $config['redhat_developers']['rhd_base_url'] = 'developers.redhat.com';
 $config['redhat_developers']['rhd_final_base_url'] = 'developers.redhat.com';
 $config['redhat_developers']['downloadManager']['baseUrl'] = 'https://developers.redhat.com';
 $config['redhat_developers']['downloadManager']['fileBaseUrl'] = '/developers.redhat.com/download-manager/file/';
-$config['redhat_developers']['keycloak']['accountUrl'] = 'https://developers.redhat.com/auth/realms/rhd/account/';
-$config['redhat_developers']['keycloak']['authUrl'] = 'https://developers.redhat.com/auth/';
-$config['redhat_developers']['keycloak']['client_id'] = 'web';
-$config['redhat_developers']['keycloak']['realm'] = 'rhd';
+$config['redhat_developers']['keycloak']['accountUrl'] = 'https://sso.redhat.com/auth/realms/redhat-external/account/';
+$config['redhat_developers']['keycloak']['authUrl'] = 'https://sso.redhat.com/auth/';
+$config['redhat_developers']['keycloak']['client_id'] = 'rhd-web';
+$config['redhat_developers']['keycloak']['realm'] = 'redhat-external';
 $config['redhat_developers']['drupal']['host'] = 'https://developers.redhat.com';
 $config['redhat_developers']['searchisko']['protocol'] = 'https';
 $config['redhat_developers']['searchisko']['host'] = 'dcp2.jboss.org';
@@ -36,13 +36,13 @@ $config['redhat_developers']['fusion']['url'] = 'https://api.developers.redhat.c
     SSO Integration for Content Editor Authentication
 */
 $config["openid_connect.settings.keycloak"]["settings"]["redirect_url"] = 'https://developers.redhat.com/openid-connect/keycloak';
-$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = '{{ drupal_content_editor_sso_client_id }}';
+$config["openid_connect.settings.keycloak"]["settings"]["client_id"] = 'rhd-web-cms';
 $config["openid_connect.settings.keycloak"]["settings"]["client_secret"] = '{{ drupal_content_editor_sso_client_secret }}';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://developers.redhat.com/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'rhd';
-$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/auth';
-$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/token';
-$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/userinfo';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_base"] = 'https://sso.redhat.com/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["keycloak_realm"] = 'redhat-external';
+$config["openid_connect.settings.keycloak"]["settings"]["authorization_endpoint_kc"] = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/auth';
+$config["openid_connect.settings.keycloak"]["settings"]["token_endpoint_kc"] = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token';
+$config["openid_connect.settings.keycloak"]["settings"]["userinfo_endpoint_kc"] = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/userinfo';
 
 
 /**


### PR DESCRIPTION
Migrates developers.redhat.com to use the new SSO servers.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-3661

### Verification Process

* The build should go green
* Please view the  site source and ensure `keycloak.js` is loaded from `sso.redhat.com`.
* Please visit the site and ensure you can login as a site visitor
* Please visit the site and ensure you can login as Drupal admin using the SSO login.