### PR TITLE
[RHDX-67] Add Drupal caching to Product downloads

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.services.yml
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/rhd_assemblies.services.yml
@@ -2,9 +2,15 @@ services:
   rhd_assemblies.wordpress_api:
     class: Drupal\rhd_assemblies\Service\WordpressApi
     arguments: ['@http_client']
+  cache.download_manager:
+   class: Drupal\Core\Cache\CacheBackendInterface
+   tags:
+     - { name: cache.bin }
+   factory: cache_factory:get
+   arguments: ['download_manager']
   rhd_assemblies.download_manager_api:
     class: Drupal\rhd_assemblies\Service\DownloadManagerApi
-    arguments: ['@http_client', '@entity_type.manager']
+    arguments: ['@http_client', '@entity_type.manager', '@cache.download_manager', '@logger.factory', '@config.factory']
   rhd_assemblies.assembly_build_connectors_build:
     class: Drupal\rhd_assemblies\Plugin\AssemblyBuild\ConnectorsBuild
     arguments: ['@entity_type.manager']

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/ProductDownloadHeroBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/ProductDownloadHeroBuild.php
@@ -30,7 +30,7 @@ class ProductDownloadHeroBuild extends AssemblyBuildBase implements AssemblyBuil
         $parent_entity->get('field_product_machine_name')->value
       );
 
