### PR TITLE
[No Issue] Update to rhel-76.4 version of base image

### DIFF
--- a/_docker/drupal/Dockerfile.mp
+++ b/_docker/drupal/Dockerfile.mp
@@ -1,4 +1,4 @@
-FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.3
+FROM images.paas.redhat.com/rhdp/developer-base:rhel-76.4
 USER root
 ARG composer_profile="production"
 CMD ["/var/www/drupal/run-httpd.sh"]


### PR DESCRIPTION
This commit updates to the rhel-76.4 version of the developer base image which has been updated to incorporate changes in IT PaaS entitlement management when building images in Managed Platform

### Verification Process

* The build should go green
* Log in to the Drupal container and verify the version of Ansible is 2.9 by using `ansible --version` from the command line.