### PR TITLE
Add new generation for rhd_registered cookie

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
@@ -61,7 +61,7 @@ app.sso = function () {
                         if (resp && resp.registrationTimestamp) {
                             var dt = new Date();
                             var ck = getCookie('rhd_logged');
-                            if (dt-resp.registrationTimestamp < 86400000 && ck.length === 0) {
+                            if (dt-(new Date(resp.registrationTimestamp)) < 86400000 && ck.length === 0) {
                                 document.cookie = "rhd_logged=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
                                 document.cookie = "rhd_registered=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
                             }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
@@ -56,8 +56,8 @@ app.sso = function () {
                         headers: swelHeaders,
                         mode:'cors'
                     })
-                    .then(req => req.json())
-                    .then(resp => {
+                    .then(function(req) { return req.json(); })
+                    .then(function(resp) {
                         if (resp && resp.registrationTimestamp) {
                             var dt = new Date();
                             var ck = getCookie('rhd_logged');

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/5-sso.js
@@ -48,6 +48,26 @@ app.sso = function () {
                         usr.socialAccountsLinked.push(social);
                     }
                 }
+                if (Headers && app.keycloak.token && drupalSettings.rhd.swel) {
+                    var swelHeaders = new Headers();
+                    swelHeaders.append('Authorization', 'Bearer '+app.keycloak.token);
+                    fetch(drupalSettings.rhd.swel.url+'/api/analytics/usr/v1/websiteregstatus/rhd',{
+                        method:'GET',
+                        headers: swelHeaders,
+                        mode:'cors'
+                    })
+                    .then(req => req.json())
+                    .then(resp => {
+                        if (resp && resp.registrationTimestamp) {
+                            var dt = new Date();
+                            var ck = getCookie('rhd_logged');
+                            if (dt-resp.registrationTimestamp < 86400000 && ck.length === 0) {
+                                document.cookie = "rhd_logged=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+                                document.cookie = "rhd_registered=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+                            }
+                        }
+                    });
+                }
 
             }).error(clearTokens);
         } else {
@@ -202,6 +222,11 @@ function storageAvailable(type) {
     catch (e) {
         return false;
     }
+}
+
+function getCookie( name ) {
+    var re = new RegExp('(?:(?:^|.*;\\s*)'+name+'\\s*\\=\\s*([^;]*).*$)|^.*$');
+    return document.cookie.replace(re, "$1");
 }
 
 


### PR DESCRIPTION
Adds a replacement for the current registration cookie `rhd_registered` to work with the new SSO
* Upon successful login the SWEL service is called to check registration date
* IF registration was within 24 hours
* AND the `rhd_logged` cookie is not set
* Set the `rhd_registration` cookie