### PR TITLE
[NO ISSUE] Resolve download_url fromUri error

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp2/rhdp2.theme
@@ -245,7 +245,7 @@ function rhdp2_preprocess_node(&$variables) {
     $download_url = $node->get('field_cheat_sheet_download_url')->getValue();
     $download_path = parse_url($download_url[0]['uri'])['path'];
     $download_url = $download_manager_base_url . $download_path;
-    $variables['content']['field_cheat_sheet_download_url'][0]['#url'] = Url::fromUri($download_url);
+    $variables['content']['field_cheat_sheet_download_url'][0]['#url'] = Url::fromUri('internal:' . $download_url);
   }
 
   // Add difficulty to attributes.
@@ -476,7 +476,7 @@ function rhdp2_preprocess_node(&$variables) {
     $download_url = $node->get('field_cheat_sheet_download_url')->getValue();
     $download_path = parse_url($download_url[0]['uri'])['path'];
     $download_url = $download_manager_base_url . $download_path;
-    $variables['content']['field_cheat_sheet_download_url'][0]['#url'] = Url::fromUri($download_url);
+    $variables['content']['field_cheat_sheet_download_url'][0]['#url'] = Url::fromUri('internal:' . $download_url);
   }
 
   // Prepare fields for taxonomy page.


### PR DESCRIPTION
This resolves an error that arose on our new local environments where
cheat sheet cards are being rendered, and it results in an error because
the $download_url is trying to be built using Url::fromUri() without
passing a protocol. This resolved this error for me locally.

### JIRA Issue Link
* n/a

### Verification Process

* You can view a page with a cheat sheet card, and you do not see an error like "InvalidArgumentException: The URI '/download-manager/.....' in invalid. You must use a valid URI scheme in Drupal\Core\Url:fromUri()....