### PR TITLE
[RHDX-233] Disable disqus calls on cards and lists

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-compact-dynamic-article-list-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/templates/wordpress-post-compact-dynamic-article-list-item.html.twig
@@ -7,6 +7,15 @@
   <div class="rhd-c-card-content">
     <h3 class="rhd-c-card__title">
       <a href="{{ post.link }}" class="rhd-m-link">{{ post.title.rendered|raw }}</a>
+      {#
+       # @todo see RHDX-233, RHDX-234 and RHDX-124
+       #
+       # This section of HTML is currently commented out of this template
+       # because the comment count was not being displayed in the component
+       # anyway, and we should at least avoid these extra network calls and
+       # the possibility of hitting the Disqus API quota until we can properly
+       # implement the comment count in RHDX-234 and RHDX-124.
+       #
       {% if rhd_domain and post.link and "developers.redhat.com" in post.link %}
       <div class="rhd-m-list__comment tile-comment-count hidden" data-disqus-thread-link="{{ post.link }}" data-disqus-comment-count>
         <a href="{{ post.link }}#comments">
@@ -15,6 +24,7 @@
         </a>
       </div>
       {% endif %}
+      #}
     </h3>
   </div>
 </div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/components/card.twig
@@ -91,6 +91,15 @@
             {{ authors }}
           </div>
         {% endif %}
+        {#
+         # @todo see RHDX-233, RHDX-234 and RHDX-124
+         #
+         # This section of HTML is currently commented out of this template
+         # because the comment count was not being displayed in the component
+         # anyway, and we should at least avoid these extra network calls and
+         # the possibility of hitting the Disqus API quota until we can properly
+         # implement the comment count in RHDX-234 and RHDX-124.
+         #
         {% if absolute_url and rhd_domain and "developers.redhat.com" in absolute_url %}
           <div class="tile-comment-count hidden" data-disqus-thread-link="{{ absolute_url }}" data-disqus-comment-count>
             <a href="{{ absolute_url }}#disqus_thread">
@@ -100,6 +109,7 @@
             </a>
           </div>
         {% endif %}
+        #}
       </div>
     {% endif %}
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--article--compact-dynamic-article-list-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--article--compact-dynamic-article-list-item.html.twig
@@ -7,6 +7,15 @@
   <div class="rhd-c-card-content">
     <h3 class="rhd-c-card__title">
       <a href="{{ url }}" class="rhd-m-link">{{ label }}</a>
+			{#
+			 # @todo see RHDX-233, RHDX-234 and RHDX-124
+			 #
+			 # This section of HTML is currently commented out of this template
+			 # because the comment count was not being displayed in the component
+			 # anyway, and we should at least avoid these extra network calls and
+			 # the possibility of hitting the Disqus API quota until we can properly
+			 # implement the comment count in RHDX-234 and RHDX-124.
+			 #
       {% if rhd_domain and absolute_url and "developers.redhat.com" in absolute_url %}
       <div class="rhd-m-list__comment tile-comment-count hidden" data-disqus-thread-link="{{ absolute_url }}" data-disqus-comment-count>
         <a href="{{ absolute_url }}#comments">
@@ -15,6 +24,7 @@
         </a>
       </div>
       {% endif %}
+			#}
     </h3>
   </div>
 </div>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--compact-dynamic-article-list-item.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--compact-dynamic-article-list-item.html.twig
@@ -7,6 +7,15 @@
   <div class="rhd-c-card-content">
     <h3 class="rhd-c-card__title">
       <a href="{{ url }}" class="rhd-m-link">{{ label }}</a>
+      {#
+       # @todo see RHDX-233, RHDX-234 and RHDX-124
+       #
+       # This section of HTML is currently commented out of this template
+       # because the comment count was not being displayed in the component
+       # anyway, and we should at least avoid these extra network calls and
+       # the possibility of hitting the Disqus API quota until we can properly
+       # implement the comment count in RHDX-234 and RHDX-124.
+       #
       {% if rhd_domain and absolute_url and "developers.redhat.com" in absolute_url %}
       <div class="rhd-m-list__comment tile-comment-count hidden" data-disqus-thread-link="{{ absolute_url }}" data-disqus-comment-count>
         <a href="{{ absolute_url }}#comments">
@@ -15,6 +24,7 @@
         </a>
       </div>
       {% endif %}
+      #}
     </h3>
   </div>
 </div>


### PR DESCRIPTION
This comments out the Disqus HTML markup on 3 Twig templates: the card
component-level template and 2 node type implementations of the Compact
Dynamic Article List. This should prevent any Disqus API calls from
being made. This is a temporary measure until we can actually implement
the comment count feature on these cards and compact dynamic article
lists. Since this functionality is not present currently, there is no
reason to make these API  calls, and we actually benefit from preventing
the calls from taking place (currently) to cut back on network calls and
reduce the probability of hitting our Disqus API quota.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-233

### Verification Process

* No Disqus calls are made  to fetch  comments for any Card-like components or Compact Dynamic Article List component(s)

There are many obvious Card-based components on the homepage. There is also a  Compact Dynamic Article List component at the very top of the homepage.

One way of checking this could be to open up the Chrome debugger > network tab, refresh to make a request  to the homepage, filter by XHR requests and/or the 'disqus'  string. Currently on Prod, I see this:

<img width="1624" alt="Screen Shot 2020-01-29 at 1 27 18 PM" src="https://user-images.githubusercontent.com/7155034/73398945-37197200-429b-11ea-9a3c-d75954b4cccf.png">

(they are 400  - Bad Requests because we are at our Disqus quota)

The goal of this PR is for none of these requests to be made
