### PR TITLE
[RHDX-412] Rework cta styles and add light-blue theme

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.call_to_action.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/assembly.assembly_type.call_to_action.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 id: call_to_action
 label: 'Call to Action'
 description: 'A link with optional title, text, and background image'
-visual_styles: "dark|Dark|Dark background with white text\r\nno-background|No Background|No background color\r\nleft|Left|Left aligned content"
+visual_styles: "light-blue|Light-Blue|Light Blue background with white text\r\ndark|Dark|Dark background with white text\r\nno-background|No Background|No background color\r\nleft|Left|Left aligned content\r\ncentered|Center|Center aligned content\r\nright|Right|Right aligned content"
 new_revision: true

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_call-to-action.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_call-to-action.scss
@@ -2,42 +2,15 @@
 
 .component {
   &.assembly-type-call_to_action {
-    background-color: var(--rhd-theme--ui-background-dark--light-blue);
     @include with-background-padding;
-
-    .cta__container {
-      text-align: center;
-      // @to-do: This is applied without hte .dark classname; Is this assembly always dark?
-      color: var(--rhd-theme--component-font--color-light);
-    }
 
     .cta__title,
     .cta__content {
-      // @to-do: This is applied without hte .dark classname; Is this assembly always dark?
-      color: var(--rhd-theme--component-font--color-light);
       margin-bottom: var(--rhd-theme--container-spacer-md);
     }
 
     .ics-wrapper {
       margin-bottom: var(--rhd-theme--container-spacer-md);
-    }
-
-    &.left {
-      float: none !important;
-      text-align: left;
-
-      .cta__title,
-      .cta__content,
-      .cta__cta,
-      .ics-wrapper {
-        text-align: left;
-      }
-    }
-    &.dark {
-      //background-color: var(--rhd-theme--component-background--color-dark);
-    }
-    &.no-background {
-      background-color: transparent;
     }
   }
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-base.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-base.scss
@@ -1,3 +1,6 @@
+//
+//Base component class
+//
 .component {
     //isolate any absolute positioned children to the component
     position: relative;
@@ -42,34 +45,51 @@
         }
     }
 
-    /*Reset floats from old 2018 css globals */
+//
+//default component classes
+//
+
+    //Align text left
     &.left   { 
-        float: none !important; 
-    }
-    &.centered   { 
-        float: none !important; 
-    }
-    &.right  { 
-        float: none !important; 
+        text-align: left;
     }
 
-    //default component classes
+    //Align text to center
+    &.centered   { 
+        text-align: center;
+    }
+
+    //Align text right
+    &.right  { 
+        text-align: right;
+    }
+
+    //Add grey background only, legacy style not part of themeing 
     &.background-gray {
         background: $rhd-theme--component-background--color-extra-light;
     }
+
+    //Remove top vertical component spacing
     &.no-padding-top {
         @extend .pf-u-pt-0;
     }
 
+    //Remove bottom vertical component spacing
     &.no-padding-bottom {
         @extend .pf-u-pb-0;
+    }  
+
+    //no background color/transparent
+    &.no-background {
+        background-color: transparent;
     }
     
+    //Adds component padding all round used with background image or coloured backgrounds.
     &.has-background {
         @include with-background-padding;
     }
 
-    //extra component classes
+    //extra component classes used for card images
     &.image-no-crop {
         .rhd-c-card {
             img.rhd-c-card__image, img.image-style-static-item {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-styles.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/components/_component-styles.scss
@@ -66,6 +66,71 @@ $componentStyles: (
                 )
             )
     ),
+    'light-blue': (
+        'foregroundColor': var(--rhd-theme--component-font--color-light),
+        'backgroundColor': var(--rhd-theme--ui-background-dark--light-blue),
+        'cardColor': var(--rhd-theme--component-background--color-dark),
+        'linkColor': #{$white},
+        'linkHoverColor': #{$white},
+        'addImagePadding': true,
+        'buttonOverrides': (
+                'm-link': (
+                    'Color': #{$white},
+                    'hover--Color': #{$alto},
+                    'active--Color': #{$alto},
+                    'BorderColor': transparent,
+                    'hover--BorderColor': transparent,
+                    'active--BorderColor': transparent,
+                    'BackgroundColor': transparent,
+                    'hover--BackgroundColor': transparent,
+                    'active--BackgroundColor': transparent
+                ),
+                'm-link--secondary': (
+                    'Color': #{$white},
+                    'hover--Color': #{$alto},
+                    'active--Color': #{$alto},
+                    'BorderColor': transparent,
+                    'hover--BorderColor': transparent,
+                    'active--BorderColor': transparent,
+                    'BackgroundColor': transparent,
+                    'hover--BackgroundColor': transparent,
+                    'active--BackgroundColor': transparent
+                ),
+                'm-secondary': (
+                    'Color': #{$white},
+                    'hover--Color': #{$black},
+                    'active--Color': #{$black},
+                    'BorderColor': #{$white},
+                    'hover--BorderColor': #{$white},
+                    'active--BorderColor': #{$white},
+                    'BackgroundColor': transparent,
+                    'hover--BackgroundColor': #{$white},
+                    'active--BackgroundColor': #{$white}
+                ),
+                'm-secondary-alt': (
+                    'Color': #{$white},
+                    'hover--Color': #{$black},
+                    'active--Color': #{$black},
+                    'BorderColor': #{$white},
+                    'hover--BorderColor': #{$white},
+                    'active--BorderColor': #{$white},
+                    'BackgroundColor': transparent,
+                    'hover--BackgroundColor': #{$white},
+                    'active--BackgroundColor': #{$white}
+                ),
+                'm-tertiary': (
+                    'Color': #{$white},
+                    'hover--Color': #{$black},
+                    'active--Color': #{$black},
+                    'BorderColor': #{$white},
+                    'hover--BorderColor': #{$white},
+                    'active--BorderColor': #{$white},
+                    'BackgroundColor': transparent,
+                    'hover--BackgroundColor': #{$white},
+                    'active--BackgroundColor': #{$white}
+                )
+            )
+    ),
     'gray': (
         'foregroundColor': var(--rhd-theme--component-font--color-dark),
         'backgroundColor': var(--rhd-theme--component-background--color-light),


### PR DESCRIPTION
### JIRA Issue Link
https://projects.engineering.redhat.com/browse/RHDX-412

### Verification Process
check cat components on 
https://docs.google.com/spreadsheets/d/1cD6W-nwd4wqyhMclD_kqJffnmOvjM_RNA8sT_C-UXoc/edit#gid=0

Test any CTA_assembly you should have the option for dark theme and light-blue theme, also left centre and right align.

Now if you have a background Image you can select dark to have white text and leave without a theme class to maintain dark text if the background image is light.

will require content changes need to discuss with UX , plan to make changes (Alistair) 40 components.

Tc confirm Alistair will make the changes to the live content after release.
