### PR TITLE
[No Issue] Begin removal of Jenkinsfile duplication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,56 +1,50 @@
 /*
-    This pipeline is used to send a webhook from the legacy RHD Jenkins instance to the "new" Jenkins instance running on Managed Platform.
+    This pipeline is used to send a webhook from the Developer Jenkins master to the Managed Platform Jenkins master to trigger
+    the CI pipeline for this project.
 
-    This pipeline is not intended to be run directly, but instead called by our existing Jenkins Job and passed parameters from the GitHub Pull Request Builder
-    plugin, namely the ID of the pull request that is being built and the SHA of the tip of that branch.
+    This pipeline expects to be executed via the GitHub Pull Request Builder Trigger and will explicitly fail if the required
+    parameters are not set.
  */
 @Library('RedHatDevelopersPipelineUtils')
 import com.redhat.developer.pr.*
 import com.redhat.developer.mp.*
 
-properties([
-        [$class: 'ParametersDefinitionProperty', parameterDefinitions:
-                [
-                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The id of the Pull Request that should be built.', name: 'PULL_REQUEST_ID'],
-                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: '', description: 'The current ref that is being built.', name: 'PULL_REQUEST_REF'],
-                        [$class: 'hudson.model.StringParameterDefinition', defaultValue: 'rebuild this please', description: 'A context to be sent to the CI pipeline.', name: 'PULL_REQUEST_CONTEXT']
-                ]
-        ]
-])
-
-
-node('cic-rhd-01') {
+node {
 
     timeout(60) {
 
         stage("Sanity Check") {
 
-            if(!params.PULL_REQUEST_ID) {
-                error "Please provide a pull request id."
+            if(!env.ghprbPullId) {
+                error "Cannot locate expected environment variable 'ghprbPullId'. Has this been triggered by the Git Hub Pull Request Builder?"
             }
 
-            if(!params.PULL_REQUEST_REF) {
-                error "Please provide the ref of the pull request being built."
+            if(!env.ghprbActualCommit) {
+                error "Cannot locate expected environment variable 'ghprbActualCommit'. Has this been triggered by the Git Hub Pull Request Builder?"
             }
         }
 
-        def cause = "${params.PULL_REQUEST_REF}-${env.BUILD_NUMBER}"
+        def cause = "${env.ghprbActualCommit}-${env.BUILD_NUMBER}"
+        def context = env.ghprbCommentBody ? env.ghprbCommentBody.toString().trim() : ""
+        def credentials = [
+                usernamePassword(credentialsId: 'developers-redhat-com-automated-api-token', passwordVariable: 'JENKINS_USER_PASSWORD', usernameVariable: 'JENKINS_USER'),
+                usernamePassword(credentialsId: 'redhat-developer-ci-github-api-token', passwordVariable: 'GITHUB_USER_PASSWORD', usernameVariable: 'GITHUB_USER')
+        ]
 
-        /*
-            Firstly trigger the job on jenkins.paas.redhat.com by sending a web-hook with the ID of the pull request that we're building and the cause
-            defined as the current HEAD reference of the PR branch and then the current build number
-         */
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'redhat-developer-automated', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
+        withCredentials(credentials) {
+
+            /*
+                Firstly trigger the job on jenkins.paas.redhat.com by sending a web-hook with the ID of the pull request that we're building and the cause
+                defined as the current HEAD reference of the PR branch and then the current build number
+             */
             def jenkinsJob = "https://jenkins.paas.redhat.com/generic-webhook-trigger/invoke?token=rhdp-pr-build"
-            scheduleMpBuild(pullRequestId: "${params.PULL_REQUEST_ID}", cause: cause, jenkinsJob: jenkinsJob, jenkinsUser: env.USERNAME, jenkinsPassword: env.PASSWORD, context: "${params.PULL_REQUEST_CONTEXT}")
-        }
+            scheduleMpBuild(pullRequestId: "${env.ghprbPullId}", cause: cause, jenkinsJob: jenkinsJob, jenkinsUser: env.JENKINS_USER, jenkinsPassword: env.JENKINS_USER_PASSWORD, context: context)
 
-        /*
-            And then we wait for that build to appear to be running on jenkins.paas.redhat.com. In particular we're waiting to see the above cause appear on the list
-            of statuses for our pull request.
-         */
-        withCredentials([string(credentialsId: 'e4d8cc35-9cfd-4df5-a842-eed5f4b6faf0', variable: 'TOKEN')]) {
-            waitForMpBuildToStart(gitRepository: 'redhat-developer/developers.redhat.com', pullRequestRef: "${params.PULL_REQUEST_REF}", cause: cause, gitApiCredentials: TOKEN)
+            /*
+                And then we wait for that build to appear to be running on jenkins.paas.redhat.com. In particular we're waiting to see the above cause appear on the list
+                of statuses for our pull request.
+             */
+            waitForMpBuildToStart(gitRepository: 'redhat-developer/developers.redhat.com', pullRequestRef: "${env.ghprbActualCommit}", cause: cause, gitApiCredentials: env.GITHUB_USER_PASSWORD)
         }
     }
 }


### PR DESCRIPTION
We have two Jenkinsfiles in the root of the repo. `Jenkinsfile` was for the legacy PR pipeline before we migrated to the PSI upshift infrastructure. `Jenkinsfile.psi` supported the migration to PSI.

We can now start to remove this duplication. First step here is to simply replace the contents of `Jenkinsfile` with that of `Jenkinsfile.psi`. Once this is done and merged, the pipelines can be updated to use `Jenkinsfile` and the `Jenkinsfile.psi` can be deleted.

### JIRA Issue Link
* N/A

### Verification Process

* The build should go green.