### PR TITLE
[RHDX-425] Update usage of hide class

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/js/show-more.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/js/show-more.js
@@ -6,7 +6,9 @@
         var $showMoreText = $($showMoreElem).text();
         var $showMoreButton = $($showMoreElem).next();
 
-        if ($showMoreText.length >= 700) {
+        if ($showMoreText.length <= 2000) {
+          $(this).css('max-height', 'unset');
+        } else {
           $($showMoreButton).removeClass('pf-u-hidden');
         }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/js/show-more.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/js/show-more.js
@@ -7,7 +7,7 @@
         var $showMoreButton = $($showMoreElem).next();
 
         if ($showMoreText.length >= 700) {
-          $($showMoreButton).removeClass('hide');
+          $($showMoreButton).removeClass('pf-u-hidden');
         }
 
         $($showMoreButton).on('click', function() {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/terms-and-conditions.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/scripts/js/rhd/terms-and-conditions.js
@@ -61,7 +61,7 @@ app.termsAndConditions = {
         }
 
         //create template string for thankyou message
-        messageTemplate = messageTemplate + '<div class="component rhd-c-product-download-alert pf-c-content hide" id="downloadthankyou">';
+        messageTemplate = messageTemplate + '<div class="component rhd-c-product-download-alert pf-c-content" id="downloadthankyou">';
         messageTemplate = messageTemplate + '<div class="rhd-c-panel pf-l-grid">';
         messageTemplate = messageTemplate + '<div class="rhd-c-panel-close pf-l-grid__item pf-m-1-col pf-m-offset-11-col"><a href="#" onclick="app.termsAndConditions.hideDownloadMessage();"><i class="fas fa-times"></i></a></div>';
         messageTemplate = messageTemplate + '<div class="pf-l-grid__item pf-m-12-col">';

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -166,6 +166,7 @@ function rhdp2_preprocess_node(&$variables) {
     }
 
     // Process Table of Contents.
+    // @TODO: this also lives in article.module.
     if ($node->hasField('field_hide_toc')) {
       $variables['hide_toc'] = $node->field_hide_toc->value ?? FALSE;
     }
@@ -503,7 +504,7 @@ function rhdp2_preprocess_assembly(&$variables) {
       $variables['display_type'] = 'nav-menu';
     }
   }
-  
+
   // Define if an ICS file is attached to an event on the Call to Action assembly
   if ($type == 'call_to_action') {
     $variables['has_ics'] = FALSE;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--call-to-action.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/assembly/assembly--call-to-action.html.twig
@@ -36,7 +36,7 @@
         {{ content.field_display_cta_timer }}
       </div>
       <div class="cta__cta pf-u-hidden">
-        {# The hide class is removed by countdown.js when the timer runs out. #}
+        {# The pf-u-hidden class is removed by countdown.js when the timer runs out. #}
         {{ content.field_cta_link }}
       </div>
     {% else %}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--article--full.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--article--full.html.twig
@@ -2,21 +2,13 @@
   'component',
   'author-' ~ author_location
 ] %}
-{% set article_classes = (hide_toc == TRUE) ? [
+{% set article_classes =  [
   'pf-l-grid__item',
   'pf-xs-12-col',
   'pf-m-12-col-on-xs',
   'pf-m-10-col-on-lg',
   'gsi',
-  'fetch-toc',
-  'article-content',
-] : [
-  'pf-l-grid__item',
-  'pf-xs-12-col',
-  'pf-m-12-col-on-xs',
-  'pf-m-10-col-on-lg',
-  'gsi',
-  'fetch-toc',
+  not hide_toc ? 'fetch-toc',
   'article-content',
 ] %}
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--full.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--full.html.twig
@@ -38,8 +38,7 @@
           {{ content.field_video_resource }}
         </div>
         <div class="pf-l-grid__item pf-m-12-col {{ (has_slides ? 'pf-m-5-col-on-lg slides' : 'pf-u-hidden') }}">
-          <iframe src="https://www.slideshare.net{{ content.field_slideshare_source.0['#url'] }}" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen></iframe>
-        </div>
+          {% if has_slides %}<iframe src="https://www.slideshare.net{{ content.field_slideshare_source.0['#url'] }}" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen></iframe>{% endif %}
       </div>
     </div>
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--full.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--video-resource--full.html.twig
@@ -37,7 +37,7 @@
         <div class="pf-l-grid__item pf-m-12-col {{ (has_slides ? 'pf-m-7-col-on-lg') }}">
           {{ content.field_video_resource }}
         </div>
-        <div class="pf-l-grid__item pf-m-12-col {{ (has_slides ? 'pf-m-5-col-on-lg slides' : 'hide') }}">
+        <div class="pf-l-grid__item pf-m-12-col {{ (has_slides ? 'pf-m-5-col-on-lg slides' : 'pf-u-hidden') }}">
           <iframe src="https://www.slideshare.net{{ content.field_slideshare_source.0['#url'] }}" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="max-width: 100%;" allowfullscreen></iframe>
         </div>
       </div>
@@ -50,12 +50,12 @@
           <div class="show-more-text video-description">
             {{ content.body }}
           </div>
-          <a class="show-more hide" onclick="return false;">
+          <a class="show-more pf-u-hidden" onclick="return false;">
             <span class="more">Show More</span>
             <span class="less">Show Less</span>
           </a>
         </div>
-        <div class="pf-l-grid__item pf-m-12-col {{ (has_target_product ? 'pf-m-4-col-on-lg' : 'hide') }} ">
+        <div class="pf-l-grid__item pf-m-12-col {{ (has_target_product ? 'pf-m-4-col-on-lg' : 'pf-u-hidden') }} ">
           {{ content.field_video_target_product }}
         </div>
       </div>


### PR DESCRIPTION
### JIRA Issue Link
[RHDX-425](https://projects.engineering.redhat.com/browse/RHDX-425?filter=-1)

### Verification Process
Any usage of `.hide` in  twig templates, hooks or js files intended to hide/show elements on the page should be replaced with `.pf-u-hidden`, now that Foundation is removed. 

- Check video resource;  There should not be calls to slideshare.net if there is no slide deck.
- Check show more text on Videos and Learning Paths
- Simplified table of contents twig classes; Check that it hides when its supposed to (field_hide_toc)

There is some usage of `.hide`  in the rhdp-searchapp, I did not update that usage since the class exists within that web component.

/videos/youtube/FC3jSKgTNK0/
/videos/youtube/ajlY_qiIunA/
/videos/youtube/ywrA0312bOo/
/videos/youtube/B9MdhWCvDCM/
/videos/youtube/Cv8_EHQgUZ4/
