### PR TITLE
[RHDX-291] Set required cron interval ImageCache External

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -97,7 +97,7 @@
         "drupal/publication_date": "2.x-dev",
         "jquery/select2": "4.0.3",
         "drupal/twig_tweak": "^2.1",
-        "drupal/imagecache_external": "^1.1",
+        "drupal/imagecache_external": "1.2",
         "drupal/readonlymode": "^1.0",
         "drupal/session_limit": "^1.0@beta",
         "drupal/seckit": "1.1",

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20914ebcb5f80c63a3b49257a37a94f3",
+    "content-hash": "fb208869406a53486105f894e74f49bc",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -4176,7 +4176,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta1",
-                    "datestamp": "1513981984",
+                    "datestamp": "1580800935",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -4334,7 +4334,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1532037781",
+                    "datestamp": "1581284770",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4851,8 +4851,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-rc2+10-dev",
-                    "datestamp": "1578145983",
+                    "version": "8.x-1.0-rc2+15-dev",
+                    "datestamp": "1581473874",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -6635,7 +6635,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1562866084",
+                    "datestamp": "1581285935",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8310,7 +8310,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-rc1",
-                    "datestamp": "1561322281",
+                    "datestamp": "1581259945",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."

--- a/_docker/drupal/drupal-filesystem/web/config/sync/imagecache_external.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/imagecache_external.settings.yml
@@ -17,4 +17,4 @@ imagecache_external_allowed_mimetypes:
   - application/octet-stream;charset=utf-8
 _core:
   default_config_hash: pf41tN-PPhgH1h2NxglpZuVbsh8xKOnO2r5cqM3aeYs
-imagecache_external_cron_flush_frequency: 1
+imagecache_external_cron_flush_frequency: 0

--- a/_docker/drupal/drupal-filesystem/web/config/sync/imagecache_external.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/imagecache_external.settings.yml
@@ -17,3 +17,4 @@ imagecache_external_allowed_mimetypes:
   - application/octet-stream;charset=utf-8
 _core:
   default_config_hash: pf41tN-PPhgH1h2NxglpZuVbsh8xKOnO2r5cqM3aeYs
+imagecache_external_cron_flush_frequency: 1


### PR DESCRIPTION
There is a required cron interval config keyvalue that we apparently had
never set for the ImageCache External module. I tested this against the
1.1 and 1.2 releases locally and it _seemed_ like the field was required
in both releases. I am not sure, at least at this point in my debugging,
why we started to encounter these cron failures at this point, instead
of at an earlier date whenever this required value was introduced to the
contrib module. Setting a value resolves the error that arises during
cron execution though. I will verify this on the PR build once a build
either fails or completes successfully by reviewing the logs and testing
the command(s) against the commandline of the PR environment.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-291

### Verification Process

* Builds  succesfully
* Tests are green

* login to Drupal and view the logs at /admin/reports/dblog and ensure that there  aren't any cron errors reported

* Connect to the PR terminal (https://github.com/redhat-developer/developers.redhat.com/tree/master/previews#connecting-to-drupal-in-your-preview-environment) and run `drush cron` and verify that it completes successfully without this specific error being reported. There is a 'known issue' error that presents during cron execution here (https://projects.engineering.redhat.com/browse/RHDX-155).
