### PR TITLE
[RHDX-153] add dark theme to hero download

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_product-download-hero.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_product-download-hero.scss
@@ -105,14 +105,14 @@
   
 
   // OTHER VISUAL STYLES
-    &.light.component {
+    &.light {
       background-image: var(--rhd-theme--ui-background-image__product-hero-light);
     }
 
-    &.dark.component {
+    &.dark {
       background-image: var(--rhd-theme--ui-background-image__product-hero-dark);
 
-      &>*,
+      p,
       .pf-c-title,
       .pf-c-content,
       .pf-m-link,
@@ -136,4 +136,5 @@
       @extend .pf-u-pt-0;
       @extend .pf-u-pb-0;
     }
+
   }


### PR DESCRIPTION
### JIRA Issue Link
https://projects.engineering.redhat.com/browse/RHDX-153

### Verification Process
Go to https://developer-preview-3464.ext.us-west.dc.preprod.paas.redhat.com/products/fuse/overview and check the 'download tooling' link and the paragraph text 'Distributed, cloud-native integration platform' in the hero is white.
