### PR TITLE
[RHDX-548] Add hide title field to Topics page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.node.topic_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.topic_page.body
+    - field.field.node.topic_page.field_hide_title
     - field.field.node.topic_page.field_meta_tags
     - field.field.node.topic_page.field_sections
     - field.field.node.topic_page.field_share_image
@@ -51,7 +52,7 @@ third_party_settings:
         - field_tax_stage
         - field_tags
       parent_name: ''
-      weight: 4
+      weight: 6
       format_type: details
       format_settings:
         label: 'Purpose Attributes'
@@ -70,7 +71,7 @@ bundle: topic_page
 mode: default
 content:
   body:
-    weight: 1
+    weight: 2
     settings:
       rows: 9
       summary_rows: 3
@@ -80,18 +81,25 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 7
     region: settings
     settings: {  }
     third_party_settings: {  }
+  field_hide_title:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_meta_tags:
-    weight: 8
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
     region: settings
   field_sections:
-    weight: 2
+    weight: 3
     settings:
       form_mode: default
       override_labels: true
@@ -110,7 +118,7 @@ content:
     region: content
   field_share_image:
     type: image_image
-    weight: 3
+    weight: 5
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber
@@ -193,26 +201,26 @@ content:
     region: fields
   langcode:
     type: language_select
-    weight: 2
+    weight: 4
     region: fields
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
-    weight: 9
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: moderation_state_default
     region: settings
   path:
     type: path
-    weight: 7
+    weight: 8
     region: settings
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 11
+    weight: 12
     region: settings
     settings: {  }
     third_party_settings: {  }
@@ -225,7 +233,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 11
     region: settings
     settings: {  }
     third_party_settings: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.topic_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.topic_page.body
+    - field.field.node.topic_page.field_hide_title
     - field.field.node.topic_page.field_meta_tags
     - field.field.node.topic_page.field_sections
     - field.field.node.topic_page.field_share_image
@@ -77,6 +78,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_hide_title: true
   field_meta_tags: true
   field_share_image: true
   field_tags: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_hide_title.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_hide_title.yml
@@ -1,0 +1,23 @@
+uuid: cf088f96-d969-4f96-bda7-030445057868
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_title
+    - node.type.topic_page
+id: node.topic_page.field_hide_title
+field_name: field_hide_title
+entity_type: node
+bundle: topic_page
+label: 'Hide Title'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.node.topic_page.field_sections.yml
@@ -8,6 +8,7 @@ dependencies:
     - assembly.assembly_type.code_snippet
     - assembly.assembly_type.collection
     - assembly.assembly_type.combo
+    - assembly.assembly_type.compact_dynamic_article_list
     - assembly.assembly_type.content
     - assembly.assembly_type.content_image
     - assembly.assembly_type.content_pull_quote
@@ -25,6 +26,7 @@ dependencies:
     - assembly.assembly_type.featured_resources
     - assembly.assembly_type.hero
     - assembly.assembly_type.katacodas
+    - assembly.assembly_type.layout_two_col_left_sidebar
     - assembly.assembly_type.learning_paths
     - assembly.assembly_type.on_page_navigation
     - assembly.assembly_type.product_categories
@@ -53,30 +55,32 @@ settings:
   handler_settings:
     target_bundles:
       all_products_listing: all_products_listing
-      cta_form: cta_form
       call_to_action: call_to_action
       code_snippet: code_snippet
       collection: collection
       combo: combo
+      compact_dynamic_article_list: compact_dynamic_article_list
       content: content
-      content_image: content_image
-      content_pull_quote: content_pull_quote
       static_content_band: static_content_band
+      events_list: events_list
       curated_links: curated_links
       featured_products: featured_products
       dynamic_content_feed: dynamic_content_feed
       dynamic_content_list: dynamic_content_list
+      cta_form: cta_form
       embedded_content: embedded_content
       events_hero: events_hero
-      events_list: events_list
       product_categories: product_categories
       featured_articles: featured_articles
       featured_evangelists: featured_evangelists
+      content_pull_quote: content_pull_quote
       featured_resources: featured_resources
+      content_image: content_image
       hero: hero
-      katacodas: katacodas
-      learning_paths: learning_paths
       on_page_navigation: on_page_navigation
+      katacodas: katacodas
+      layout_two_col_left_sidebar: layout_two_col_left_sidebar
+      learning_paths: learning_paths
       product_comparison_table: product_comparison_table
       rich_text: rich_text
       rich_text_columns: rich_text_columns
@@ -86,5 +90,5 @@ settings:
     sort:
       field: _none
     auto_create: false
-    auto_create_bundle: blog_posts
+    auto_create_bundle: all_products_listing
 field_type: entity_reference_revisions

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/_pf4-custom-globals.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhd-frontend/src/styles/rhd-theme/_pf4-custom-globals.scss
@@ -64,16 +64,15 @@
 
   img,
   embed,
-  iframe,
   object,
   audio,
   video {
     max-width: 100%;
-    //Removed to prevent iframe size issue
-    //height: auto;
+    height: auto;
   }
 
   iframe {
+    max-width: 100%;
     border: 0;
   }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
@@ -11,7 +11,7 @@
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
 
-  {% if not node.field_hide_title %}
+  {% if not node.field_hide_title.0.value == 1 %}
   <div class="topic-page__title component">
     <div class="pf-l-grid">
       {{ title_prefix }}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
@@ -24,6 +24,6 @@
   {% endif %}
 
   <div{{ content_attributes.addClass('node__content') }}>
-    {{ content.field_sections }}
+    {{ content|without('body') }}
   </div>
 </article>

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/node/node--topic-page.html.twig
@@ -10,15 +10,20 @@
 %}
 {{ attach_library('classy/node') }}
 <article{{ attributes.addClass(classes) }}>
+
+  {% if not node.field_hide_title %}
   <div class="topic-page__title component">
     <div class="pf-l-grid">
       {{ title_prefix }}
       <h1{{ title_attributes }}>{{ label }}</h1>
       {{ title_suffix }}
+
+      {{ content.body }}
     </div>
   </div>
+  {% endif %}
 
   <div{{ content_attributes.addClass('node__content') }}>
-    {{ content }}
+    {{ content.field_sections }}
   </div>
 </article>


### PR DESCRIPTION
### JIRA Issue Link
https://projects.engineering.redhat.com/browse/RHDX-458
https://projects.engineering.redhat.com/browse/RHDX-459

### Verification Process
A topic page now has a field to hide the title.

When the field is active, the Title and Body of the topic page should no longer appear on the rendered page.

I also repaired a Patternfly css override to reset images back to height: auto.
Images embedded into assemblies that have width/height attributes should render in the correct ratio.