### PR TITLE
[NO ISSUE] Grant content creators access to create Media

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/user.role.content_creator.yml
@@ -32,6 +32,7 @@ permissions:
   - 'create katacoda_individual_lesson content'
   - 'create landing_page content'
   - 'create learning_path content'
+  - 'create media'
   - 'create page content'
   - 'create product content'
   - 'create promotion_card content'


### PR DESCRIPTION
This grants the content creator role access to create Media entities.
This bug was reported by Marco Rizzi while working on the RHAMT product
page.

### JIRA Issue Link
n/a

### Verification Process

Go here: /user/login

Do this:

* Log in to a Drupal user account with only the content creator role

Go to the RHAMT node edit form: /node/37375/edit

Do this:

* Click on the Fields tab and scroll down to the Individual Sub Pages field and open the panel if it is closed
* Click on the Edit button for the Overview paragraph
* Scroll down to the PRODUCT FEATURE IMAGE AND TEXT section and then the Media Reference section within that section and click on the green Add Media button
* Click on the Upload tab and then click on the Choose File button to pick a file to upload from your computer
* Fill out a file/media name and any other required fields on the Media/Image entity
* Click the blue Place button

You should see this:

* You should see the image you uploaded (or a thumbnail at least) displayed in a Current Selection section within that Media Reference section
* You should be able to persist the Node edit form successfully