### PR TITLE
[RHDX-450] Do not load trustarc on local environment

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/html.html.twig
@@ -228,7 +228,6 @@ window.NREUM||(NREUM={}),__nr_require=function(t,n,e){function r(e){if(!n[e]){va
     } )( window, document, digitalData );
     {% endif %}
   </script>
-  <script type="text/javascript" src="https://issues.jboss.org/s/36fcee7e2c47b82293b8ffd249c9132e-T/-bdgec2/72005/38e4585ff05eb2dd95a30399b8504050/2.0.22/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=03f305bd">
   </script>
   {% if (rhd_dtm_code) %}
   <script id="dpal" src="{{rhd_dtm_code}}"></script>
@@ -248,8 +247,11 @@ window.NREUM||(NREUM={}),__nr_require=function(t,n,e){function r(e){if(!n[e]){va
 
     <css-placeholder token="{{ placeholder_token }}">
     {% if (rhd_sentry_track) %}
-    <script src="{{ rhd_sentry_script }}" crossorigin="anonymous"></script>
-    <script>Raven.config('{{ rhd_sentry_code }}', { environment: '{{rhd_environment}}', whitelistUrls: [/redhat\.com/] }).install()</script>
+      <script src="{{ rhd_sentry_script }}" crossorigin="anonymous"></script>
+      <script>Raven.config('{{ rhd_sentry_code }}', { environment: '{{rhd_environment}}', whitelistUrls: [/redhat\.com/] }).install()</script>
+    {% endif %}
+    {% if (rhd_environment != 'local') %}
+      <script type="text/javascript" src="https://consent.trustarc.com/notice?domain=redhat.com&amp;c=teconsent&amp;js=nj&amp;noticeType=bb&amp;gtm=1&amp;text=true&amp;privacypolicylink=https://www.redhat.com/en/about/privacy-policy" id="truste_0.24698138195918173"></script>
     {% endif %}
     <js-placeholder token="{{ placeholder_token }}">
   </head>
@@ -285,6 +287,7 @@ window.NREUM||(NREUM={}),__nr_require=function(t,n,e){function r(e){if(!n[e]){va
     </div>
 
     <js-bottom-placeholder token="{{ placeholder_token }}">
+    <script type="text/javascript" src="https://issues.jboss.org/s/36fcee7e2c47b82293b8ffd249c9132e-T/-bdgec2/72005/38e4585ff05eb2dd95a30399b8504050/2.0.22/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=03f305bd">
     {% if (rhd_dtm_code) %}
     <script type="text/javascript">
       if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.libraries.yml
@@ -13,7 +13,6 @@ new-relic:
     js/new-relic.min.js: { minified: true }
 
 jira-issue-collector:
-  header: true
   js:
     https://issues.jboss.org/s/36fcee7e2c47b82293b8ffd249c9132e-T/-bdgec2/72005/38e4585ff05eb2dd95a30399b8504050/2.0.22/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=03f305bd: { type: external, minified: true }
 

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/templates/system/html.html.twig
@@ -236,7 +236,9 @@
     <script src="{{ rhd_sentry_script }}" crossorigin="anonymous"></script>
     <script>Raven.config('{{ rhd_sentry_code }}', { environment: '{{rhd_environment}}', whitelistUrls: [/redhat\.com/] }).install()</script>
     {% endif %}
-    <script type="text/javascript" src="https://consent.trustarc.com/notice?domain=redhat.com&amp;c=teconsent&amp;js=nj&amp;noticeType=bb&amp;gtm=1&amp;text=true&amp;privacypolicylink=https://www.redhat.com/en/about/privacy-policy" id="truste_0.24698138195918173"></script>
+    {% if (rhd_environment != 'local') %}
+      <script type="text/javascript" src="https://consent.trustarc.com/notice?domain=redhat.com&amp;c=teconsent&amp;js=nj&amp;noticeType=bb&amp;gtm=1&amp;text=true&amp;privacypolicylink=https://www.redhat.com/en/about/privacy-policy" id="truste_0.24698138195918173"></script>
+    {% endif %}
     <js-placeholder token="{{ placeholder_token }}">
   </head>
   <body{{ attributes.addClass(body_classes) }} id="rhd-page-body">


### PR DESCRIPTION
This makes the following changes to asset/libraries loading: we will now
load trustarc in the rhdp theme (it previously/curently is not), the
JIRA issue collector will load in the at the bottom of the <body>,
trustarc will not load on local environments.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-450

### Verification Process
* TrustArc scripts/assets do no load on local environments
* TrustArc scripts/assets and functionality continues to behave exactly as it does now on all non-local environments
* TrustArc now loads on the `rhdp` theme (old, paragraphs-based Product pages e.g. RHEL)
* The JIRA issue collector loads at the bottom of the <body>