### PR TITLE
[RHDX-360] Fix theme suggestions conditional logic

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -11,6 +11,7 @@ use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 
 /**
@@ -74,6 +75,7 @@ function rhdp2_theme_suggestions_page_alter(array &$suggestions, array $variable
     if (is_numeric($node) && strpos($node, '.') === FALSE && strpos($node, '-') === FALSE) {
       $node = Node::load($node);
     }
+
     // If we have a $node object that is an instanceof NodeInterface, create
     // template suggestions.
     if ($node instanceof NodeInterface) {
@@ -82,7 +84,6 @@ function rhdp2_theme_suggestions_page_alter(array &$suggestions, array $variable
       if (!in_array($new_suggestion, $suggestions)) {
         $suggestions[] = $new_suggestion;
       }
-
       if ($node->hasField('field_kiosk_mode') && $node->field_kiosk_mode->value == TRUE) {
         $suggestions[] = 'page__kiosk_mode';
       }
@@ -727,7 +728,7 @@ function redhat_www_ddo_default($node) {
   $ddo_pageID = "";
   $ddo_title = "";
 
-  if (!is_null($node)) {
+  if (!empty($node) && $node instanceof NodeInterface) {
     if ($siteerror == '/node/' . $node->nid->value) {
       $errorType = "404";
       $errorMessage = "404-error";

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -12,7 +12,6 @@ use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Menu\MenuTreeParameters;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_preprocess_page().
@@ -69,16 +68,25 @@ function rhdp2_preprocess_menu(&$variables) {
 function rhdp2_theme_suggestions_page_alter(array &$suggestions, array $variables) {
   $node = \Drupal::request()->attributes->get('node');
 
-  if (!is_null($node) && method_exists($node, 'getType')) {
-    $new_suggestion = 'page__' . $node->getType();
-
-    if (!in_array($new_suggestion, $suggestions)) {
-      $suggestions[] = $new_suggestion;
+  if (!empty($node)) {
+    // If $node is a string integer i.e. '123', retrieve the Node object with
+    // that nid.
+    if (is_numeric($node) && strpos($node, '.') === FALSE && strpos($node, '-') === FALSE) {
+      $node = Node::load($node);
     }
-  }
+    // If we have a $node object that is an instanceof NodeInterface, create
+    // template suggestions.
+    if ($node instanceof NodeInterface) {
+      $new_suggestion = 'page__' . $node->getType();
 
-  if($node && $node->hasField('field_kiosk_mode') && $node->field_kiosk_mode->value == TRUE) {
-    $suggestions[] =  'page__kiosk_mode';
+      if (!in_array($new_suggestion, $suggestions)) {
+        $suggestions[] = $new_suggestion;
+      }
+
+      if ($node->hasField('field_kiosk_mode') && $node->field_kiosk_mode->value == TRUE) {
+        $suggestions[] = 'page__kiosk_mode';
+      }
+    }
   }
 
   return $suggestions;


### PR DESCRIPTION
The conditional logic we have in hook_theme_suggestions_alter() is not
properly validating that we have retrieved a Node object in $node. I
have adjusted the logic to ensure that we've actually fetched an object
that is an instance of NodeInterface. This should resolve an issue that
arises when trying to view Node revisions.

```
Error: Call to a member function hasField() on string in rhdp2_theme_suggestions_page_alter() (line 80 of themes/custom/rhdp2/rhdp2.theme).
```

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-360

### Verification Process

Go here: /node/213906/revisions/17508836/view/

You should not see this:

```
The website encountered an unexpected error. Please try again later.
Error: Call to a member function hasField() on string in rhdp2_theme_suggestions_page_alter() (line 80 of themes/custom/rhdp2/rhdp2.theme).
rhdp2_theme_suggestions_page_alter(Array, Array, 'page') (Line: 449)
Drupal\Core\Theme\ThemeManager->alterForTheme(Object, 'theme_suggestions', Array, Array, 'page') (Line: 458)
Drupal\Core\Theme\ThemeManager->alter(Array, Array, Array, 'page') (Line: 245)
Drupal\Core\Theme\ThemeManager->render('page', Array) (Line: 437)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 195)
Drupal\Core\Render\Renderer->render(Array) (Line: 501)
Drupal\Core\Template\TwigExtension->escapeFilter(Object, Array, 'html', NULL, 1) (Line: 367)
__TwigTemplate_1272c3f60e315a3d4a67c19f5c6ed52fbf1fa5cf38a91bce649d2cff447b77f2->doDisplay(Array, Array) (Line: 455)
Twig\Template->displayWithErrorHandling(Array, Array) (Line: 422)
Twig\Template->display(Array) (Line: 434)
Twig\Template->render(Array) (Line: 64)
twig_render_template('themes/custom/rhdp2/templates/system/html.html.twig', Array) (Line: 384)
Drupal\Core\Theme\ThemeManager->render('html', Array) (Line: 437)
Drupal\Core\Render\Renderer->doRender(Array, ) (Line: 195)
Drupal\Core\Render\Renderer->render(Array) (Line: 147)
Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}() (Line: 582)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 148)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray(Object, 'kernel.view', Object) (Line: 76)
Drupal\webprofiler\EventDispatcher\TraceableEventDispatcher->dispatch('kernel.view', Object) (Line: 156)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 49)
Asm89\Stack\Cors->handle(Object, 1, 1) (Line: 50)
Drupal\ban\BanMiddleware->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 38)
Drupal\webprofiler\StackMiddleware\WebprofilerMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 693)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```
