### PR TITLE
[RHDX-367] Add a How do I report an issue section to RHAMT

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/paragraph/paragraph--help.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/paragraph/paragraph--help.html.twig
@@ -16,6 +16,17 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
         <div class="row">
             <div class="large-24 columns">
                 <h2 class="subpage-name" id="community">Help</h2>
+                {#
+                 # This "How do I report an issue" section will only display for
+                 # the RHAMT product. This section was added as a result of a
+                 # request from Marco Rizzi.
+                 #
+                 # @see https://projects.engineering.redhat.com/browse/RHDX-367
+                 #}
+                {% if product_machine_name == 'migrationtoolkit' %}
+                    <h4>How do I report an issue?</h4>
+                    <p>Our issue tracking system is available on <a href="https://issues.redhat.com/projects/WINDUP/issues">https://issues.redhat.com/projects/WINDUP/issues</a>. You may use your <a href="https://access.redhat.com">access.redhat.com</a> user account to login to this system. To find out how to use the issue tracking system, refer to <a href="https://confluence.atlassian.com/display/JIRA/JIRA+Documentation">https://confluence.atlassian.com/display/JIRA/JIRA+Documentation</a></p>
+                {% endif %}
                 {% if (show_forums or show_stack_overflow) %}
                     <h4>Community Q&amp;A</h4>
                     <p>


### PR DESCRIPTION
This adds a 'How do I report an issue' section to the RHAMT Product's
Help sub-page. This content is added via a conditional, targeting the
field_product_machine_name value.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-367

### Verification Process

#### RHAMT (positive)

Go to https://developer-preview-3528.ext.us-west.dc.preprod.paas.redhat.com/products/rhamt/help

You should see a new section with the following text:

> How do I report an issue?
> 
> Our issue tracking system is available on https://issues.redhat.com/projects/WINDUP/issues. You may use your access.redhat.com user account to login to this system. To find out how to use the issue tracking system, refer to https://confluence.atlassian.com/display/JIRA/JIRA+Documentation

##### Screenshot

<img width="1267" alt="Screen Shot 2020-03-18 at 7 05 04 AM" src="https://user-images.githubusercontent.com/7155034/76968959-fa571800-68e6-11ea-842f-0e2eb9291459.png">

#### RHEL (negative)

Go to https://developer-preview-3528.ext.us-west.dc.preprod.paas.redhat.com/products/rhel/help

You should *not* see any changes / new section

##### Screenshot

<img width="1321" alt="Screen Shot 2020-03-18 at 7 04 51 AM" src="https://user-images.githubusercontent.com/7155034/76968966-fdea9f00-68e6-11ea-8138-6eabff12545d.png">