### PR TITLE
[RHDX-293] Show Opt In Field on Eloqua Form 

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/templates/rhd-eloqua-embed-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/templates/rhd-eloqua-embed-page.html.twig
@@ -213,6 +213,20 @@
     <div id="GatedFormContainer"></div>
     {% if redirect_url or overlabel %}
       <script>
+        function hideLabels(context) {
+          // F_FormData_OptIn-form-group
+          $('label', context).each(function() {
+            var $this = $(this);
+            if ($this.prev().attr('type') == 'radio' || $this.parent().attr('id') == 'F_FormData_OptIn-form-group' ) {
+              // Do not move labels for radios.
+              // Do not remove label on OptIn.
+            } else {
+              $('#' + $this.attr('for')).attr('placeholder', $this.text());
+              $this.hide();
+            }
+          });
+        }
+
         var targetNode = document.getElementById('GatedFormContainer');
         var config = { childList: true };
         var callback = function(mutationsList, observer) {
@@ -228,17 +242,11 @@
                 }
                 {% endif %}
                 {% if overlabel %}
-                $('label', $search).each(function() {
-                  var $this = $(this);
-                  $('#' + $this.attr('for')).attr('placeholder', $this.text());
-                  $this.hide();
-                });
+                  hideLabels($search);
                 {% endif %}
               }
             }
-
           }
-
         };
         var observer = new MutationObserver(callback);
         observer.observe(targetNode, config);

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/templates/rhd-eloqua-embed-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_eloqua_embed/templates/rhd-eloqua-embed-page.html.twig
@@ -125,7 +125,7 @@
         content: none;
       }
       #GatedFormContainer .form-content > #F_FormData_OptIn-form-group.form-group:not(:empty):not(#FormSubmitButton-form-group) {
-        display: none !important;
+        /*display: none !important;*/
       }
       .dark #GatedFormContainer .form-content > .form-group .control-label,
       .dark #GatedFormContainer .form-content > .form-group label,
@@ -141,7 +141,7 @@
 
       @media (min-width: 701px) {
         #GatedFormContainer .form-content > #F_FormData_OptIn-form-group.form-group:not(:empty):not(#FormSubmitButton-form-group) {
-          display: none !important;
+          /*display: none !important;*/
         }
         .inline #GatedFormContainer .form-content {
           display: flex;


### PR DESCRIPTION
### JIRA Issue Link
[RHDX-293](https://projects.engineering.redhat.com/browse/RHDX-293)

### Verification Process
The Eloqua forms that display the Country field should provide an Opt In radio selection after selecting specific countries.

1. - See the test form provided here: https://developers.redhat.com/node/215345/
2. - Create test content: Assembly Page node, Eloqua Form assembly using the contents of the 215345 in production
3. - Select a GDPR country such as  "Austria",  "Belgium", "Bulgaria".
4. - Verify an Opt In field appears with the label "Red Hat may use your personal data to inform you about its products, services, and events. You may withdraw your consent any time (see Privacy Statement for details)."
5. - Submit the form and verify that you do not have a form validation error.

Test the form with and without the visual style `Label in Fields`.
Note that you may need to run a site recache after visual style changes, as we have a current known caching issue with the Eloqua Form assembly type.

Please check other known forms, such as OpenJDK or Contact Sales.