-      if (isset($product_downloads)) {
+      if (!empty($product_downloads)) {
         $featured = $product_downloads[0]->featuredArtifact;
         $featured->fileSize = format_size($featured->fileSize);
         $build['featured'] = [];

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/ProductDownloadListBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/ProductDownloadListBuild.php
@@ -30,12 +30,12 @@ class ProductDownloadListBuild extends AssemblyBuildBase implements AssemblyBuil
         $parent_entity->get('field_product_machine_name')->value
       );
 
-      if (isset($product_downloads)) {
+      if (!empty($product_downloads)) {
         foreach ($product_downloads[0]->productVersions as $key => $version) {
           $versions[$key] = $version;
 
           foreach ($version->files as $file_key => $file) {
-            $versions[$key]->files[$file_key]->fileSize = format_size($file->fileSize);
+            $versions[$key]->files[$file_key]->fileSize = (!empty($file->fileSize)) ? format_size($file->fileSize) : NULL;
           }
         }
 

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
@@ -64,11 +64,11 @@ class DownloadManagerApi {
    *   The Guzzle client.
    * @param Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   entity type manager.
-   * @var \Drupal\Core\Cache\CacheBackendInterface $cache_bin
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_bin
    *   Download Manager cache bin service.
-   * @var \Drupal\Core\Logger\LoggerChannelFactory $logger_factory
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $logger_factory
    *   Logger factory service.
-   * @var \Drupal\Core\Config\ConfigFactory $config_factory
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
    *   Config factory service.
    */
   public function __construct(ClientInterface $client, EntityTypeManager $entity_type_manager, CacheBackendInterface $cache_bin, LoggerChannelFactory $logger_factory, ConfigFactory $config_factory) {
@@ -114,7 +114,7 @@ class DownloadManagerApi {
           $request = $this->client->request('GET', $feed_url);
           $response = $request->getBody()->getContents();
           $data = json_decode($response);
-          // Persist this data to the download_manager_api cache bin for an hour.
+          // Persist this data to a download_manager_api cache bin for an hour.
           $this->cacheBin->set($cid, $data, time() + 3600);
         }
         catch (\Exception $e) {

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
@@ -2,7 +2,10 @@
 
 namespace Drupal\rhd_assemblies\Service;
 
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelFactory;
 use GuzzleHttp\ClientInterface;
 
 /**
@@ -34,17 +37,54 @@ class DownloadManagerApi {
   protected $entityTypeManager;
 
   /**
+   * Download Manager cache bin.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBin;
+
+  /**
+   * Logger factory service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
+
+  /**
+   * Config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
    * Constructor.
    *
    * @param GuzzleHttp\ClientInterface $client
    *   The Guzzle client.
    * @param Drupal\Core\Entity\EntityTypeManager $entity_type_manager
-   *   Drupal's entity type manager.
+   *   entity type manager.
+   * @var \Drupal\Core\Cache\CacheBackendInterface $cache_bin
+   *   Download Manager cache bin service.
+   * @var \Drupal\Core\Logger\LoggerChannelFactory $logger_factory
+   *   Logger factory service.
+   * @var \Drupal\Core\Config\ConfigFactory $config_factory
+   *   Config factory service.
    */
-  public function __construct(ClientInterface $client, EntityTypeManager $entity_type_manager) {
-    $this->apiUrl = 'https://developers.redhat.com/download-manager/rest/available/';
+  public function __construct(ClientInterface $client, EntityTypeManager $entity_type_manager, CacheBackendInterface $cache_bin, LoggerChannelFactory $logger_factory, ConfigFactory $config_factory) {
+    $this->configFactory = $config_factory;
+    // If there is a Download Manager baseUrl config object, use that to set
+    // the apiUrl. Else, point the apiUrl to Download Manager Prod.
+    if (!empty($this->configFactory->get('redhat_developers')->get('downloadManager.baseUrl'))) {
+      $this->apiUrl = $this->configFactory->get('redhat_developers')->get('downloadManager.baseUrl') . '/download-manager/rest/available/';
+    }
+    else {
+      $this->apiUrl = 'https://developers.redhat.com/download-manager/rest/available/';
+    }
     $this->client = $client;
     $this->entityTypeManager = $entity_type_manager;
+    $this->cacheBin = $cache_bin;
+    $this->loggerFactory = $logger_factory;
   }
 
   /**
@@ -58,22 +98,37 @@ class DownloadManagerApi {
    *   sucessful. Otherwise, returns FALSE.
    */
   public function getContentById($id) {
-    try {
-      $feed_url = $this->apiUrl . $id;
-      $request = $this->client->request('GET', $feed_url);
-      $response = $request->getBody()->getContents();
+    $data = &drupal_static(__FUNCTION__);
 
-      return json_decode($response);
+    // If there is nothing in this static variable, fetch the data.
+    if (!isset($data)) {
+      $cid = 'download_manager_api:product:' . $id;
+      // Serve the cached Download Manager data if available.
+      if ($cache = $this->cacheBin->get($cid)) {
+        $data = $cache->data;
+      }
+      // If this is uncached or the cache is invalid, fetch fresh data.
+      else {
+        try {
+          $feed_url = $this->apiUrl . $id;
+          $request = $this->client->request('GET', $feed_url);
+          $response = $request->getBody()->getContents();
+          $data = json_decode($response);
+          // Persist this data to the download_manager_api cache bin for an hour.
+          $this->cacheBin->set($cid, $data, time() + 3600);
+        }
+        catch (\Exception $e) {
+          $this->loggerFactory->get('rhd_assemblies')->error(
+            "Exception while calling Download Manager API: @message", [
+              '@message' => $e->getMessage(),
+            ]
+          );
+          return FALSE;
+        }
+      }
     }
-    catch (\Exception $e) {
-      \Drupal::logger('rhd_assemblies')->error(
-        "Exception while calling Download Manager API: @message", [
-          '@message' => $e->getMessage(),
-        ]
-      );
 
-      return FALSE;
-    }
+    return $data;
   }
 
   /**

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--product-download-list.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--product-download-list.html.twig
@@ -28,7 +28,11 @@
           <i class="fa fa-calendar-alt"></i> Release date <br/><span class="product-version__release-date">{{ versionReleaseDate|date("F d, Y") }}</span>
         </div>
         <div class="pf-l-grid__item product-version__cta">
-          <a class="pf-c-button pf-m-secondary" href="{{ file.url }}">Download ({{ file.fileSize }})</a>
+          {% if file.fileSize is defined and file.fileSize is not null %}
+            <a class="pf-c-button pf-m-secondary" href="{{ file.url }}">Download ({{ file.fileSize }})</a>
+          {% else %}
+            <a class="pf-c-button pf-m-secondary" href="{{ file.url }}">Download</a>
+          {% endif %}
         </div>
       </div><!-- End of version row item -->
 


### PR DESCRIPTION
This adds a Drupal cache bin and drupal_static() caching to our Download
Manager interactions. This should significantly improve the performance
of, most notably, the product download pages, but more generally pages
that reference Product Download Hero assembl(ies) and/or Product
Download List assembl(ies).

### JIRA Issue Link
* Related to: https://projects.engineering.redhat.com/browse/RHDX-67

### Verification Process

#### 'download_manager_api:product:' . $id cache bin

* This implements a cache bin for Download Manager responses by Product ID.

TODO: We will need to implement a configurable TTL in the future. It is currently set, in code, to an hour

#### drupal_static() caching

* This will provide static caching of the Download Manager response, getProductById() method. This should considerably improve the performance of Product download pages, almost all of which make multiple getProductById() calls i.e. Product Download Hero + Product Download List

##### See

https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/drupal_static/8.2.x
https://www.oreilly.com/library/view/high-performance-drupal/9781449358013/ch04.html (static caching section)

#### Product fileSize validation

* The Product Download List twig file should now validate that the fileSize exists before trying to render the value. If not value exists, it will just render 'Download'