### PR TITLE
[NO ISSUE] Remove /openshift Adobe ddo e2e test

### DIFF
--- a/_tests/e2e/tests/specs/export/rhd-adobe-ddo-spec.js
+++ b/_tests/e2e/tests/specs/export/rhd-adobe-ddo-spec.js
@@ -37,18 +37,6 @@ describe('Adobe DDO', function() {
         }
     });
 
-    it("should have a valid digitalData object on the /openshift page", () => {
-        BasicPage.open('openshift');
-        const digitalData = Driver.getAdobeDdo();
-
-        if (Utils.isManagedPaasEnvironment() || Utils.isProduction()) {
-            expect(digitalData.page.category.primaryCategory).to.equal("openshift");
-        }
-        else { 
-            expect(digitalData).to.not.be.null;
-        }
-    });
-
     it("should have a valid digitalData object on the /rhel8 page", () => {
         BasicPage.open('rhel8');
         const digitalData = Driver.getAdobeDdo();


### PR DESCRIPTION
The /openshift route now redirects to
https://developers.redhat.com/products/openshift/getting-started. As a
result, one of the assertions in the rhd-adobe-ddo-spec.js file is
failing. Now that this Openshift is in a Product page, it will be
covered by the Product page e2e test(s), and we can remove this
assertion.

### JIRA Issue Link
* n/a

### Verification Process

* All of the tests pass