### PR TITLE
[RHDX-248] Update Layout: 2 Column assembly type display

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.layout_two_col_left_sidebar.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.layout_two_col_left_sidebar.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: layout_two_col_left_sidebar
-label: 'Layout: Two Column with Left Sidebar'
-description: ''
-visual_styles: ''
+label: 'Layout: Two Column'
+description: 'This is a layout assembly type that will "wrap" other assemblies to provide various, 2 column layout options.'
+visual_styles: "left-sidebar|Left sidebar|Displays column 1 content in a left sidebar and column 2 spans the remaining space.\r\nright-sidebar|Right sidebar|Displays column 2 content in a right sidebar and column 1 spans the remaining space."
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.layout_two_col_left_sidebar.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.layout_two_col_left_sidebar.default.yml
@@ -66,12 +66,17 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 1
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  visual_styles:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   langcode: true
   user_id: true
-  visual_styles: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.layout_two_col_left_sidebar.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.layout_two_col_left_sidebar.default.yml
@@ -28,7 +28,7 @@ content:
     third_party_settings:
       fences:
         fences_field_tag: div
-        fences_field_classes: 'pf-l-grid__item pf-m-12-col pf-m-4-col-on-lg pf-m-3-col-on-xl'
+        fences_field_classes: pf-l-grid__item
         fences_field_item_tag: none
         fences_field_item_classes: ''
         fences_label_tag: none
@@ -44,7 +44,7 @@ content:
     third_party_settings:
       fences:
         fences_field_tag: div
-        fences_field_classes: 'pf-l-grid__item pf-m-12-col pf-m-8-col-on-lg pf-m-9-col-on-xl'
+        fences_field_classes: pf-l-grid__item
         fences_field_item_tag: none
         fences_field_item_classes: ''
         fences_label_tag: none

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.layout_two_col_left_sidebar.field_column_1.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.layout_two_col_left_sidebar.field_column_1.yml
@@ -4,8 +4,17 @@ status: true
 dependencies:
   config:
     - assembly.assembly_type.compact_dynamic_article_list
+    - assembly.assembly_type.content_with_image
+    - assembly.assembly_type.dynamic_content_feed
+    - assembly.assembly_type.events_hero
+    - assembly.assembly_type.hero
     - assembly.assembly_type.layout_two_col_left_sidebar
+    - assembly.assembly_type.product_download_hero
+    - assembly.assembly_type.product_try_it_hero
     - assembly.assembly_type.rich_text
+    - assembly.assembly_type.sign_up_hero
+    - assembly.assembly_type.static_content_band
+    - assembly.assembly_type.video_hero
     - field.storage.assembly.field_column_1
 id: assembly.layout_two_col_left_sidebar.field_column_1
 field_name: field_column_1
@@ -22,7 +31,16 @@ settings:
   handler_settings:
     target_bundles:
       compact_dynamic_article_list: compact_dynamic_article_list
+      static_content_band: static_content_band
+      dynamic_content_feed: dynamic_content_feed
+      events_hero: events_hero
+      hero: hero
+      product_download_hero: product_download_hero
+      product_try_it_hero: product_try_it_hero
       rich_text: rich_text
+      content_with_image: content_with_image
+      sign_up_hero: sign_up_hero
+      video_hero: video_hero
     sort:
       field: _none
     auto_create: false

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.layout_two_col_left_sidebar.field_column_2.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.layout_two_col_left_sidebar.field_column_2.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - assembly.assembly_type.compact_dynamic_article_list
     - assembly.assembly_type.content_with_image
     - assembly.assembly_type.dynamic_content_feed
     - assembly.assembly_type.events_hero
@@ -29,6 +30,7 @@ settings:
   handler: 'default:assembly'
   handler_settings:
     target_bundles:
+      compact_dynamic_article_list: compact_dynamic_article_list
       static_content_band: static_content_band
       dynamic_content_feed: dynamic_content_feed
       events_hero: events_hero

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_rhd-c-two-col-hero-layout.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_rhd-c-two-col-hero-layout.scss
@@ -1,139 +1,182 @@
 $pf-global--breakpoint--temp: 1360px;
 
