### PR TITLE
[RHDX-465] Compact Dynamic Article List Length

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.compact_dynamic_article_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_form_display.assembly.compact_dynamic_article_list.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.compact_dynamic_article_list.field_category_filter
     - field.field.assembly.compact_dynamic_article_list.field_cta_link
     - field.field.assembly.compact_dynamic_article_list.field_drupal_term_filter
+    - field.field.assembly.compact_dynamic_article_list.field_number_of_posts
     - field.field.assembly.compact_dynamic_article_list.field_title
     - field.field.assembly.compact_dynamic_article_list.field_wordpress_category_logic
   module:
@@ -31,13 +32,13 @@ content:
     type: options_buttons
     region: content
   field_category_filter:
-    weight: 5
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: wpcategories_options_select
     region: content
   field_cta_link:
-    weight: 26
+    weight: 9
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -45,10 +46,17 @@ content:
     type: link_default
     region: content
   field_drupal_term_filter:
-    weight: 7
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  field_number_of_posts:
+    weight: 5
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
     region: content
   field_title:
     weight: 3
@@ -59,7 +67,7 @@ content:
     type: string_textfield
     region: content
   field_wordpress_category_logic:
-    weight: 6
+    weight: 7
     settings:
       display_label: true
     third_party_settings: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.compact_dynamic_article_list.default.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/core.entity_view_display.assembly.compact_dynamic_article_list.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.assembly.compact_dynamic_article_list.field_category_filter
     - field.field.assembly.compact_dynamic_article_list.field_cta_link
     - field.field.assembly.compact_dynamic_article_list.field_drupal_term_filter
+    - field.field.assembly.compact_dynamic_article_list.field_number_of_posts
     - field.field.assembly.compact_dynamic_article_list.field_title
     - field.field.assembly.compact_dynamic_article_list.field_wordpress_category_logic
   module:
@@ -63,6 +64,7 @@ hidden:
   field_audience_selection: true
   field_category_filter: true
   field_drupal_term_filter: true
+  field_number_of_posts: true
   field_wordpress_category_logic: true
   langcode: true
   name: true

--- a/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.compact_dynamic_article_list.field_number_of_posts.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/field.field.assembly.compact_dynamic_article_list.field_number_of_posts.yml
@@ -1,0 +1,25 @@
+uuid: 9c24942e-617e-4e8b-93d5-92a2728e1be5
+langcode: en
+status: true
+dependencies:
+  config:
+    - assembly.assembly_type.compact_dynamic_article_list
+    - field.storage.assembly.field_number_of_posts
+id: assembly.compact_dynamic_article_list.field_number_of_posts
+field_name: field_number_of_posts
+entity_type: assembly
+bundle: compact_dynamic_article_list
+label: 'Number of Posts'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: 8
+default_value_callback: ''
+settings:
+  min: 4
+  max: 10
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/CompactDynamicArticleListBuild.php
+++ b/_docker/drupal/drupal-filesystem/web/modules/custom/rhd_assemblies/src/Plugin/AssemblyBuild/CompactDynamicArticleListBuild.php
@@ -4,14 +4,11 @@ namespace Drupal\rhd_assemblies\Plugin\AssemblyBuild;
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\assembly\Plugin\AssemblyBuildBase;
-use Drupal\assembly\Plugin\AssemblyBuildInterface;
-use Drupal\node\Entity\Node;
-use Drupal\Core\HttpClient;
 
 /**
- * Displays a list of recent content from Wordpress and Drupal with Disqus comments and related topics
- *  @AssemblyBuild(
+ * Displays a list of recent content from Wordpress and Drupal in a list.
+ *
+ * @AssemblyBuild(
  *   id = "compact_dynamic_article_list",
  *   types = { "compact_dynamic_article_list" },
  *   label = @Translation("Compact Dynamic Article List")
@@ -19,12 +16,19 @@ use Drupal\Core\HttpClient;
  */
 class CompactDynamicArticleListBuild extends DynamicContentFeedBuild {
 
+  /**
+   * Build the CompactDynamicArticleList render array.
+   */
   public function build(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-    $count = 8;
+    $count = $entity->get('field_number_of_posts')->getValue();
+    $count = reset($count)['value'] ?? 8;
     $this->getItems($build, $entity, $count, 'compact_dynamic_article_list_item');
     $build['latest_comments'] = $this->getComments();
   }
 
+  /**
+   * Fetch comments from Disqus, and return a render array.
+   */
   protected function getComments() {
     $config = \Drupal::config('rhd_disqus.disqussettings');
     $shortname = $config->get('rhd_disqus_shortname') ?: FALSE;


### PR DESCRIPTION
This adds a field to the Compact Dynamic Article List assembly type, the
same field that is on the Dynamic Content Feed, that allows an editor to
configure the number of articles displayed in the list. The current
number of articles displayed is 8. This provides a default of 8, but
allows an editor to set the valuable anywhere between 4 to 10.

### JIRA Issue Link
* https://projects.engineering.redhat.com/browse/RHDX-465

### Verification Process

#### Doesn't break existing Dynamic Content Article Lists

Go to the [homepage](https://developer-preview-3565.ext.us-west.dc.preprod.paas.redhat.com/) and verify that the list in the left sidebar, at the very top of the page still renders as expected.

##### Editors can set number of articles per assembly

* Go to the [homepage edit form](https://developer-preview-3565.ext.us-west.dc.preprod.paas.redhat.com/home/edit/) and observe the Number of Posts field
* Set some number of posts between 4 and 10
* Save the field and [view the homepage](https://developer-preview-3565.ext.us-west.dc.preprod.paas.redhat.com/)
* You should see that the number of articles in the list is the number you just set

Ex. 6 posts

<img width="1631" alt="Screen Shot 2020-05-04 at 9 50 19 AM" src="https://user-images.githubusercontent.com/7155034/80992071-d8a9e580-8ded-11ea-8451-a5942ae036f4.png">
