### PR TITLE
[RHDX-471] Related Products field renders as Card

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_products.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.featured_products.default.yml
@@ -48,7 +48,7 @@ content:
     weight: 1
     label: hidden
     settings:
-      view_mode: featured_tile
+      view_mode: card
       link: false
     third_party_settings:
       fences:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.books.default.yml
@@ -359,7 +359,7 @@ content:
     weight: 15
     label: hidden
     settings:
-      view_mode: teaser
+      view_mode: card
       link: false
     third_party_settings:
       fences:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.card.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.node.product.card.yml
@@ -81,14 +81,14 @@ content:
     label: hidden
     settings:
       image_style: large
-      image_link: content
+      image_link: ''
     third_party_settings:
       fences:
-        fences_field_tag: div
+        fences_field_tag: none
         fences_field_classes: ''
-        fences_field_item_tag: div
+        fences_field_item_tag: none
         fences_field_item_classes: ''
-        fences_label_tag: div
+        fences_label_tag: none
         fences_label_classes: ''
   field_short_description:
     type: basic_string

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -658,7 +658,7 @@ function _is_field_used_as_content_image_in_card($variables) {
  */
 function _is_field_used_as_hero_image_in_card($variables) {
   if ($variables['entity_type'] === 'node') {
-    if ($variables['element']['#bundle'] === 'product' && ($variables['element']['#view_mode'] === 'featured_tile' || $variables['element']['#view_mode'] === 'card') && $variables['field_name'] === 'field_image') {
+    if ($variables['element']['#bundle'] === 'product' && in_array($variables['element']['#view_mode'], ['featured_tile', 'card']) && $variables['field_name'] === 'field_image') {
       return TRUE;
     }
   }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -658,7 +658,7 @@ function _is_field_used_as_content_image_in_card($variables) {
  */
 function _is_field_used_as_hero_image_in_card($variables) {
   if ($variables['entity_type'] === 'node') {
-    if ($variables['element']['#bundle'] === 'product' && $variables['element']['#view_mode'] === 'featured_tile' && $variables['field_name'] === 'field_image') {
+    if ($variables['element']['#bundle'] === 'product' && ($variables['element']['#view_mode'] === 'featured_tile' || $variables['element']['#view_mode'] === 'card') && $variables['field_name'] === 'field_image') {
       return TRUE;
     }
   }


### PR DESCRIPTION
The related products field on the Books node type now renders the
referenced Product nodes with the Card view mode. This required some
minor changes to make the Card view mode, for the Product node type,
display as intended.

I also decided to have the Featured Products assembly type render the
referenced Products using the Card view mode since it is more intuitive
that the Featured Tile view mode, and we eventually want to eliminate
card-related usage of the Featured Tile or Tile view modes in favor of
Card.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-471

### Verification Process

#### Related Products field on Book

* [Edit Knative Cookbook](https://developer-preview-3564.ext.us-west.dc.preprod.paas.redhat.com/books/knative-cookbook/old/edit) and add Red Hat Enterprise Linux as a reference in the Related Product field
* Save the node to persist your changes and view [Knative Cookbook](https://developer-preview-3564.ext.us-west.dc.preprod.paas.redhat.com/books/knative-cookbook/old/)

You should see this:

<img width="1650" alt="Screen Shot 2020-05-04 at 9 26 58 AM" src="https://user-images.githubusercontent.com/7155034/80989195-70590500-8de9-11ea-8d2a-dd03e8471dc0.png">

#### Featured Products assembly type

The Featured Products assembly type towards the top of the [/products](https://developer-preview-3564.ext.us-west.dc.preprod.paas.redhat.com/products) page should render exactly as it does currently on Prod. The only difference is that it is rendering the Product nodes using the Card view mode.

* [Log into Drupal](https://developer-preview-3564.ext.us-west.dc.preprod.paas.redhat.com/user/login/)

Visit the [display settings for the Featured Products assembly type](https://developer-preview-3564.ext.us-west.dc.preprod.paas.redhat.com//admin/structure/assembly/featured_products/display) to be 100% certain the Featured Products assembly type is using the Card view mode to render the Product nodes: 