-.component {
-    &.rhd-c-two-col-hero-layout {
-        > .pf-l-grid {
-            
-            > .pf-m-12-col {
-                @include nestedComponent;
+.component.rhd-c-two-col-hero-layout {
+  > .pf-l-grid {
+    > .pf-l-grid__item {
+      // If this is a lg breakpoint or higher, this content is nested.
+      @media screen and (min-width: $pf-global--breakpoint--lg) {
+        @include nestedComponent;
+      }
 
-                &:first-of-type {
-                    @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
-                        grid-row: 2;
-                    }
-                    .component {
-                        margin-top: 0;
-                    }
-                }
-
-            }
-
-            .field--name-field-column-2 {
-                > .assembly.component:first-of-type {
-                  // Remove margin-top from first assembly rendered in 2nd
-                  // column within the Layout 2 col, sidebar left assembly type.
-                  // This makes it match the behavior of the left, 1st column.
-                  @media screen and (min-width: $pf-global--breakpoint--lg) {
-                    margin-top: 0;
-                  }
-                }
-            }
+      &:first-of-type {
+        @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
+          grid-row: 2;
         }
-
-        .field--name-field-column-1 {
-          .medium-cta {
-            margin-left: 0;
-            margin-bottom: 0;
-          }
+        .component {
+          margin-top: 0;
         }
-
-        .field--name-field-column-2 {
-          .assembly-type-rich_text,
-          .assembly-type-content_with_image,
-          .assembly-type-events_hero ,
-          .assembly-type-hero ,
-          .assembly-type-product_download_hero ,
-          .assembly-type-product_try_it_hero ,
-          .assembly-type-sign_up_hero ,
-          .assembly-type-video_hero {
-            padding-left:  var(--rhd-theme--container-spacer-md);
-            padding-right:  var(--rhd-theme--container-spacer-md);
-          }
-          .component {
-            &.assembly-type-static_content_band {
-              .component-limit-width {
-                >.pf-l-flex {
-                  &.rhd-c-card-grid__wrapper {
-                    .assembly {
-                      &.rhd-c-card {
-                        width: calc(33.3% - var(--rhd-theme--container-spacer-lg));
-                        margin-left: $rhd-flex-half--spacer;
-                        margin-right: $rhd-flex-half--spacer;
-
-                        @media screen and (max-width: $pf-global--breakpoint--temp) {
-                          width: calc(50% - #{$rhd-flex--spacer});
-                        }
-          
-                        @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
-                          width: calc(33% - #{$rhd-flex--spacer});
-                        }
-
-                        @media screen and (max-width: $pf-global--breakpoint--md) {
-                          width: calc(50% - #{$rhd-flex--spacer});
-                        }
-
-                        @media screen and (max-width: $pf-global--breakpoint--sm) {
-                          width: 100%;
-                          margin: 0 0 $rhd-flex--spacer 0;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-          
-              &.four-up {
-                .component-limit-width {
-                  >.pf-l-flex {
-                    &.rhd-c-card-grid__wrapper {
-                      .assembly {
-                        &.pf-l-flex,
-                        &.assembly-type-node_reference {
-                          width: 33%;
-
-                          @media screen and (max-width: $pf-global--breakpoint--temp) {
-                            width: 50%;
-                          }
-          
-                          @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
-                            width: 33%;
-                          }
-
-                          @media screen and (max-width: $pf-global--breakpoint--md) {
-                            width: 50%;
-                          }
-
-                          @media screen and (max-width: $pf-global--breakpoint--xs) {
-                            width: 100%;
-                          }
-                        }
-          
-                        &.rhd-c-card {
-                          width: calc(33% - #{$rhd-flex--spacer});
-
-                          @media screen and (max-width: $pf-global--breakpoint--temp) {
-                            width: calc(50% - #{$rhd-flex--spacer});
-                          }
-          
-                          @media screen and (max-width: $pf-global--breakpoint--lg) {
-                            width: calc(33% - #{$rhd-flex--spacer});
-                          }
-
-                          @media screen and (max-width: $pf-global--breakpoint--md) {
-                            width: calc(50% - #{$rhd-flex--spacer});
-                          }
-
-                          @media screen and (max-width: $pf-global--breakpoint--xs) {
-                            width: 100%;
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }          
-        }
+      }
     }
+
+    .field--name-field-column-1,
+    .field--name-field-column-2 {
+      > .assembly.component:first-of-type {
+        // Remove margin-top from first assembly rendered in each column.
+        @media screen and (min-width: $pf-global--breakpoint--lg) {
+          margin-top: 0;
+        }
+      }
+    }
+  }
+
+  // Grid spacing
+  .field--name-field-column-1,
+  .field--name-field-column-2 {
+    @media screen and (min-width: $pf-global--breakpoint--sm) {
+      --pf-l-grid__item--GridColumnEnd: span 12;
+    }
+    @media screen and (min-width: $pf-global--breakpoint--lg) {
+      --pf-l-grid__item--GridColumnEnd: span 6;
+    }
+  }
+  &.left-sidebar {
+    @media screen and (min-width: $pf-global--breakpoint--lg) {
+      .field--name-field-column-1 {
+        --pf-l-grid__item--GridColumnEnd: span 4;
+      }
+      .field--name-field-column-2 {
+        --pf-l-grid__item--GridColumnEnd: span 8;
+      }
+    }
+    @media screen and (min-width: $pf-global--breakpoint--xl) {
+      .field--name-field-column-1 {
+        --pf-l-grid__item--GridColumnEnd: span 3;
+      }
+      .field--name-field-column-2 {
+        --pf-l-grid__item--GridColumnEnd: span 9;
+      }
+    }
+  }
+  &.right-sidebar {
+    @media screen and (min-width: $pf-global--breakpoint--lg) {
+      .field--name-field-column-1 {
+        --pf-l-grid__item--GridColumnEnd: span 8;
+      }
+      .field--name-field-column-2 {
+        --pf-l-grid__item--GridColumnEnd: span 4;
+      }
+    }
+    @media screen and (min-width: $pf-global--breakpoint--xl) {
+      .field--name-field-column-1 {
+        --pf-l-grid__item--GridColumnEnd: span 9;
+      }
+      .field--name-field-column-2 {
+        --pf-l-grid__item--GridColumnEnd: span 3;
+      }
+    }
+  }
+
+
+  .rhd-c-dynamic-content-list-compact .medium-cta {
+    margin-left: 0;
+    margin-bottom: 0;
+  }
+
+  .field--name-field-column-2 {
+    .assembly-type-rich_text,
+    .assembly-type-content_with_image,
+    .assembly-type-events_hero ,
+    .assembly-type-hero ,
+    .assembly-type-product_download_hero ,
+    .assembly-type-product_try_it_hero ,
+    .assembly-type-sign_up_hero ,
+    .assembly-type-video_hero {
+      padding-left:  var(--rhd-theme--container-spacer-md);
+      padding-right:  var(--rhd-theme--container-spacer-md);
+    }
+
+    .component.assembly-type-static_content_band {
+      .component-limit-width {
+        >.pf-l-flex {
+          &.rhd-c-card-grid__wrapper {
+            .assembly {
+              &.rhd-c-card {
+                width: calc(33.3% - var(--rhd-theme--container-spacer-lg));
+                margin-left: $rhd-flex-half--spacer;
+                margin-right: $rhd-flex-half--spacer;
+
+                @media screen and (max-width: $pf-global--breakpoint--temp) {
+                  width: calc(50% - #{$rhd-flex--spacer});
+                }
+  
+                @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
+                  width: calc(33% - #{$rhd-flex--spacer});
+                }
+
+                @media screen and (max-width: $pf-global--breakpoint--md) {
+                  width: calc(50% - #{$rhd-flex--spacer});
+                }
+
+                @media screen and (max-width: $pf-global--breakpoint--sm) {
+                  width: 100%;
+                  margin: 0 0 $rhd-flex--spacer 0;
+                }
+              }
+            }
+          }
+        }
+      }
+  
+      &.four-up {
+        .component-limit-width {
+          >.pf-l-flex {
+            &.rhd-c-card-grid__wrapper {
+              .assembly {
+                &.pf-l-flex,
+                &.assembly-type-node_reference {
+                  width: 33%;
+
+                  @media screen and (max-width: $pf-global--breakpoint--temp) {
+                    width: 50%;
+                  }
+  
+                  @media screen and (max-width: $pf-global--breakpoint--lg - 1) {
+                    width: 33%;
+                  }
+
+                  @media screen and (max-width: $pf-global--breakpoint--md) {
+                    width: 50%;
+                  }
+
+                  @media screen and (max-width: $pf-global--breakpoint--xs) {
+                    width: 100%;
+                  }
+                }
+  
+                &.rhd-c-card {
+                  width: calc(33% - #{$rhd-flex--spacer});
+
+                  @media screen and (max-width: $pf-global--breakpoint--temp) {
+                    width: calc(50% - #{$rhd-flex--spacer});
+                  }
+  
+                  @media screen and (max-width: $pf-global--breakpoint--lg) {
+                    width: calc(33% - #{$rhd-flex--spacer});
+                  }
+
+                  @media screen and (max-width: $pf-global--breakpoint--md) {
+                    width: calc(50% - #{$rhd-flex--spacer});
+                  }
+
+                  @media screen and (max-width: $pf-global--breakpoint--xs) {
+                    width: 100%;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }          
 }


### PR DESCRIPTION
This changes the way that Layout: 2 Column assembly type will display
content. We want to use this assembly type to support any kind of
assembly-based, 2 column layouts, not just a left sidebar scenario. To
do so, I have created 2 visual styles: Left sidebar and right sidebar.
The default behavior, now, will be an evenly split 6:6 layout.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-248

Relates to: https://projects.engineering.redhat.com/browse/RHDX-179

### Verification Process

#### Default - no visual style
![localhost_ (4)](https://user-images.githubusercontent.com/7155034/73964943-0ef7c780-48c8-11ea-8d84-6379c39ab006.png)

#### Right sidebar visual style
![localhost_assembly_31000_view](https://user-images.githubusercontent.com/7155034/73964951-161ed580-48c8-11ea-8b81-fc922eebd9d6.png)

#### Left sidebar visual style
![localhost_ (5)](https://user-images.githubusercontent.com/7155034/73964958-1a4af300-48c8-11ea-8323-50ff1d129026.png)


### Important note

If/when merged, this will require a content update (update the visual style to Left Sidebar) of the 1 referenced Layout: Two Column assembly on Prod (the homepage). We could write a migration for that I suppose, but since there is only 1, it seems like a better use of time to just update the content manually.