### PR TITLE
[RHDX-333] Make DownloadManagerApi use EntityTypeManagerInterface

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Service/DownloadManagerApi.php
@@ -4,7 +4,7 @@ namespace Drupal\rhd_assemblies\Service;
 
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactory;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use GuzzleHttp\ClientInterface;
 
@@ -32,7 +32,7 @@ class DownloadManagerApi {
   /**
    * Entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -62,7 +62,7 @@ class DownloadManagerApi {
    *
    * @param GuzzleHttp\ClientInterface $client
    *   The Guzzle client.
-   * @param Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache_bin
    *   Download Manager cache bin service.
@@ -71,7 +71,7 @@ class DownloadManagerApi {
    * @param \Drupal\Core\Config\ConfigFactory $config_factory
    *   Config factory service.
    */
-  public function __construct(ClientInterface $client, EntityTypeManager $entity_type_manager, CacheBackendInterface $cache_bin, LoggerChannelFactoryInterface $logger_factory, ConfigFactory $config_factory) {
+  public function __construct(ClientInterface $client, EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache_bin, LoggerChannelFactoryInterface $logger_factory, ConfigFactory $config_factory) {
     $this->configFactory = $config_factory;
     // If there is a Download Manager baseUrl config object, use that to set
     // the apiUrl. Else, point the apiUrl to Download Manager Prod.


### PR DESCRIPTION
This is a change to properly inject EntityTypeManagerInterface as a
dependency, instead of EntityTypeManager. I discovered this issue while
debugging some performance issues when I tried to enable and use the
webprofiler module. It will result in a fatal error because we are not
properly injecting the interface.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-333

### Related work

* I will be creating a merge request to Compose soon because it also includes 1 instance of this same issue. I will track that in the JIRA issue.

### Verification Process

* Everything works exactly the same as it did before
* Unfortunately, you will not be able to test this next step until we make a change to the Compose (contrib) module, and we cannot use the latest Compose branch until we are on Drupal core 8.8.x. This is the scenario, though, that originally uncovered this issue.
** You can check out this branch and enable and use the `webprofiler` Devel module
