### PR TITLE
[RHDX-54] Undefined index: field_description in rhdp2_preprocess_node

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -326,7 +326,7 @@ function rhdp2_preprocess_node(&$variables) {
   // Events content type.
   if ($node->getType() == 'events') {
     $variables['event_title'] = $node->getTitle();
-    $variables['event_description'] = $variables['content']['field_description'][0]['#text'];
+    $variables['event_description'] = $variables['content']['field_description'][0]['#text'] ?? '';
     $variables['event_url'] = $node->hasField('field_more_details') ? $node->get('field_more_details')->getValue()[0]['uri'] : '';
 
     // TODO: Fix Duplicate Logic: This will need to be refactored (see preprocess_assembly)


### PR DESCRIPTION
### JIRA Issue Link
[RHDX-54](https://projects.engineering.redhat.com/browse/RHDX-54)

### Verification Process
Viewing a node with an Assembly of type Event Hero causes a PHP warning to be written to the logs. 
The current only content that this affects is node 23605, or https://localhost/testingandtsting/.

1. View the content /testingandtsting/ OR /node/23605 OR create and view content with an Event Hero assembly type.
2. Check the logs for the warning (Reports -> Recent Log Messages)
3. There should be no logs related to Undefined index: field_description.