### PR TITLE
[No Issue] Further tighten access to key Drupal resources

### DIFF
--- a/_docker/drupal/managed-platform/ansible/templates/common/apache/drupal.conf.j2
+++ b/_docker/drupal/managed-platform/ansible/templates/common/apache/drupal.conf.j2
@@ -147,3 +147,17 @@
   GracefulShutdownTimeout 15
 </IfModule>
 
+#Security blocks
+<FilesMatch "(authorize|cron|install|upgrade|xmlrpc).php">
+   Order deny,allow
+   Allow from 10.0.0.0/8
+   deny from all
+</FilesMatch>
+<FilesMatch "(CHANGELOG|changelog).txt">
+   Order deny,allow
+   deny from all
+</FilesMatch>
+<FilesMatch "(CHANGELOG|changelog).md">
+   Order deny,allow
+   deny from all
+</FilesMatch>


### PR DESCRIPTION
This small change to the Drupal Apache configuration further tightens access to key Drupal pages. 

### JIRA Issue Link
* N/A

### Verification Process

* The build should go green
* Verify that you can log in as expected using the SSO login
* Log in to the Drupal container and ensure `drush cron` works as expected
* Ensure that the following pages result in a 403 Forbidden response:
  * install.php
  * cron.php
  * authorize.php
  * upgrade.php
  * xmlrpc.php